### PR TITLE
chore: bump pandas to v2.2.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = ">=3.10"
 readme = "README.md"
 dynamic = ["version"]
 dependencies = [
-    "pandas~=2.1.1",
+    "pandas~=2.2.2",
     "SQLAlchemy==2.0.22",
     "python-telegram-bot==12.8",
 ]


### PR DESCRIPTION
No breaking changes, according to the [release notes](https://pandas.pydata.org/docs/whatsnew/index.html).

Ensures compatibility with other apps like erpnext_germany.