### PR TITLE
fix: alt build root

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -13,7 +13,7 @@ export default defineConfig({
 		},
 	},
 	build: {
-		outDir: `../${path.basename(path.resolve('..'))}/public/frontend`,
+		outDir: `../insights/public/frontend`,
 		emptyOutDir: true,
 		target: 'es2015',
 		sourcemap: true,


### PR DESCRIPTION
Same motivation as: https://github.com/frappe/builder/pull/118


- repo (e.g. when using a git worktree) isn't guaranteed to be called `insights` 
- the import isn't used anymore and breaks alt build root builds
