### PR TITLE
Upgrade pandas patch version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = ">=3.10"
 readme = "README.md"
 dynamic = ["version"]
 dependencies = [
-    "pandas==2.1.1",
+    "pandas~=2.1.1",
     "SQLAlchemy==2.0.22",
     "python-telegram-bot==12.8",
 ]


### PR DESCRIPTION
Since numpy's latest release (2.0.0) last night, is [ABI breaking](https://numpy.org/devdocs/dev/depending_on_numpy.html#numpy-2-abi-handling), numpy has to be <2.0.0. This has been fixed already in latest pandas 2.1.x