### PR TITLE
fix: perm hooks should always send true/false

### DIFF
--- a/insights/overrides.py
+++ b/insights/overrides.py
@@ -16,11 +16,11 @@ def has_permission(doc, ptype, user):
         "Insights Query",
         "Insights Dashboard",
     ]:
-        return
+        return True
 
     # only check if doc exists
     if not doc.name:
-        return
+        return True
 
     if not frappe.db.get_single_value("Insights Settings", "enable_permissions"):
         return True


### PR DESCRIPTION
None is now assumed as False by framework
