### PR TITLE
don't verify ssl certs if use_ssl is False

### DIFF
--- a/insights/insights/doctype/insights_data_source/sources/mariadb.py
+++ b/insights/insights/doctype/insights_data_source/sources/mariadb.py
@@ -121,7 +121,7 @@ class MariaDB(BaseDatabase):
             host=host,
             port=port,
             ssl=use_ssl,
-            ssl_verify_cert=True,
+            ssl_verify_cert=use_ssl,
             charset="utf8mb4",
             use_unicode=True,
         )


### PR DESCRIPTION
If `use_ssl` is set as false, Insights will still try to verify SSL Certificates causing the connection to fail. This PR fixes that behavior. 