### PR TITLE
feat: save custom column in tables

### DIFF
--- a/insights/insights/doctype/insights_data_source/sources/test_query_store.py
+++ b/insights/insights/doctype/insights_data_source/sources/test_query_store.py
@@ -12,7 +12,7 @@ test_dependencies = ["Insights Data Source", "Insights Table"]
 
 
 class TestQueryStoreDataSource(unittest.TestCase):
-    def test_temporary_table(self):
+    def test_query_store(self):
         site_db = frappe.get_doc("Insights Data Source", "Site DB")
         site_db.sync_tables(tables=["tabUser"])
         # initialize a query
@@ -36,7 +36,4 @@ class TestQueryStoreDataSource(unittest.TestCase):
         store_query.run()
         data = frappe.parse_json(store_query.results)[1:]
         self.assertEqual(len(data), frappe.db.count("User"))
-        # Temporary table should be dropped on closing the connection
-        with self.assertRaises(BaseException) as error:
-            frappe.db.sql(f"SELECT * FROM `{db_query.name}`")
-        self.assertTrue("doesn't exist" in str(error.exception))
+        self.assertTrue(frappe.db.exists("Insights Table", {"table": db_query.name}))

--- a/insights/insights/doctype/insights_query/test_insights_query.py
+++ b/insights/insights/doctype/insights_query/test_insights_query.py
@@ -96,7 +96,6 @@ class TestInsightsQuery(FrappeTestCase):
             "Pivot", {"index": "Status", "column": "Reference Type", "value": "Count"}
         )
         result = json.loads(query.results)
-        print(result)
         self.assertEqual(len(result), 3)
         self.assertEqual(len(result[0]), 5)
 
@@ -131,7 +130,6 @@ class TestInsightsQuery(FrappeTestCase):
         query.save()
         query.fetch_results()
         query.save()
-        print(query.status)
         result = json.loads(query.results)
         self.assertEqual(len(result), 11)
         self.assertEqual(result[-1][2], 10)

--- a/insights/insights/doctype/insights_table_column/insights_table_column.json
+++ b/insights/insights/doctype/insights_table_column/insights_table_column.json
@@ -6,9 +6,12 @@
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
+  "is_custom",
   "column",
   "label",
-  "type"
+  "type",
+  "column_break_l5mj",
+  "custom_definition"
  ],
  "fields": [
   {
@@ -33,12 +36,28 @@
    "label": "Type",
    "options": "Integer\nLong Int\nDecimal\nText\nLong Text\nDate\nDatetime\nTime\nString",
    "reqd": 1
+  },
+  {
+   "fieldname": "column_break_l5mj",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "is_custom",
+   "fieldtype": "Check",
+   "label": "Is Custom"
+  },
+  {
+   "fieldname": "custom_definition",
+   "fieldtype": "Code",
+   "label": "Custom Definition",
+   "options": "JSON"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2022-10-18 10:03:54.280471",
+ "modified": "2023-05-01 19:43:52.406881",
  "modified_by": "Administrator",
  "module": "Insights",
  "name": "Insights Table Column",


### PR DESCRIPTION
This pull request introduces a new feature that allows users to create and save custom columns for future use. Currently, users can create calculated columns within the query builder and save the query. However, if they wish to reuse a calculated column in another query, they have to recreate it.

This feature allows users to create a calculated column and save it directly in the corresponding table. For example, a user can create a calculated column called `Total Amount` in the `Sales Invoice` table, which sums the values of `base_net_total` and `base_total_taxes_and_charges`. This calculated column can then be added to any query involving the `Sales Invoice` table.

<img width="1049" alt="CleanShot 2023-05-04 at 12 39 36@2x" src="https://user-images.githubusercontent.com/25369014/236134794-21f20936-b3af-41a3-bb75-1917615983a0.png">

<img width="1438" alt="CleanShot 2023-05-04 at 12 40 30@2x" src="https://user-images.githubusercontent.com/25369014/236134805-b882dcea-8b34-4428-a52e-0c3e553980db.png">

- [ ] Add a `Save` button in Column Panel to save custom columns (?)