### PR TITLE
Fix drill-down not working in Table Chart inside Dashboard

### DIFF
--- a/frontend/src2/dashboard/DashboardChart.vue
+++ b/frontend/src2/dashboard/DashboardChart.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { watchDebounced } from '@vueuse/core'
 import { AlertTriangle, Maximize } from 'lucide-vue-next'
-import { computed, inject, ref } from 'vue'
+import { computed, inject, ref, provide } from 'vue'
 import { useRouter } from 'vue-router'
 import { getCachedChart } from '../charts/chart'
 import ChartRenderer from '../charts/components/ChartRenderer.vue'
@@ -16,7 +16,7 @@ const chart = computed(() => {
 	if (!props.item.chart) return null
 	return getCachedChart(props.item.chart)
 })
-
+provide('chart',chart)
 const dashboard = inject<Dashboard>('dashboard')!
 if (props.item.chart && !chart.value?.dataQuery.result.executedSQL) {
 	dashboard.refreshChart(props.item.chart)


### PR DESCRIPTION
This PR fixes the issue where **drill-down was not working in TableChart.vue** because `chart` was `undefined`.  
closes: #447 


### 🛠 Fix Implemented  
- Used **`provide('chart', chart)`** in `DashboardChart.vue` so it can be accessed in `TableChart.vue`.
- Now, `chart` is **available** in `TableChart.vue`, enabling drill-down functionality.
