### PR TITLE
fix(v3): Add Boolean, UUID in supported column types

### DIFF
--- a/insights/insights/doctype/insights_data_source_v3/ibis_utils.py
+++ b/insights/insights/doctype/insights_data_source_v3/ibis_utils.py
@@ -479,6 +479,10 @@ def to_insights_type(dtype: DataType):
         return "Date"
     if dtype.is_time():
         return "Time"
+    if dtype.is_boolean():
+        return "Boolean"
+    if dtype.is_uuid():
+        return "UUID"
     frappe.throw(f"Cannot infer data type for: {dtype}")
 
 


### PR DESCRIPTION
### Traceback

```python
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 115, in application
    response = frappe.api.handle(request)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/api/__init__.py", line 49, in handle
    data = endpoint(**arguments)
           ^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/api/v1.py", line 36, in handle_rpc_call
    return frappe.handler.handle()
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/handler.py", line 49, in handle
    data = execute_cmd(cmd)
           ^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/handler.py", line 85, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/__init__.py", line 1822, in call
    return fn(*args, **newargs)
           ^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/utils/typing_validations.py", line 32, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "apps/insights/insights/decorators.py", line 22, in wrapper
    return function(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/insights/insights/decorators.py", line 165, in wrapper
    return function(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/insights/insights/api/workbooks.py", line 20, in fetch_query_results
    columns = get_columns_from_schema(ibis_query.schema())
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/insights/insights/insights/doctype/insights_data_source_v3/ibis_utils.py", line 459, in get_columns_from_schema
    "type": to_insights_type(dtype),
            ^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/insights/insights/insights/doctype/insights_data_source_v3/ibis_utils.py", line 484, in to_insights_type
    frappe.throw(f"Cannot infer data type for: {dtype}")
  File "apps/frappe/frappe/__init__.py", line 691, in throw
    msgprint(
  File "apps/frappe/frappe/__init__.py", line 652, in msgprint
    _raise_exception()
  File "apps/frappe/frappe/__init__.py", line 603, in _raise_exception
    raise exc
frappe.exceptions.ValidationError: Cannot infer data type for: !uuid
```