### PR TITLE
fix: filter and sort tooltip values

### DIFF
--- a/frontend/src/widgets/AxisChart/getAxisChartOptions.js
+++ b/frontend/src/widgets/AxisChart/getAxisChartOptions.js
@@ -219,8 +219,18 @@ function makeOptions(chartType, labels, datasets, options) {
 			trigger: 'axis',
 			confine: true,
 			appendToBody: false,
-			valueFormatter: (value) => (isNaN(value) ? value : formatNumber(value)),
+			formatter: (params) => {
+				const filteredParams = params
+					.filter((p) => p.value !== 0 && p.value !== null) 
+					.sort((a, b) => b.value - a.value);
+		
+				if (!filteredParams.length) return ''; 
+				return filteredParams
+					.map((p) => `${p.marker} ${p.seriesName}: ${formatNumber(p.value)}`)
+					.join('<br/>');
+			},
 		},
+		
 	}
 }
 

--- a/frontend/src2/charts/helpers.ts
+++ b/frontend/src2/charts/helpers.ts
@@ -559,6 +559,12 @@ function getTooltip(options: any = {}) {
 		confine: true,
 		appendToBody: false,
 		formatter: (params: Object | Array<Object>) => {
+			if (Array.isArray(params)) {
+                params = params
+                    .filter((p) => p.value?.[1] !== 0) 
+                    .sort((a, b) => b.value?.[1] - a.value?.[1]); 
+            }
+
 			if (!Array.isArray(params)) {
 				const p = params as any
 				const value = options.xySwapped ? p.value[0] : p.value[1]


### PR DESCRIPTION
### **PR Description:**
- Ensures zero values are excluded from the tooltip.
- Sorts tooltip data in descending order for better readability.

Closes #390


**Before Fix**
![image](https://github.com/user-attachments/assets/159eb88a-1fcb-453a-8067-6c1d62f41373)

**After Fix**

![image](https://github.com/user-attachments/assets/2c586410-47f5-4b0a-9f29-b0cbd66a6096)

