### PR TITLE
feat: add support for clipping y-axis with `yAxis.min` and `yAxis.max`

### DIFF
--- a/frontend/src/widgets/AxisChart/getAxisChartOptions.js
+++ b/frontend/src/widgets/AxisChart/getAxisChartOptions.js
@@ -160,6 +160,7 @@ function makeOptions(chartType, labels, datasets, options) {
 				formatter: (value, _) => (!isNaN(value) ? getShortNumber(value, 1) : value),
 			},
 			min: options.yAxisMin,
+			max: options.yAxisMax,
 		})),
 		series: datasets.map((dataset, index) => ({
 			name: dataset.label,

--- a/frontend/src/widgets/AxisChart/getAxisChartOptions.js
+++ b/frontend/src/widgets/AxisChart/getAxisChartOptions.js
@@ -159,6 +159,7 @@ function makeOptions(chartType, labels, datasets, options) {
 			axisLabel: {
 				formatter: (value, _) => (!isNaN(value) ? getShortNumber(value, 1) : value),
 			},
+			min: options.yAxisMin,
 		})),
 		series: datasets.map((dataset, index) => ({
 			name: dataset.label,


### PR DESCRIPTION
I didn't add any way to set this in the UI. 

I intend to set this to 'dataMin' and 'dataMax' directly InsightsChart.options field

I need prettier charts. Please!

References: 
- https://echarts.apache.org/en/option.html#yAxis.min
- https://echarts.apache.org/en/option.html#yAxis.max