### PR TITLE
fix: dev server not running

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -21,6 +21,7 @@ export default defineConfig({
 	esbuild: { loader: 'tsx' },
 	resolve: {
 		alias: {
+			vue: 'vue/dist/vue.esm-bundler.js',
 			'@': path.resolve(__dirname, 'src'),
 			'tailwind.config.js': path.resolve(__dirname, 'tailwind.config.js'),
 		},
@@ -42,7 +43,8 @@ export default defineConfig({
 		},
 	},
 	optimizeDeps: {
-		include: ['feather-icons', 'showdown', 'tailwind.config.js'],
+		include: ['feather-icons','showdown','tailwind.config.js','highlight.js/lib/core'],
+		
 	},
 	define: {
 		// enable hydration mismatch details in production build


### PR DESCRIPTION
fixes error due to highlight.js import in lowlight
`Uncaught SyntaxError: The requested module '/@fs/home/{user}/frappe-bench/apps/insights/node_modules/highlight.js/lib/core.js?v=90dd4c39' does not provide an export named 'default'`

closes #512
OS: Ubuntu 22.04 
Node: v21.7.3
insights: version-3
frappe: version-16