### PR TITLE
fix: cast port to integer

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+# Root editor config file
+root = true
+
+# Common settings
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+
+# python - standard formatting
+[{*.py}]
+indent_style = space
+indent_size = 4
+
+[{*.js,*.vue}]
+indent_style = tab
+indent_size = 4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ fail_fast: false
 
 repos:
   - repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.6.0
     hooks:
       - id: black
         types_or: [python, pyi]

--- a/insights/insights/doctype/data_source/data_source.py
+++ b/insights/insights/doctype/data_source/data_source.py
@@ -3,6 +3,7 @@
 
 import frappe
 from frappe.database.mariadb.database import MariaDBDatabase
+from frappe.utils import cint
 from frappe.model.document import Document
 
 from contextlib import contextmanager
@@ -37,7 +38,7 @@ class DataSource(Document):
         if self.database_type == "MariaDB":
             return MariaDBDatabase(
                 host=self.host,
-                port=self.port,
+                port=cint(self.port),
                 user=self.username,
                 password=self.get_password(),
             )


### PR DESCRIPTION
Currently since port is Data type it's being sent as string to DB connector. 
Fix: cast to int before saving. 

```

Traceback (most recent call last):
  File "apps/insights/insights/insights/doctype/data_source/data_source.py", line 360, in connect_to_db
    db.connect()
  File "apps/frappe/frappe/database/database.py", line 92, in connect
    self._conn = self.get_connection()
  File "apps/frappe/frappe/database/mariadb/database.py", line 86, in get_connection
    conn = pymysql.connect(
  File "env/lib/python3.10/site-packages/pymysql/connections.py", line 290, in __init__
    raise ValueError("port should be of type int")
ValueError: port should be of type int
```

---

Few more observations:
- Setup/onboarding form doesn't clarify which fields are mandatory. 
- host can be made optional - localhost as default
- port can also be made optional - DB connectors assume the default port.