### PR TITLE
fix catch all 404 page not found page

### DIFF
--- a/frontend/src/router.ts
+++ b/frontend/src/router.ts
@@ -141,17 +141,17 @@ const routes = [
 		},
 	},
 	{
-		path: '/not-found',
-		name: 'Not Found',
-		component: () => import('@/pages/NotFound.vue'),
+		path: '/trial-expired',
+		name: 'Trial Expired',
+		component: () => import('@/pages/TrialExpired.vue'),
 		meta: {
 			hideSidebar: true,
 		},
 	},
 	{
-		path: '/trial-expired',
-		name: 'Trial Expired',
-		component: () => import('@/pages/TrialExpired.vue'),
+		path: '/:pathMatch(.*)*',
+		name: 'Not Found',
+		component: () => import('@/pages/NotFound.vue'),
 		meta: {
 			hideSidebar: true,
 		},


### PR DESCRIPTION
Change the path of page 404 not found from path "not-found" --> "/:pathMatch(.*)*" 
then move to the end of the router array