### PR TITLE
fix: right-aligned numbers in tables

### DIFF
--- a/frontend/src/components/Table/TanstackTable.vue
+++ b/frontend/src/components/Table/TanstackTable.vue
@@ -105,13 +105,13 @@ const showPagination = computed(
 							v-for="header in headerGroup.headers"
 							:key="header.id"
 							:colSpan="header.colSpan"
-							class="border-b border-r text-gray-800 font-bold"
+							class="border-b border-r text-gray-800"
 							:width="header.column.columnDef.id === 'index' ? '6rem' : 'auto'"
 						>
 							<div
 								class="flex items-center gap-2 truncate py-2 px-3"
 								:class="[
-									header.column.columnDef.isNumber ? 'justify-end' : 'justify-center',
+									header.column.columnDef.isNumber ? 'justify-end' : '',
 									header.column.getCanSort()
 										? 'cursor-pointer hover:text-gray-800'
 										: '',
@@ -160,11 +160,7 @@ const showPagination = computed(
 					</tr>
 				</thead>
 				<tbody>
-					<tr 
-					 	v-for="(row, index) in table.getRowModel().rows" 
-						:key="row.id"
-						class="hover:bg-gray-100"
-					>
+					<tr v-for="(row, index) in table.getRowModel().rows" :key="row.id">
 						<td
 							v-for="cell in row.getVisibleCells()"
 							:key="cell.id"

--- a/frontend/src/components/Table/TanstackTable.vue
+++ b/frontend/src/components/Table/TanstackTable.vue
@@ -105,13 +105,13 @@ const showPagination = computed(
 							v-for="header in headerGroup.headers"
 							:key="header.id"
 							:colSpan="header.colSpan"
-							class="border-b border-r text-gray-800"
+							class="border-b border-r text-gray-800 font-bold"
 							:width="header.column.columnDef.id === 'index' ? '6rem' : 'auto'"
 						>
 							<div
 								class="flex items-center gap-2 truncate py-2 px-3"
 								:class="[
-									header.column.columnDef.isNumber ? 'text-right' : '',
+									header.column.columnDef.isNumber ? 'justify-end' : 'justify-center',
 									header.column.getCanSort()
 										? 'cursor-pointer hover:text-gray-800'
 										: '',
@@ -160,7 +160,11 @@ const showPagination = computed(
 					</tr>
 				</thead>
 				<tbody>
-					<tr v-for="(row, index) in table.getRowModel().rows" :key="row.id">
+					<tr 
+					 	v-for="(row, index) in table.getRowModel().rows" 
+						:key="row.id"
+						class="hover:bg-gray-100"
+					>
 						<td
 							v-for="cell in row.getVisibleCells()"
 							:key="cell.id"


### PR DESCRIPTION
This PR enhances the table component by:
- Bolding and center-aligning the table headers.
- Right-aligning numeric columns.
-  Adding hover effects on rows for better user interactivity.


**Closes #311** — This PR addresses the feature request for bolding and centering table headings as described in the issue #311

**Before:**
![image](https://github.com/user-attachments/assets/fd328734-d9f2-41f3-ac02-b46964275373)


**After:**

![image](https://github.com/user-attachments/assets/a9b956ad-e8e7-4eb7-8360-39d849a4aab6)
