### PR TITLE
fix: set Date/Datetime fields in expression builder.

### DIFF
--- a/frontend/src/components/Query/Column/ColumnExpressionPicker.vue
+++ b/frontend/src/components/Query/Column/ColumnExpressionPicker.vue
@@ -72,7 +72,7 @@
 				:options="columnTypes"
 			/>
 		</div>
-		<div v-if="showDateFormatOptions" class="space-y-1 text-sm text-gray-600">
+		<div v-if="showDateFormatOptions" class="mt-2 text-sm text-gray-600">
 			<div class="font-light">Date Format</div>
 			<Autocomplete
 				v-model="expression.dateFormat"

--- a/frontend/src/components/Query/Column/ColumnExpressionPicker.vue
+++ b/frontend/src/components/Query/Column/ColumnExpressionPicker.vue
@@ -81,7 +81,12 @@
 			/>
 		</div>
 		<div class="mt-4 text-sm text-gray-600">
-			<Input type="checkbox" label="Group By" v-model="expression.groupBy" />
+			<Input
+				type="checkbox"
+				:label="!showDateFormatOptions ? 'Group By' : 'Group By (Unable to group by Date/Datetime expressions at this time).'"
+				v-model="expression.groupBy"
+				:disabled="showDateFormatOptions"
+			/>
 		</div>
 		<!-- Action Buttons -->
 		<div class="mt-3 flex justify-end space-x-2">
@@ -160,6 +165,13 @@ watchEffect(() => {
 	expression.error = errorMessage
 })
 const showDateFormatOptions = computed(() => ['Date', 'Datetime'].includes(expression.valueType))
+watchEffect(() => {
+	if (showDateFormatOptions.value) {
+		// Currently group by date field is not supported on expressions due to.
+		// pymysql.err.OperationalError: (1056, "Can't group on '{AGGREGATE} of {DATE_FIELD}'")
+		expression.groupBy = false;
+	}
+});
 
 const codeViewUpdate = debounce(function ({ cursorPos }) {
 	expression.help = null

--- a/frontend/src/components/Query/Column/ColumnExpressionPicker.vue
+++ b/frontend/src/components/Query/Column/ColumnExpressionPicker.vue
@@ -143,7 +143,7 @@ const expression = reactive({
 	raw: input.value,
 	label: column.label,
 	groupBy: column.aggregation == 'Group By',
-	valueType: 'String',
+	valueType: column.type,
 	ast: null,
 	error: null,
 	tokens: [],

--- a/frontend/src/components/Query/Column/ColumnExpressionPicker.vue
+++ b/frontend/src/components/Query/Column/ColumnExpressionPicker.vue
@@ -82,10 +82,10 @@
 		</div>
 		<div class="mt-4 text-sm text-gray-600">
 			<Input
+				v-if="!showDateFormatOptions"
 				type="checkbox"
-				:label="!showDateFormatOptions ? 'Group By' : 'Group By (Unable to group by Date/Datetime expressions at this time).'"
+				label="Group By"
 				v-model="expression.groupBy"
-				:disabled="showDateFormatOptions"
 			/>
 		</div>
 		<!-- Action Buttons -->

--- a/frontend/src/components/Query/Column/ColumnExpressionPicker.vue
+++ b/frontend/src/components/Query/Column/ColumnExpressionPicker.vue
@@ -73,7 +73,7 @@
 			/>
 		</div>
 		<div v-if="showDateFormatOptions" class="mt-2 text-sm text-gray-600">
-			<div class="font-light">Date Format</div>
+			<div class="mb-1 font-light">Date Format</div>
 			<Autocomplete
 				v-model="expression.dateFormat"
 				:options="dateFormats"

--- a/frontend/src/components/Query/Column/ColumnExpressionPicker.vue
+++ b/frontend/src/components/Query/Column/ColumnExpressionPicker.vue
@@ -72,6 +72,14 @@
 				:options="columnTypes"
 			/>
 		</div>
+		<div v-if="showDateFormatOptions" class="space-y-1 text-sm text-gray-600">
+			<div class="font-light">Date Format</div>
+			<Autocomplete
+				v-model="expression.dateFormat"
+				:options="dateFormats"
+				placeholder="Select a date format..."
+			/>
+		</div>
 		<div class="mt-4 text-sm text-gray-600">
 			<Input type="checkbox" label="Group By" v-model="expression.groupBy" />
 		</div>
@@ -93,10 +101,12 @@
 </template>
 
 <script setup>
+import Autocomplete from '@/components/Controls/Autocomplete.vue'
 import Code from '@/components/Controls/Code.vue'
 import Tooltip from '@/components/Tooltip.vue'
 import { debounce } from 'frappe-ui'
 
+import { dateFormats } from '@/utils/format'
 import { FUNCTIONS } from '@/utils/query'
 import { parse } from '@/utils/expressions'
 import { ref, inject, watchEffect, reactive, computed } from 'vue'
@@ -138,6 +148,9 @@ const expression = reactive({
 	error: null,
 	tokens: [],
 	help: null,
+	dateFormat: ['Date', 'Datetime'].includes(props.column.type)
+		? dateFormats.find((format) => format.value === props.column.format_option?.date_format)
+		: {},
 })
 watchEffect(() => {
 	expression.raw = input.value
@@ -146,6 +159,7 @@ watchEffect(() => {
 	expression.tokens = tokens
 	expression.error = errorMessage
 })
+const showDateFormatOptions = computed(() => ['Date', 'Datetime'].includes(expression.valueType))
 
 const codeViewUpdate = debounce(function ({ cursorPos }) {
 	expression.help = null
@@ -200,6 +214,12 @@ const addExpressionColumn = () => {
 		label: expression.label,
 		column: expression.label.replace(/\s/g, '_'),
 		aggregation: expression.groupBy ? 'Group By' : '',
+	}
+
+	if (showDateFormatOptions.value) {
+		newColumn.format_option = {
+			date_format: expression.dateFormat.value
+		}
 	}
 	emit('column-select', newColumn)
 }


### PR DESCRIPTION
When adding an Expression, if the field type is date or datetime. The following error occurs:
```
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 58, in application
    response = frappe.api.handle()
  File "apps/frappe/frappe/api.py", line 54, in handle
    return frappe.handler.handle()
  File "apps/frappe/frappe/handler.py", line 45, in handle
    data = execute_cmd(cmd)
  File "apps/frappe/frappe/handler.py", line 83, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "apps/frappe/frappe/__init__.py", line 1584, in call
    return fn(*args, **newargs)
  File "apps/frappe/frappe/handler.py", line 310, in run_doc_method
    response = doc.run_method(method, **args)
  File "apps/frappe/frappe/model/document.py", line 925, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 1269, in composer
    return composed(self, method, *args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 1251, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "apps/frappe/frappe/model/document.py", line 922, in fn
    return method_object(*args, **kwargs)
  File "apps/insights/insights/insights/doctype/insights_query/insights_query_client.py", line 79, in add_column
    self.save()
  File "apps/frappe/frappe/model/document.py", line 298, in save
    return self._save(*args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 332, in _save
    self.run_before_save_methods()
  File "apps/frappe/frappe/model/document.py", line 1058, in run_before_save_methods
    self.run_method("before_save")
  File "apps/frappe/frappe/model/document.py", line 925, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 1269, in composer
    return composed(self, method, *args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 1251, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "apps/frappe/frappe/model/document.py", line 922, in fn
    return method_object(*args, **kwargs)
  File "apps/insights/insights/insights/doctype/insights_query/insights_query.py", line 72, in before_save
    self.update_query()
  File "apps/insights/insights/insights/doctype/insights_query/insights_query.py", line 88, in update_query
    query = self._data_source.build_query(query=self)
  File "apps/insights/insights/insights/doctype/insights_data_source/insights_data_source.py", line 88, in build_query
    return self.db.build_query(query)
  File "apps/insights/insights/insights/doctype/insights_data_source/sources/frappe_db.py", line 285, in build_query
    return self.query_builder.build(query)
  File "apps/insights/insights/insights/query_builders/sql_builder.py", line 30, in build
    self.process_columns()
  File "apps/insights/insights/insights/query_builders/sql_builder.py", line 82, in process_columns
    _column = self.process_column_format(row, _column)
  File "apps/insights/insights/insights/query_builders/sql_builder.py", line 101, in process_column_format
    return ColumnFormat.format_date(format_option.date_format, column)
AttributeError: 'NoneType' object has no attribute 'date_format'
```

Fixes:
- https://github.com/frappe/insights/commit/d8a4bc4a52ff8c6d86091fc86526a5db172ee393 Field type was not retained when editing an expression,
- https://github.com/frappe/insights/commit/681d4d67810f5babe12be6a6c13fd7f9be3a1179 I don't fully understand why we can't use an aggregate function when grouping on date types. Need look into this. Maybe someone with more experience already knows the solution for this.
- https://github.com/frappe/insights/commit/32a278cf565e24ad136417cc53eb3efb57117d32, https://github.com/frappe/insights/commit/020bf21626634a96a5e7286da7b856b17e2e9e7e Add date format selector for Date/Datetime fields

Here is the fix in action:
![fix-expression-date](https://user-images.githubusercontent.com/29856401/199576032-1746a341-615f-4c34-bd67-685b5c7d0a3f.gif)
