### PR TITLE
feat: support stored procedure execution

### DIFF
--- a/insights/insights/doctype/insights_data_source_v3/ibis_utils.py
+++ b/insights/insights/doctype/insights_data_source_v3/ibis_utils.py
@@ -15,7 +15,6 @@ from ibis.expr.types import Expr
 from ibis.expr.types import Table as IbisQuery
 
 from insights.cache_utils import make_digest
-from insights.insights.doctype.insights_data_source_v3.data_warehouse import Warehouse
 from insights.insights.doctype.insights_data_source_v3.insights_data_source_v3 import (
     DataSourceConnectionError,
 )
@@ -443,12 +442,7 @@ class IbisQueryBuilder:
 
             df = pd.DataFrame.from_records(rows, columns=columns)
 
-            results = Warehouse().db.create_table(
-                make_digest(raw_sql),
-                df,
-                temp=True,
-                overwrite=True,
-            )
+            results = ibis.memtable(df)
 
         elif raw_sql.strip().lower().startswith(("select", "with")):
             results = db.sql(raw_sql)
@@ -658,7 +652,7 @@ def exec_with_return(
 def get_ibis_table_name(table: IbisQuery):
     dt = table.op().find_topmost(DatabaseTable)
     if not dt:
-        return None
+        return "right_table"
     return dt[0].name
 
 

--- a/insights/insights/doctype/insights_data_source_v3/insights_data_source_v3.json
+++ b/insights/insights/doctype/insights_data_source_v3/insights_data_source_v3.json
@@ -13,6 +13,7 @@
   "use_ssl",
   "is_site_db",
   "is_frappe_db",
+  "enable_stored_procedure_execution",
   "column_break_pfsa",
   "database_name",
   "username",
@@ -116,11 +117,17 @@
    "fieldname": "bigquery_service_account_key",
    "fieldtype": "JSON",
    "label": "BigQuery Service Account Key (JSON)"
+  },
+  {
+   "default": "0",
+   "fieldname": "enable_stored_procedure_execution",
+   "fieldtype": "Check",
+   "label": "Enable Stored Procedure Execution"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-11-07 19:06:14.814805",
+ "modified": "2025-02-18 14:19:27.774432",
  "modified_by": "Administrator",
  "module": "Insights",
  "name": "Insights Data Source v3",

--- a/insights/insights/doctype/insights_data_source_v3/insights_data_source_v3.py
+++ b/insights/insights/doctype/insights_data_source_v3/insights_data_source_v3.py
@@ -161,6 +161,7 @@ class InsightsDataSourcev3(InsightsDataSourceDocument, Document):
         database_type: DF.Literal[
             "MariaDB", "PostgreSQL", "SQLite", "DuckDB", "BigQuery", "MSSQL"
         ]
+        enable_stored_procedure_execution: DF.Check
         host: DF.Data | None
         is_frappe_db: DF.Check
         is_site_db: DF.Check


### PR DESCRIPTION
Added the possibility to execute stored procedures by adding the exec word to the conditions and using raw_sql() from ibis instead of sql(). 

Also added the possibility to use Current Date as variable (@Today) in queries. It will be replaced by the current server date in the following format ('YYYY-MM-DD').

Use:
`EXEC usp_report_Sales @valuationDate = @Today, @ShowSerialNumbers=1`