### PR TITLE
Add Inline Labels Feature for Donut Chart in v3

### DIFF
--- a/frontend/src2/charts/components/DonutChartConfigForm.vue
+++ b/frontend/src2/charts/components/DonutChartConfigForm.vue
@@ -35,6 +35,7 @@ const discrete_dimensions = computed(() =>
 			/>
 			<MeasurePicker label="Value" :options="props.measures" v-model="config.value_column" />
 			<FormControl
+				v-if="!config.showInlineLabels"
 				v-model="config.legend_position"
 				label="Legend Position"
 				type="select"
@@ -45,6 +46,8 @@ const discrete_dimensions = computed(() =>
 					{ label: 'Right', value: 'right' },
 				]"
 			/>
+			<Checkbox v-model="config.showInlineLabels" label="Inline Labels" />
+			<Checkbox v-model="config.showNumberFormat" label="Display Values as Numbers" />
 		</div>
 	</CollapsibleSection>
 </template>

--- a/frontend/src2/charts/components/DonutChartConfigForm.vue
+++ b/frontend/src2/charts/components/DonutChartConfigForm.vue
@@ -47,7 +47,6 @@ const discrete_dimensions = computed(() =>
 				]"
 			/>
 			<Checkbox v-model="config.showInlineLabels" label="Inline Labels" />
-			<Checkbox v-model="config.showNumberFormat" label="Display Values as Numbers" />
 		</div>
 	</CollapsibleSection>
 </template>

--- a/frontend/src2/charts/components/DonutChartConfigForm.vue
+++ b/frontend/src2/charts/components/DonutChartConfigForm.vue
@@ -35,7 +35,7 @@ const discrete_dimensions = computed(() =>
 			/>
 			<MeasurePicker label="Value" :options="props.measures" v-model="config.value_column" />
 			<FormControl
-				v-if="!config.showInlineLabels"
+				v-if="!config.show_inline_labels"
 				v-model="config.legend_position"
 				label="Legend Position"
 				type="select"
@@ -46,7 +46,7 @@ const discrete_dimensions = computed(() =>
 					{ label: 'Right', value: 'right' },
 				]"
 			/>
-			<Checkbox v-model="config.showInlineLabels" label="Inline Labels" />
+			<Checkbox v-model="config.show_inline_labels" label="Inline Labels" />
 		</div>
 	</CollapsibleSection>
 </template>

--- a/frontend/src2/charts/helpers.ts
+++ b/frontend/src2/charts/helpers.ts
@@ -310,7 +310,7 @@ export function getDonutChartOptions(config: DountChartConfig, result: QueryResu
 
 	let center, radius, top, left, right, bottom, padding, orient
 	const legend_position = config.legend_position || 'bottom'
-	const showInlineLabels = config.showInlineLabels || false;
+	const show_inline_labels = config.show_inline_labels || false
 
 	if (legend_position == 'bottom') {
 		orient = 'horizontal'
@@ -344,7 +344,7 @@ export function getDonutChartOptions(config: DountChartConfig, result: QueryResu
 		top = 'middle'
 		padding = [30, 0, 30, 0]
 	}
-	if (showInlineLabels) {
+	if (show_inline_labels) {
 		center = ['50%', '50%']
 	}
 
@@ -360,7 +360,7 @@ export function getDonutChartOptions(config: DountChartConfig, result: QueryResu
 				center,
 				radius,
 				labelLine: {
-					show: showInlineLabels,
+					show: show_inline_labels,
 					lineStyle: {
 						width: 2,
 					},
@@ -369,31 +369,31 @@ export function getDonutChartOptions(config: DountChartConfig, result: QueryResu
 					smooth: true,
 				},
 				label: {
-                    show: showInlineLabels,
+					show: show_inline_labels,
 					formatter: ({ value, name }: any) => {
 						const percentage = total > 0 ? (value[1] / total) * 100 : 0
 						return `${ellipsis(name, 20)} (${percentage.toFixed(0)}%)`
-					  },
-                },
+					},
+				},
 				emphasis: { scaleSize: 5 },
 			},
 		],
-		legend: !showInlineLabels
-		? {
-			...getLegend(),
-			top,
-			left,
-			right,
-			bottom,
-			padding,
-			orient,
-			formatter: (name: string) => {
-				const labelIndex = labels.indexOf(name)
-				const percent = (values[labelIndex] / total) * 100
-				return `${ellipsis(name, 20)} (${percent.toFixed(0)}%)`
-			  },
-		  }
-		: null,
+		legend: !show_inline_labels
+			? {
+					...getLegend(),
+					top,
+					left,
+					right,
+					bottom,
+					padding,
+					orient,
+					formatter: (name: string) => {
+						const labelIndex = labels.indexOf(name)
+						const percent = (values[labelIndex] / total) * 100
+						return `${ellipsis(name, 20)} (${percent.toFixed(0)}%)`
+					},
+			  }
+			: null,
 		tooltip: {
 			trigger: 'item',
 			confine: true,

--- a/frontend/src2/charts/helpers.ts
+++ b/frontend/src2/charts/helpers.ts
@@ -310,6 +310,9 @@ export function getDonutChartOptions(config: DountChartConfig, result: QueryResu
 
 	let center, radius, top, left, right, bottom, padding, orient
 	const legend_position = config.legend_position || 'bottom'
+	const showInlineLabels = config.showInlineLabels || false;
+	const showNumberFormat = config.showNumberFormat || false
+
 	if (legend_position == 'bottom') {
 		orient = 'horizontal'
 		radius = ['45%', '75%']
@@ -342,6 +345,9 @@ export function getDonutChartOptions(config: DountChartConfig, result: QueryResu
 		top = 'middle'
 		padding = [30, 0, 30, 0]
 	}
+	if (showInlineLabels) {
+		center = ['50%', '50%']
+	}
 
 	return {
 		animation: true,
@@ -354,12 +360,29 @@ export function getDonutChartOptions(config: DountChartConfig, result: QueryResu
 				name: valueColumn?.name,
 				center,
 				radius,
-				labelLine: { show: false },
-				label: { show: false },
+				labelLine: {
+					show: showInlineLabels,
+					lineStyle: {
+						width: 2,
+					},
+					length: 10,
+					length2: 20,
+					smooth: true,
+				},
+				label: {
+                    show: showInlineLabels,
+					formatter: ({ value, name }: any) => {
+						const percentage = total > 0 ? (value[1] / total) * 100 : 0
+						return showNumberFormat
+						  ? `${ellipsis(name, 20)} (${formatNumber(value[1], 2)})`
+						  : `${ellipsis(name, 20)} (${percentage.toFixed(0)}%)`
+					  },
+                },
 				emphasis: { scaleSize: 5 },
 			},
 		],
-		legend: {
+		legend: !showInlineLabels
+		? {
 			...getLegend(),
 			top,
 			left,
@@ -370,9 +393,12 @@ export function getDonutChartOptions(config: DountChartConfig, result: QueryResu
 			formatter: (name: string) => {
 				const labelIndex = labels.indexOf(name)
 				const percent = (values[labelIndex] / total) * 100
-				return `${ellipsis(name, 20)} (${percent.toFixed(0)}%)`
-			},
-		},
+				return showNumberFormat
+				  ? `${ellipsis(name, 20)} (${formatNumber(values[labelIndex], 2)})`
+				  : `${ellipsis(name, 20)} (${percent.toFixed(0)}%)`
+			  },
+		  }
+		: null,
 		tooltip: {
 			trigger: 'item',
 			confine: true,

--- a/frontend/src2/charts/helpers.ts
+++ b/frontend/src2/charts/helpers.ts
@@ -311,7 +311,6 @@ export function getDonutChartOptions(config: DountChartConfig, result: QueryResu
 	let center, radius, top, left, right, bottom, padding, orient
 	const legend_position = config.legend_position || 'bottom'
 	const showInlineLabels = config.showInlineLabels || false;
-	const showNumberFormat = config.showNumberFormat || false
 
 	if (legend_position == 'bottom') {
 		orient = 'horizontal'
@@ -373,9 +372,7 @@ export function getDonutChartOptions(config: DountChartConfig, result: QueryResu
                     show: showInlineLabels,
 					formatter: ({ value, name }: any) => {
 						const percentage = total > 0 ? (value[1] / total) * 100 : 0
-						return showNumberFormat
-						  ? `${ellipsis(name, 20)} (${formatNumber(value[1], 2)})`
-						  : `${ellipsis(name, 20)} (${percentage.toFixed(0)}%)`
+						return `${ellipsis(name, 20)} (${percentage.toFixed(0)}%)`
 					  },
                 },
 				emphasis: { scaleSize: 5 },
@@ -393,9 +390,7 @@ export function getDonutChartOptions(config: DountChartConfig, result: QueryResu
 			formatter: (name: string) => {
 				const labelIndex = labels.indexOf(name)
 				const percent = (values[labelIndex] / total) * 100
-				return showNumberFormat
-				  ? `${ellipsis(name, 20)} (${formatNumber(values[labelIndex], 2)})`
-				  : `${ellipsis(name, 20)} (${percent.toFixed(0)}%)`
+				return `${ellipsis(name, 20)} (${percent.toFixed(0)}%)`
 			  },
 		  }
 		: null,

--- a/frontend/src2/types/chart.types.ts
+++ b/frontend/src2/types/chart.types.ts
@@ -76,7 +76,7 @@ export type DountChartConfig = {
 	label_column: Dimension
 	value_column: Measure
 	legend_position?: 'top' | 'bottom' | 'left' | 'right'
-	showInlineLabels?: boolean;
+	show_inline_labels?: boolean;
 }
 export type FunnelChartConfig = {
 	label_column: Dimension

--- a/frontend/src2/types/chart.types.ts
+++ b/frontend/src2/types/chart.types.ts
@@ -76,6 +76,8 @@ export type DountChartConfig = {
 	label_column: Dimension
 	value_column: Measure
 	legend_position?: 'top' | 'bottom' | 'left' | 'right'
+	showInlineLabels?: boolean;
+	showNumberFormat?: boolean;
 }
 export type FunnelChartConfig = {
 	label_column: Dimension

--- a/frontend/src2/types/chart.types.ts
+++ b/frontend/src2/types/chart.types.ts
@@ -77,7 +77,6 @@ export type DountChartConfig = {
 	value_column: Measure
 	legend_position?: 'top' | 'bottom' | 'left' | 'right'
 	showInlineLabels?: boolean;
-	showNumberFormat?: boolean;
 }
 export type FunnelChartConfig = {
 	label_column: Dimension


### PR DESCRIPTION
This PR adds the inline labels feature for the Donut Chart in v3, which was previously available in v2 but missing in v3. The feature allows labels to be displayed inside the chart.