### PR TITLE
fix: update prop name for Avatar component

### DIFF
--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -96,7 +96,7 @@
 							<Avatar
 								size="xl"
 								:label="session.user.full_name"
-								:imageURL="session.user.user_image"
+								:image="session.user.user_image"
 							/>
 							<span
 								class="rg:inline ml-2 hidden overflow-hidden text-ellipsis whitespace-nowrap"

--- a/frontend/src/pages/Avatars.vue
+++ b/frontend/src/pages/Avatars.vue
@@ -5,7 +5,7 @@
 			v-for="avatar in avatars"
 			:key="avatar.label"
 			:label="avatar.label"
-			:imageURL="avatar.imageURL"
+			:image="avatar.image"
 		/>
 	</div>
 </template>

--- a/frontend/src/pages/ManageTeamMembers.vue
+++ b/frontend/src/pages/ManageTeamMembers.vue
@@ -50,7 +50,7 @@ function addMembers(members) {
 				:key="member.name"
 			>
 				<div class="flex items-center space-x-2">
-					<Avatar :label="member.full_name" :imageURL="member.user_image" />
+					<Avatar :label="member.full_name" :image="member.user_image" />
 					<div>
 						<div>{{ member.full_name }}</div>
 						<div class="text-sm text-gray-600">{{ member.email }}</div>

--- a/frontend/src/pages/Teams.vue
+++ b/frontend/src/pages/Teams.vue
@@ -117,7 +117,7 @@ function getAvatars(members) {
 	return members
 		.map((member) => ({
 			label: member.full_name,
-			imageURL: member.user_image,
+			image: member.user_image,
 		}))
 		.slice(0, 3)
 		.concat(members.length > 3 ? [{ label: `${members.length - 3}` }] : [])


### PR DESCRIPTION
`imageURL` -> `image` in latest frappe-ui.

Avatar was not loading correctly due to this:

<img width="521" alt="CleanShot 2023-10-06 at 22 20 15@2x" src="https://github.com/frappe/insights/assets/34810212/59c6c35e-22d5-4f0b-83da-877c51aedbad">


Now it is:

<img width="974" alt="CleanShot 2023-10-06 at 22 20 22@2x" src="https://github.com/frappe/insights/assets/34810212/14d9a2bd-1f77-406c-a8f8-df99a73e6ba9">

> Just noticed, my first contribution to insights 😃
