### PR TITLE
build: bump pandas & python 3.11 support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 # frappe -- https://github.com/frappe/frappe is installed via 'bench init'
-pandas~=1.4.2
+pandas~=1.5.1


### PR DESCRIPTION
Installing on 3.11 requires building from source which is long and slow process. 

Latest pandas versions ship wheels. Tested locally. 


Nothing breaking from what I can tell:
- https://pandas.pydata.org/pandas-docs/version/1.5.0/whatsnew/v1.5.0.html#backwards-incompatible-api-changes
- https://pandas.pydata.org/pandas-docs/version/1.5.1/whatsnew/v1.5.1.html