### PR TITLE
fix: adjust height for textarea in text widget.

### DIFF
--- a/frontend/src2/dashboard/DashboardText.vue
+++ b/frontend/src2/dashboard/DashboardText.vue
@@ -44,7 +44,7 @@ const editedText = ref(unref(props.item.text))
 					ref="textEditor"
 					:editable="true"
 					:content="editedText"
-					editor-class="h-[8rem] prose-sm cursor-text bg-gray-100 rounded p-2"
+					editor-class="min-h-[8rem] h-auto prose-sm cursor-text bg-gray-100 rounded p-2"
 					@change="editedText = $event"
 				/>
 				<p class="text-xs text-gray-500">Markdown supported</p>


### PR DESCRIPTION
Auto and minimum height for the textarea with fixed height while adding text in a dashboard.