### PR TITLE
fix(ux): Sidebar Appearing Briefly on Public Links in Frappe Insights

### DIFF
--- a/frontend/src/components/AppShell.vue
+++ b/frontend/src/components/AppShell.vue
@@ -19,11 +19,18 @@ import Sidebar from '@/components/Sidebar.vue'
 import SuspenseFallback from '@/components/SuspenseFallback'
 import sessionStore from '@/stores/sessionStore'
 import settingsStore from '@/stores/settingsStore'
-import { computed, onMounted } from 'vue'
+import { ref, onMounted, watch } from 'vue'
 import { useRoute } from 'vue-router'
 
 const session = sessionStore()
 const route = useRoute()
-const hideSidebar = computed(() => route.meta.hideSidebar || !session.isLoggedIn)
+const hideSidebar = ref(true)
+watch(
+	route,
+	(newRoute) => {
+		hideSidebar.value = newRoute.meta.hideSidebar || !session.isLoggedIn
+	},
+	{ immediate: true }
+)
 onMounted(() => session.isLoggedIn && settingsStore())
 </script>


### PR DESCRIPTION
This PR addresses the issue where the sidebar appears momentarily on public links before being hidden. This fix ensures that the sidebar does not appear where sidebar shouldn't load, providing a cleaner and more consistent user experience for public links.

**Before:**
when the link is loaded,
![Insights](https://github.com/user-attachments/assets/f0d8fa68-67c1-4690-a786-a2ba71520700)

**Changes:**
In AppShell.vue, hidesidebar defined as a ref with true value then added a watch for route and update hidesidebar as per route.meta of new route.

**Related Issue:** #299 