### PR TITLE
fix: Fill NAN and NAT fields before sending them to the frontend

### DIFF
--- a/insights/api/__init__.py
+++ b/insights/api/__init__.py
@@ -123,7 +123,7 @@ def get_csv_data(filename: str):
     count = table.count().execute().item()
 
     columns = get_columns_from_schema(table.schema())
-    rows = table.head(50).execute().to_dict(orient="records")
+    rows = table.head(50).execute().fillna("").to_dict(orient="records")
 
     return {
         "tablename": file_name,


### PR DESCRIPTION
Hi,

I encountered an issue when trying to load a CSV file, exported from Google Sheets, that contained NAT or NAN values.

Example output after been read by Ibis:
```json
{
        "Product Code": "zzzzzz",
        "Project Code": "zzzzzz",
        "Accounting Period": NaT,
        "Doc N°": nan,
        "Order": None,
        "Contract": None,
}
```

In this case it doesn't throw any error in the UI, the dialog only shows **No data to display.**
In the console we have the following error: `Error: SyntaxError: JSON.parse: unexpected character at line 1 column 1714 of the JSON data`

My proposal is to apply a fillna on the first 50 rows before they are sent back to the UI, so that the JSON can be correctly read on the client side.

Please let me know if you disagree with this solution.

Have a nice day !

