### PR TITLE
feat(v2): Add data labels to bar charts

### DIFF
--- a/frontend/src/widgets/AxisChart/getAxisChartOptions.js
+++ b/frontend/src/widgets/AxisChart/getAxisChartOptions.js
@@ -177,12 +177,12 @@ function makeOptions(chartType, labels, datasets, options) {
 			areaStyle:
 				dataset.series_options.showArea || options.showArea
 					? {
-							color: new graphic.LinearGradient(0, 0, 0, 1, [
-								{ offset: 0, color: dataset.series_options.color || colors[index] },
-								{ offset: 1, color: '#fff' },
-							]),
-							opacity: 0.2,
-					  }
+						color: new graphic.LinearGradient(0, 0, 0, 1, [
+							{ offset: 0, color: dataset.series_options.color || colors[index] },
+							{ offset: 1, color: '#fff' },
+						]),
+						opacity: 0.2,
+					}
 					: undefined,
 			// bar styles
 			itemStyle: {
@@ -194,6 +194,17 @@ function makeOptions(chartType, labels, datasets, options) {
 			barMaxWidth: 50,
 			stack: options.stack ? 'stack' : null,
 		})),
+
+		label: {
+			show: options.show_data_labels,
+			position: 'top',
+			formatter: (params) => {
+				const value = params.value;
+				return !isNaN(value) ? getShortNumber(value, 1) : value;
+			},
+			fontSize: 12,
+			color: '#333',
+		},
 		legend: {
 			icon: 'circle',
 			type: 'scroll',
@@ -216,14 +227,14 @@ function makeOptions(chartType, labels, datasets, options) {
 function getMarkLineOption(options) {
 	return options.referenceLine
 		? {
-				data: [
-					{
-						name: options.referenceLine,
-						type: options.referenceLine.toLowerCase(),
-						label: { position: 'middle', formatter: '{b}: {c}' },
-					},
-				],
-		  }
+			data: [
+				{
+					name: options.referenceLine,
+					type: options.referenceLine.toLowerCase(),
+					label: { position: 'middle', formatter: '{b}: {c}' },
+				},
+			],
+		}
 		: {}
 }
 

--- a/frontend/src/widgets/AxisChart/getAxisChartOptions.js
+++ b/frontend/src/widgets/AxisChart/getAxisChartOptions.js
@@ -197,7 +197,7 @@ function makeOptions(chartType, labels, datasets, options) {
 
 		label: {
 			show: options.show_data_labels,
-			position: 'top',
+			position: 'inside',
 			formatter: (params) => {
 				const value = params.value;
 				return !isNaN(value) ? getShortNumber(value, 1) : value;

--- a/frontend/src/widgets/Bar/BarOptions.vue
+++ b/frontend/src/widgets/Bar/BarOptions.vue
@@ -19,5 +19,6 @@ const props = defineProps({
 
 		<Checkbox v-model="options.stack" label="Stack Values" />
 		<Checkbox v-model="options.roundedBars" label="Rounded Bars" />
+		<Checkbox v-model="options.show_data_labels" label="Show Data Labels" />
 	</div>
 </template>

--- a/frontend/src/widgets/Row/RowOptions.vue
+++ b/frontend/src/widgets/Row/RowOptions.vue
@@ -12,5 +12,6 @@ const props = defineProps({
 		<AxisChartOptions seriesType="bar" v-model:options="options" :columns="props.columns" />
 		<Checkbox v-model="options.stack" label="Stack Values" />
 		<Checkbox v-model="options.roundedBars" label="Rounded Bars" />
+		<Checkbox v-model="options.show_data_labels" label="Show Data Labels" />
 	</div>
 </template>


### PR DESCRIPTION
This PR adds support for data labels in bar charts, allowing users to toggle labels on or off via a new show_data_labels option. Labels are positioned on top of bars for stacked charts and formatted using getShortNumber for better readability.

Closes: #274 