### PR TITLE
Fix : Filters not taking affect on shared public dashboard links (v3) #411

### DIFF
--- a/frontend/src2/charts/SharedChart.vue
+++ b/frontend/src2/charts/SharedChart.vue
@@ -7,7 +7,7 @@ import ChartRenderer from './components/ChartRenderer.vue'
 import { getFormattedRows } from '../query/helpers'
 import { showErrorToast } from '../helpers'
 
-const props = defineProps<{ chart_name: string }>()
+const props = defineProps<{ chart_name: string; query?: Record<string, string[]>}>()
 
 const chart = reactive({
 	doc: {} as WorkbookChart,
@@ -15,7 +15,7 @@ const chart = reactive({
 })
 
 const fetchingData = ref(true)
-call('insights.api.workbooks.fetch_shared_chart_data', { chart_name: props.chart_name })
+call('insights.api.workbooks.fetch_shared_chart_data', { chart_name: props.chart_name, filters: props.query })
 	.then((res: any) => {
 		fetchingData.value = false
 		chart.doc = res.chart

--- a/frontend/src2/dashboard/SharedDashboard.vue
+++ b/frontend/src2/dashboard/SharedDashboard.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { call } from 'frappe-ui'
 import { ref } from 'vue'
+import { useRoute } from 'vue-router'
 import SharedChart from '../charts/SharedChart.vue'
 import { WorkbookDashboard } from '../types/workbook.types'
 import VueGridLayout from './VueGridLayout.vue'
@@ -8,6 +9,19 @@ import VueGridLayout from './VueGridLayout.vue'
 const props = defineProps<{ dashboard_name: string }>()
 
 const dashboard = ref<WorkbookDashboard>()
+	const route = useRoute();
+const queryString = new URLSearchParams(route.query);
+const keyValuePairs: Record<string, string[]> = {};
+
+Object.entries(route.query).forEach(([key, value]) => {
+  if (Array.isArray(value)) {
+    keyValuePairs[key] = value
+  } else {
+    keyValuePairs[key] = [value]
+  }
+})
+
+
 
 dashboard.value = await call('insights.api.dashboards.fetch_workbook_dashboard', {
 	dashboard_name: props.dashboard_name,
@@ -26,7 +40,9 @@ dashboard.value = await call('insights.api.dashboards.fetch_workbook_dashboard',
 			>
 				<template #item="{ index }">
 					<div class="relative h-full w-full rounded p-2">
-						<SharedChart :chart_name="dashboard.items[index].chart" />
+						<SharedChart :chart_name="dashboard.items[index].chart"
+						:query="keyValuePairs"
+						/>
 					</div>
 				</template>
 			</VueGridLayout>

--- a/insights/api/workbooks.py
+++ b/insights/api/workbooks.py
@@ -231,7 +231,8 @@ def update_share_permissions(
 
 
 @frappe.whitelist(allow_guest=True)
-def fetch_shared_chart_data(chart_name: str):
+def fetch_shared_chart_data(chart_name: str, filters: dict = None):
+    filters = frappe.parse_json(filters) if filters else {}
     workbooks = frappe.get_all(
         "Insights Workbook",
         filters={"charts": ["like", f"%{chart_name}%"]},
@@ -241,4 +242,4 @@ def fetch_shared_chart_data(chart_name: str):
         frappe.throw("Chart not found")
 
     workbook = frappe.get_doc("Insights Workbook", workbooks[0])
-    return workbook.get_shared_chart_data(chart_name)
+    return workbook.get_shared_chart_data(chart_name, filters)


### PR DESCRIPTION
1. Filter applied in editor mode gets applied on Shared Dashboard Link
2. URL parameters added to the Shared Dashboard Link get applied to the charts in case the chart consists of a filter by similar column.
( idea here is to put a filter for certain column in editor, over-ride the same with parameters passed via url )
#411 