### PR TITLE
feat: Add persistent sidebar state using localStorage

### DIFF
--- a/frontend/src2/components/AppSidebar.vue
+++ b/frontend/src2/components/AppSidebar.vue
@@ -4,7 +4,7 @@
 		:class="isSidebarCollapsed ? 'w-12' : 'w-56'"
 	>
 		<div class="flex flex-col overflow-hidden">
-			<UserDropdown class="p-2" :isCollapsed="isSidebarCollapsed" />
+			<UserDropdown class="p-2" :isCollapsed="isSidebarCollapsed.value" />
 			<div class="flex flex-col overflow-y-auto">
 				<template v-for="link in links">
 					<SidebarLink
@@ -13,7 +13,7 @@
 						:icon="link.icon"
 						:label="link.label"
 						:to="link.to"
-						:isCollapsed="isSidebarCollapsed"
+						:isCollapsed="isSidebarCollapsed.value"
 						@click="link.onClick"
 					/>
 				</template>
@@ -21,7 +21,7 @@
 		</div>
 		<SidebarLink
 			:label="isSidebarCollapsed ? 'Expand' : 'Collapse'"
-			:isCollapsed="isSidebarCollapsed"
+			:isCollapsed="isSidebarCollapsed.value"
 			@click="isSidebarCollapsed = !isSidebarCollapsed"
 			class="m-2"
 		>
@@ -41,6 +41,7 @@
 </template>
 
 <script setup lang="ts">
+import { useStorage } from '@vueuse/core'
 import {
 	Book,
 	Database,
@@ -48,17 +49,14 @@ import {
 	LayoutGrid,
 	PanelRightOpen,
 	SettingsIcon,
-	Warehouse,
 } from 'lucide-vue-next'
-import { computed, ref, watch } from 'vue'
+import { computed, ref } from 'vue'
+import useSettings from '../settings/settings'
 import Settings from '../settings/Settings.vue'
 import SidebarLink from './SidebarLink.vue'
 import UserDropdown from './UserDropdown.vue'
-import { waitUntil } from '../helpers'
-import useSettings from '../settings/settings'
-import { useStorage } from '@vueuse/core'
 
-const isSidebarCollapsed = useStorage('sidebarState', false)
+const isSidebarCollapsed = useStorage('insights:sidebarCollapsed', false)
 const showSettingsDialog = ref(false)
 
 const settings = useSettings()

--- a/frontend/src2/components/AppSidebar.vue
+++ b/frontend/src2/components/AppSidebar.vue
@@ -56,8 +56,9 @@ import SidebarLink from './SidebarLink.vue'
 import UserDropdown from './UserDropdown.vue'
 import { waitUntil } from '../helpers'
 import useSettings from '../settings/settings'
+import { useStorage } from '@vueuse/core'
 
-const isSidebarCollapsed = ref(false)
+const isSidebarCollapsed = useStorage('sidebarState', false)
 const showSettingsDialog = ref(false)
 
 const settings = useSettings()


### PR DESCRIPTION
**Description:**

This PR adds persistence for the sidebar state (collapsed or expanded) using localStorage via @vueuse/core. The sidebar will remember its state across sessions, enhancing the user experience.

**Changes:**

Used useStorage to sync the sidebar state with localStorage.
Defaults to expanded (false) if no value exists in localStorage.

**Testing:**

Toggle the sidebar and refresh the page to confirm the state persists.
Clear localStorage and reload to verify the default expanded state.
