### PR TITLE
fix: enhance drill-down dialog with total row count and load all rows

### DIFF
--- a/frontend/src2/charts/components/DrillDown.vue
+++ b/frontend/src2/charts/components/DrillDown.vue
@@ -35,6 +35,9 @@ watch(
 			drillDownQuery.value
 				.execute()
 				.then(() => {
+					return drillDownQuery.value?.fetchResultCount()
+				})
+				.then(() => {
 					showDrillDownResults.value = true
 				})
 				.catch(() => {
@@ -62,30 +65,17 @@ function onSort(newSortOrder: Record<string, 'asc' | 'desc'>) {
 </script>
 
 <template>
-	<Dialog
-		v-model="showDrillDownResults"
-		:options="{
-			title: 'Drill Down Results',
-			size: '5xl',
-		}"
-		@close="drillDownQuery = null"
-	>
+	<Dialog v-model="showDrillDownResults" :options="{
+		title: 'Drill Down Results',
+		size: '5xl',
+	}" @close="drillDownQuery = null">
 		<template #body-content>
-			<div
-				v-if="drillDownQuery"
-				class="relative flex h-[35rem] w-full flex-1 flex-col overflow-hidden rounded border bg-white"
-			>
-				<DataTable
-					:loading="drillDownQuery.executing"
-					:columns="drillDownQuery.result.columns"
-					:rows="drillDownQuery.result.rows"
-					:enable-pagination="true"
-					:show-column-totals="true"
-					:show-filter-row="true"
-					:sort-order="sortOrder"
-					@sort="onSort"
-					:on-export="drillDownQuery ? drillDownQuery.downloadResults : undefined"
-				>
+			<div v-if="drillDownQuery"
+				class="relative flex h-[35rem] w-full flex-1 flex-col overflow-hidden rounded border bg-white">
+				<DataTable :loading="drillDownQuery.executing" :columns="drillDownQuery.result.columns"
+					:rows="drillDownQuery.result.rows" :enable-pagination="true" :show-column-totals="true"
+					:show-filter-row="true" :sort-order="sortOrder" @sort="onSort"
+					:on-export="drillDownQuery ? drillDownQuery.downloadResults : undefined">
 					<template #footer-left>
 						<p class="tnum p-1 text-sm text-gray-600">
 							Showing {{ drillDownQuery.result.rows.length }} of

--- a/frontend/src2/charts/components/DrillDown.vue
+++ b/frontend/src2/charts/components/DrillDown.vue
@@ -81,18 +81,31 @@ function loadAllRows() {
 </script>
 
 <template>
-	<Dialog v-model="showDrillDownResults" :options="{
-		title: 'Drill Down Results',
-		size: '5xl',
-	}" @close="drillDownQuery = null">
+	<Dialog
+		v-model="showDrillDownResults"
+		:options="{
+			title: 'Drill Down Results',
+			size: '5xl',
+		}"
+		@close="drillDownQuery = null"
+	>
 		<template #body-content>
-			<div v-if="drillDownQuery"
-				class="relative flex h-[35rem] w-full flex-1 flex-col overflow-hidden rounded border bg-white">
-				<DataTable :loading="drillDownQuery.executing" :columns="drillDownQuery.result.columns"
-					:rows="drillDownQuery.result.rows" :enable-pagination="true" :show-column-totals="true"
-					:show-filter-row="true" :sort-order="sortOrder" @sort="onSort"
-					:on-export="drillDownQuery ? drillDownQuery.downloadResults : undefined">
-					<template #footer-left>
+			<div
+				v-if="drillDownQuery"
+				class="relative flex h-[35rem] w-full flex-1 flex-col overflow-hidden rounded border bg-white"
+			>
+				<DataTable
+					:loading="drillDownQuery.executing"
+					:columns="drillDownQuery.result.columns"
+					:rows="drillDownQuery.result.rows"
+					:enable-pagination="true"
+					:show-column-totals="true"
+					:show-filter-row="true"
+					:sort-order="sortOrder"
+					@sort="onSort"
+					:on-export="drillDownQuery ? drillDownQuery.downloadResults : undefined"
+				>
+				<template #footer-left>
 						<div class="flex items-center justify-between p-1 gap-4">
 							<p class="tnum text-sm text-gray-600">
 								Showing {{ drillDownQuery.result.rows.length }} of

--- a/frontend/src2/charts/components/DrillDown.vue
+++ b/frontend/src2/charts/components/DrillDown.vue
@@ -60,6 +60,10 @@ function onSort(newSortOrder: Record<string, 'asc' | 'desc'>) {
 		})
 
 		drillDownQuery.value.execute()
+		.then(() => drillDownQuery.value?.fetchResultCount())
+		.catch((error) => {
+			console.error('Failed to sort and fetch row count:', error)
+		});
 	}
 }
 

--- a/frontend/src2/charts/components/DrillDown.vue
+++ b/frontend/src2/charts/components/DrillDown.vue
@@ -62,6 +62,22 @@ function onSort(newSortOrder: Record<string, 'asc' | 'desc'>) {
 		drillDownQuery.value.execute()
 	}
 }
+
+function loadAllRows() {
+	if (drillDownQuery.value) {
+		drillDownQuery.value.addLimit(drillDownQuery.value.result.totalRowCount)
+		drillDownQuery.value
+			.execute()
+			.then(() => {
+				return drillDownQuery.value?.fetchResultCount()
+			})
+			.catch((error) => {
+				console.error('Failed to load all rows:', error)
+			})
+
+	}
+}
+
 </script>
 
 <template>
@@ -77,10 +93,21 @@ function onSort(newSortOrder: Record<string, 'asc' | 'desc'>) {
 					:show-filter-row="true" :sort-order="sortOrder" @sort="onSort"
 					:on-export="drillDownQuery ? drillDownQuery.downloadResults : undefined">
 					<template #footer-left>
-						<p class="tnum p-1 text-sm text-gray-600">
-							Showing {{ drillDownQuery.result.rows.length }} of
-							{{ drillDownQuery.result.totalRowCount }} rows
-						</p>
+						<div class="flex items-center justify-between p-1 gap-4">
+							<p class="tnum text-sm text-gray-600">
+								Showing {{ drillDownQuery.result.rows.length }} of
+								{{ drillDownQuery.result.totalRowCount }} rows
+							</p>
+							<Button
+							v-if="drillDownQuery.result.rows.length < drillDownQuery.result.totalRowCount"
+								:variant="'ghost'"
+								theme="gray"
+								size="sm"
+								label="Load All Rows"
+								@click="loadAllRows"
+							>
+							</Button>
+						</div>
 					</template>
 				</DataTable>
 			</div>


### PR DESCRIPTION
### **PR Description**
- Fixed the issue with the total row count displaying incorrectly in the drill-down dialog footer.
- Added a "Load All Rows" button to fetch and display all rows when required.
- Ensured the button is conditionally displayed only when not all rows are loaded.

This PR addresses both pagination and total row count issues in the drill-down dialog.
Closes #405:

**Before Fix**

![image](https://github.com/user-attachments/assets/880f62aa-1075-4fa3-b503-d60e82ea8b85)

**After Fix**

[After.webm](https://github.com/user-attachments/assets/47fd3dc6-d6b7-42d1-b700-d0a4b85ab10a)
