### PR TITLE
Private sharing Support

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -52,6 +52,7 @@
 		"vue-router": "^4.0.12",
 		"vue-sonner": "^1.0.3",
 		"vue-tsc": "^2.0.21",
-		"vuedraggable": "^4.1.0"
+		"vuedraggable": "^4.1.0",
+		"jwt-decode": "4.0.0"
 	}
 }

--- a/frontend/src2/charts/SharedChart.vue
+++ b/frontend/src2/charts/SharedChart.vue
@@ -7,7 +7,7 @@ import ChartRenderer from './components/ChartRenderer.vue'
 import { getFormattedRows } from '../query/helpers'
 import { showErrorToast } from '../helpers'
 
-const props = defineProps<{ chart_name: string }>()
+const props = defineProps<{ chart_name: string; query?: Record<string, string[]>}>()
 
 const chart = reactive({
 	doc: {} as WorkbookChart,
@@ -15,7 +15,7 @@ const chart = reactive({
 })
 
 const fetchingData = ref(true)
-call('insights.api.workbooks.fetch_shared_chart_data', { chart_name: props.chart_name })
+call('insights.api.workbooks.fetch_shared_chart_data', { chart_name: props.chart_name, filters: props.query })
 	.then((res: any) => {
 		fetchingData.value = false
 		chart.doc = res.chart

--- a/frontend/src2/dashboard/DashboardShareDialog.vue
+++ b/frontend/src2/dashboard/DashboardShareDialog.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { Globe } from 'lucide-vue-next'
-import { computed, inject, ref, unref } from 'vue'
+import { Globe, Lock } from 'lucide-vue-next'
+import { computed, inject, ref, unref, watch } from 'vue'
 import { Dashboard } from './dashboard'
 import { copyToClipboard } from '../helpers'
 
@@ -9,39 +9,54 @@ const show = defineModel()
 const dashboard = inject('dashboard') as Dashboard
 
 const isPublic = ref(unref(dashboard.doc.is_public))
+const isPrivate = ref(unref(dashboard.doc.secure_embed))
+
+watch(isPublic, (newVal) => {
+	if (newVal) isPrivate.value = false;
+});
+watch(isPrivate, (newVal) => {
+	if (newVal) isPublic.value = false;
+});
 const shareLink = computed(() => dashboard.getShareLink())
 const iFrameLink = computed(() => {
 	return `<iframe src="${shareLink.value}" width="100%" height="100%" frameborder="0"></iframe>`
 })
-
+const secureLink = computed(() => dashboard.getSecureLink())
 const hasChanged = computed(() => {
-	const prev = Boolean(dashboard.doc.is_public)
-	const next = Boolean(isPublic.value)
-	return prev !== next
+	const prev_public = Boolean(dashboard.doc.is_public)
+	const next_public = Boolean(isPublic.value)
+	const prev_private = Boolean(dashboard.doc.secure_embed)
+	const next_private = Boolean(isPrivate.value)
+	return prev_public !== next_public || prev_private !== next_private
 })
 
 function saveChanges() {
-	dashboard.doc.is_public = isPublic.value
-	dashboard.doc.share_link = shareLink.value
-	show.value = false
+	if (isPublic.value && isPrivate.value && isPublic.value == isPrivate.value) {
+		alert('Public Sharing and Secure Embedding both are not possible at the same time');
+	}
+	else {
+		dashboard.doc.is_public = isPublic.value
+		dashboard.doc.secure_embed = isPrivate.value
+		dashboard.doc.share_link = shareLink.value
+		dashboard.doc.secure_link = secureLink.value
+		show.value = false
+	}
+
 }
 </script>
 
 <template>
-	<Dialog
-		v-model="show"
-		:options="{
-			title: 'Share Dashboard',
-			actions: [
-				{
-					label: 'Done',
-					variant: 'solid',
-					disabled: !hasChanged,
-					onClick: saveChanges,
-				},
-			],
-		}"
-	>
+	<Dialog v-model="show" :options="{
+		title: 'Share Dashboard',
+		actions: [
+			{
+				label: 'Done',
+				variant: 'solid',
+				disabled: !hasChanged,
+				onClick: saveChanges,
+			},
+		],
+	}">
 		<template #body-content>
 			<div class="space-y-3 text-base">
 				<div class="space-y-4">
@@ -57,28 +72,49 @@ function saveChanges() {
 						</div>
 						<Checkbox v-model="isPublic" />
 					</div>
-					<div v-if="shareLink" class="flex overflow-hidden rounded bg-gray-100">
+					<div class="flex items-center gap-3 rounded border px-3 py-2">
+						<Lock class="h-6 w-6 text-red-500" stroke-width="1.5" />
+						<div class="flex flex-1 flex-col">
+							<div class="font-medium leading-5 text-gray-800">
+								Enable Private Access
+							</div>
+							<div class="text-sm text-gray-700">
+								Only users with auto-generated tokens can view this dashboard
+							</div>
+						</div>
+						<Checkbox v-model="isPrivate" />
+					</div>
+					<div v-if="shareLink && isPublic" class="flex overflow-hidden rounded bg-gray-100">
 						<div
-							class="font-code form-input flex-1 overflow-hidden text-ellipsis whitespace-nowrap rounded-r-none text-sm text-gray-600"
-						>
+							class="font-code form-input flex-1 overflow-hidden text-ellipsis whitespace-nowrap rounded-r-none text-sm text-gray-600">
 							{{ shareLink }}
 						</div>
 						<Tooltip text="Copy Link" :hoverDelay="0.1">
-							<Button
-								class="w-8 rounded-none bg-gray-200 hover:bg-gray-300"
-								icon="link-2"
-								@click="copyToClipboard(shareLink)"
-							>
+							<Button class="w-8 rounded-none bg-gray-200 hover:bg-gray-300" icon="link-2"
+								@click="copyToClipboard(shareLink)">
 							</Button>
 						</Tooltip>
 						<Tooltip text="Copy iFrame" :hoverDelay="0.1">
-							<Button
-								class="w-8 rounded-l-none bg-gray-200 hover:bg-gray-300"
-								icon="code"
-								@click="copyToClipboard(iFrameLink)"
-							>
+							<Button class="w-8 rounded-l-none bg-gray-200 hover:bg-gray-300" icon="code"
+								@click="copyToClipboard(iFrameLink)">
 							</Button>
 						</Tooltip>
+					</div>
+					<div v-if="secureLink && isPrivate" class="flex flex-col space-y-3 rounded bg-gray-100 p-4">
+						<div class="text-gray-700 text-base font-medium">
+							<div class="mb-2">
+								Private Access Link: Use the following snippet to create a payload to call
+								"generate_embed_link" API and get the sharable link.
+							</div>
+							<div class="mb-2">
+								<br>payload = {
+          						<br>"resource" : "{{ secureLink }}",
+          						<br>"params": { "column_name": 'value' },
+          						<br>"user" : "session_user",
+          						<br>"exp": round(time.time()) + (60 * (int(10))) // Token valid for 10 Mins
+      							<br>}
+							</div>
+						</div>
 					</div>
 				</div>
 			</div>

--- a/frontend/src2/dashboard/SecureEmbedDashboard.vue
+++ b/frontend/src2/dashboard/SecureEmbedDashboard.vue
@@ -1,0 +1,77 @@
+<script setup lang="ts">
+import { call } from 'frappe-ui'
+import { ref } from 'vue'
+import { useRoute } from 'vue-router'
+import SharedChart from '../charts/SharedChart.vue'
+import { WorkbookDashboard } from '../types/workbook.types'
+import VueGridLayout from './VueGridLayout.vue'
+import { jwtDecode } from "jwt-decode";
+
+
+const props = defineProps<{ dashboard_name: string }>()
+
+
+const dashboard = ref<WorkbookDashboard>()
+const route = useRoute()
+const keyValuePairs: Record<string, string[]> = {}
+
+const jwtToken = route.query.token as string
+let isAuthenticated = false
+
+
+if (jwtToken) {
+    try {
+
+        const decodedToken = jwtDecode(jwtToken)
+        const currentTime = Math.floor(Date.now() / 1000)
+
+        if (decodedToken.exp && decodedToken.exp > currentTime) {
+            isAuthenticated = true
+
+
+            Object.entries(decodedToken.params || {}).forEach(([key, value]) => {
+                if (Array.isArray(value)) {
+                    keyValuePairs[key] = value
+                } else {
+                    keyValuePairs[key] = [value]
+                }
+            })
+        } else {
+            console.error('JWT token has expired')
+        }
+    } catch (error) {
+        console.error('Invalid JWT token', error)
+    }
+} else {
+    console.error('JWT token is missing')
+}
+
+
+
+dashboard.value = await call('insights.api.dashboards.fetch_workbook_dashboard', {
+    dashboard_name: props.dashboard_name,
+})
+
+
+</script>
+
+
+<template>
+    <div class="relative flex h-full w-full overflow-hidden">
+        <div class="flex-1 overflow-y-auto p-4">
+            <div v-if="dashboard && dashboard.secure_embed && isAuthenticated">
+                <VueGridLayout v-if="dashboard && dashboard.items.length > 0" class="h-fit w-full" :cols="20"
+                    :disabled="true" :modelValue="dashboard.items.map((item) => item.layout)">
+                    <template #item="{ index }">
+                        <div class="relative h-full w-full rounded p-2">
+                            <SharedChart :chart_name="dashboard.items[index].chart" :query="keyValuePairs" />
+                        </div>
+                    </template>
+                </VueGridLayout>
+            </div>
+            <div v-else class="flex-1 flex items-center justify-center">
+                <p class="text-red-500">Access Denied: Either token is invalid/expired or Sharing is Disabled</p>
+            </div>
+        </div>
+    </div>
+</template>

--- a/frontend/src2/dashboard/SharedDashboard.vue
+++ b/frontend/src2/dashboard/SharedDashboard.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { call } from 'frappe-ui'
 import { ref } from 'vue'
+import { useRoute } from 'vue-router'
 import SharedChart from '../charts/SharedChart.vue'
 import { WorkbookDashboard } from '../types/workbook.types'
 import VueGridLayout from './VueGridLayout.vue'
@@ -8,6 +9,19 @@ import VueGridLayout from './VueGridLayout.vue'
 const props = defineProps<{ dashboard_name: string }>()
 
 const dashboard = ref<WorkbookDashboard>()
+	const route = useRoute();
+const queryString = new URLSearchParams(route.query);
+const keyValuePairs: Record<string, string[]> = {};
+
+Object.entries(route.query).forEach(([key, value]) => {
+  if (Array.isArray(value)) {
+    keyValuePairs[key] = value
+  } else {
+    keyValuePairs[key] = [value]
+  }
+})
+
+
 
 dashboard.value = await call('insights.api.dashboards.fetch_workbook_dashboard', {
 	dashboard_name: props.dashboard_name,
@@ -26,7 +40,9 @@ dashboard.value = await call('insights.api.dashboards.fetch_workbook_dashboard',
 			>
 				<template #item="{ index }">
 					<div class="relative h-full w-full rounded p-2">
-						<SharedChart :chart_name="dashboard.items[index].chart" />
+						<SharedChart :chart_name="dashboard.items[index].chart"
+						:query="keyValuePairs"
+						/>
 					</div>
 				</template>
 			</VueGridLayout>

--- a/frontend/src2/dashboard/SharedDashboard.vue
+++ b/frontend/src2/dashboard/SharedDashboard.vue
@@ -9,16 +9,16 @@ import VueGridLayout from './VueGridLayout.vue'
 const props = defineProps<{ dashboard_name: string }>()
 
 const dashboard = ref<WorkbookDashboard>()
-	const route = useRoute();
+const route = useRoute();
 const queryString = new URLSearchParams(route.query);
 const keyValuePairs: Record<string, string[]> = {};
 
 Object.entries(route.query).forEach(([key, value]) => {
-  if (Array.isArray(value)) {
-    keyValuePairs[key] = value
-  } else {
-    keyValuePairs[key] = [value]
-  }
+	if (Array.isArray(value)) {
+		keyValuePairs[key] = value
+	} else {
+		keyValuePairs[key] = [value]
+	}
 })
 
 
@@ -31,21 +31,19 @@ dashboard.value = await call('insights.api.dashboards.fetch_workbook_dashboard',
 <template>
 	<div class="relative flex h-full w-full overflow-hidden">
 		<div class="flex-1 overflow-y-auto p-4">
-			<VueGridLayout
-				v-if="dashboard && dashboard.items.length > 0"
-				class="h-fit w-full"
-				:cols="20"
-				:disabled="true"
-				:modelValue="dashboard.items.map((item) => item.layout)"
-			>
-				<template #item="{ index }">
-					<div class="relative h-full w-full rounded p-2">
-						<SharedChart :chart_name="dashboard.items[index].chart"
-						:query="keyValuePairs"
-						/>
-					</div>
-				</template>
-			</VueGridLayout>
+			<div v-if="dashboard && dashboard.is_public">
+				<VueGridLayout v-if="dashboard && dashboard.items.length > 0" class="h-fit w-full" :cols="20"
+					:disabled="true" :modelValue="dashboard.items.map((item) => item.layout)">
+					<template #item="{ index }">
+						<div class="relative h-full w-full rounded p-2">
+							<SharedChart :chart_name="dashboard.items[index].chart" :query="keyValuePairs" />
+						</div>
+					</template>
+				</VueGridLayout>
+			</div>
+			<div v-else class="flex-1 flex items-center justify-center">
+				<p class="text-red-500">Access Denied: Public Sharing is Disabled</p>
+			</div>
 		</div>
 	</div>
 </template>

--- a/frontend/src2/dashboard/dashboard.ts
+++ b/frontend/src2/dashboard/dashboard.ts
@@ -85,13 +85,20 @@ function makeDashboard(workbookDashboard: WorkbookDashboard) {
 				}
 			})
 
-			chart.refresh(undefined, true)
+			chart.refresh()
 		},
 
 		getShareLink() {
 			return (
 				dashboard.doc.share_link ||
 				`${window.location.origin}/insights/shared/dashboard/${dashboard.doc.name}`
+			)
+		},
+
+		getSecureLink() {
+			return (
+				dashboard.doc.secure_link ||
+				`${window.location.origin}/insights/secure/dashboard/${dashboard.doc.name}`
 			)
 		},
 	})

--- a/frontend/src2/router.ts
+++ b/frontend/src2/router.ts
@@ -101,6 +101,16 @@ const routes = [
 		},
 	},
 	{
+		props: true,
+		name: 'SecureDashboard',
+		path: '/secure/dashboard/:dashboard_name',
+		component: () => import('./dashboard/SecureEmbedDashboard.vue'),
+		meta: {
+			hideSidebar: true,
+			isGuestView: true,
+		},
+	},
+	{
 		path: '/:pathMatch(.*)*',
 		component: () => import('./auth/NotFound.vue'),
 		meta: { hideSidebar: true },

--- a/frontend/src2/types/workbook.types.ts
+++ b/frontend/src2/types/workbook.types.ts
@@ -59,6 +59,8 @@ export type WorkbookDashboard = {
 	items: WorkbookDashboardItem[]
 	is_public?: boolean
 	share_link?: string
+	secure_embed? : boolean
+	secure_link?: string
 }
 
 export type WorkbookDashboardItem = WorkbookDashboardChart

--- a/insights/api/embed_link.py
+++ b/insights/api/embed_link.py
@@ -7,15 +7,8 @@ def generate_embed_link(payload):
 
     secret_key = frappe.db.get_single_value("Insights Settings", "secret_key")
 
-    users = frappe.get_all(
-        "User",
-        filters={
-            "enabled": 1,
-        },
-        fields=["email"],
-    )
-
-    user_exists = any(user["email"] == payload["user"] for user in users)
+    user_exists = frappe.db.exists("User",{"email": payload['user'], "enabled": 1})
+    
     if user_exists:
         token = jwt.encode(payload, secret_key, algorithm="HS256")
         protected_link = f"{payload['resource']}?token={token}"

--- a/insights/api/embed_link.py
+++ b/insights/api/embed_link.py
@@ -1,0 +1,24 @@
+import jwt
+import frappe
+
+
+@frappe.whitelist()
+def generate_embed_link(payload):
+
+    secret_key = frappe.db.get_single_value("Insights Settings", "secret_key")
+
+    users = frappe.get_all(
+        "User",
+        filters={
+            "enabled": 1,
+        },
+        fields=["email"],
+    )
+
+    user_exists = any(user["email"] == payload["user"] for user in users)
+    if user_exists:
+        token = jwt.encode(payload, secret_key, algorithm="HS256")
+        protected_link = f"{payload['resource']}?token={token}"
+        return protected_link
+    else:
+        frappe.throw("No Access to User")

--- a/insights/api/workbooks.py
+++ b/insights/api/workbooks.py
@@ -231,7 +231,8 @@ def update_share_permissions(
 
 
 @frappe.whitelist(allow_guest=True)
-def fetch_shared_chart_data(chart_name: str):
+def fetch_shared_chart_data(chart_name: str, filters: dict = None):
+    filters = frappe.parse_json(filters) if filters else {}
     workbooks = frappe.get_all(
         "Insights Workbook",
         filters={"charts": ["like", f"%{chart_name}%"]},
@@ -241,4 +242,4 @@ def fetch_shared_chart_data(chart_name: str):
         frappe.throw("Chart not found")
 
     workbook = frappe.get_doc("Insights Workbook", workbooks[0])
-    return workbook.get_shared_chart_data(chart_name)
+    return workbook.get_shared_chart_data(chart_name, filters)

--- a/insights/insights/doctype/insights_settings/insights_settings.json
+++ b/insights/insights/doctype/insights_settings/insights_settings.json
@@ -15,6 +15,7 @@
   "max_memory_usage",
   "integrations_section",
   "telegram_api_token",
+  "secret_key",
   "query_section",
   "fiscal_year_start",
   "week_starts_on",
@@ -134,12 +135,17 @@
    "fieldname": "apply_user_permissions",
    "fieldtype": "Check",
    "label": "Apply User Permissions"
+  },
+  {
+   "fieldname": "secret_key",
+   "fieldtype": "Data",
+   "label": "JWT Secret Key"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-12-03 16:27:21.761873",
+ "modified": "2025-01-09 16:07:51.393887",
  "modified_by": "Administrator",
  "module": "Insights",
  "name": "Insights Settings",

--- a/insights/insights/doctype/insights_settings/insights_settings.py
+++ b/insights/insights/doctype/insights_settings/insights_settings.py
@@ -29,11 +29,10 @@ class InsightsSettings(Document):
         onboarding_complete: DF.Check
         query_result_expiry: DF.Int
         query_result_limit: DF.Int
+        secret_key: DF.Data | None
         setup_complete: DF.Check
         telegram_api_token: DF.Password | None
-        week_starts_on: DF.Literal[
-            "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"
-        ]
+        week_starts_on: DF.Literal["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]
     # end: auto-generated types
 
     def before_save(self):

--- a/insights/insights/doctype/insights_workbook/insights_workbook.py
+++ b/insights/insights/doctype/insights_workbook/insights_workbook.py
@@ -122,7 +122,7 @@ class InsightsWorkbook(Document):
             item["chart"]
             for shared_dashboard in dashboards
             for item in shared_dashboard["items"]
-            if item["type"] == "chart" and shared_dashboard.get("is_public")
+            if item["type"] == "chart" and (shared_dashboard.get("is_public") or shared_dashboard.get("secure_embed"))
         ]
         # chart belongs to one of the shared dashboards
         if any(chart_name == chart["name"] for chart_name in shared_dashboard_charts):

--- a/insights/www/insights.py
+++ b/insights/www/insights.py
@@ -32,6 +32,7 @@ def get_context(context):
     guest_v3_routes = [
         "/insights/shared/chart",
         "/insights/shared/dashboard",
+        "/insights/secure/dashboard",
     ]
     if any(route in frappe.request.path for route in guest_v3_routes):
         continue_to_v3(context)


### PR DESCRIPTION
Enabling an option to share securely using authentication via JWT

1. jwt endpoint created at generate_embed_link , can access using the following payload:
payload = {
"resource" : "your_site/insights/secure/dashboard/dashboard_name",   // Generated by system
"params": { "column_name": 'value' },    // Filters
"user" : "session_user",    // User to be part of system, else jwt token will not be generated
"exp": round(time.time()) + (60 * (int(10)))       // Token valid for 10 Mins
}

2. added options to share either as public or securely as private, also validations for the same

3. insights/secure/dashboard view to support the authenticated link

4. added a field secret_key in Insights Settings for the authentication process

<img width="549" alt="Screenshot 2025-01-09 at 6 24 43 PM" src="https://github.com/user-attachments/assets/3fc57d3a-5146-4083-84ff-58a029da233c" />

