### PR TITLE
fix(script-query): Script query help should reference pandas instead

### DIFF
--- a/frontend/src/query/ScriptQueryEditor.vue
+++ b/frontend/src/query/ScriptQueryEditor.vue
@@ -39,7 +39,7 @@ const exampleCode = `def fetch_data_from_url():
 
 		try:
 				# Read data from the CSV file into a Pandas DataFrame
-				df = pd.read_csv(csv_url)
+				df = pandas.read_csv(csv_url)
 
 				# use the log function to log messages to the script log
 				log(df)


### PR DESCRIPTION
```python
pandas = frappe._dict()
pandas.DataFrame = pd.DataFrame
pandas.read_csv = pd.read_csv
pandas.json_normalize = pd.json_normalize
```

Reference: https://github.com/frappe/insights/blob/develop/insights/insights/doctype/insights_query/insights_script_query.py#L118-L130