### PR TITLE
fix: preserve trailing zeros in number formatting

### DIFF
--- a/frontend/src2/helpers/index.ts
+++ b/frontend/src2/helpers/index.ts
@@ -153,6 +153,7 @@ export function formatNumber(number: number, precision = 2) {
 	precision = precision || guessPrecision(number)
 	const locale = session.user?.country == 'India' ? 'en-IN' : session.user?.locale
 	return new Intl.NumberFormat(locale || 'en-US', {
+		minimumFractionDigits: precision,
 		maximumFractionDigits: precision,
 	}).format(number)
 }


### PR DESCRIPTION
**Description:**
Updated the formatNumber function to include minimumFractionDigits, ensuring numbers retain trailing zeros.

**Linked Issue**
Closes #403 

**Before:**

![image](https://github.com/user-attachments/assets/e2253ae5-1cdf-48b7-9637-d58218598036)

**After:**
![image](https://github.com/user-attachments/assets/ec5c6aa3-005e-4120-8794-d1c12cad42e6)
