### PR TITLE
Feat: Truncate label on Y-Axis and ability to scroll in bar charts

### DIFF
--- a/frontend/src2/charts/helpers.ts
+++ b/frontend/src2/charts/helpers.ts
@@ -194,6 +194,18 @@ export function getBarChartOptions(config: BarChartConfig, result: QueryResult, 
 		grid: getGrid({ show_legend }),
 		xAxis: swapAxes ? yAxis : xAxis,
 		yAxis: swapAxes ? xAxis : yAxis,
+		dataZoom: [
+				{
+					type: 'slider',
+					yAxisIndex: 0,
+					zoomLock: false,
+					width: 15,
+					right: 10,
+					start:100,
+					end: 60,
+					handleSize: 20,
+				},
+			],
 		series: number_columns.map((c, idx) => {
 			const serie = getSerie(config, c.name)
 			const is_right_axis = serie.align === 'Right'
@@ -213,6 +225,7 @@ export function getBarChartOptions(config: BarChartConfig, result: QueryResult, 
 			if (type == 'line') {
 				labelPosition = 'top'
 			}
+			
 
 			return {
 				type,

--- a/frontend/src2/charts/helpers.ts
+++ b/frontend/src2/charts/helpers.ts
@@ -287,6 +287,9 @@ function getXAxis(x_axis: XAxis) {
 		axisLabel: {
 			show: true,
 			rotate: rotation,
+			width: 100,
+      		overflow: 'truncate',
+      		ellipsis: '...',
 		},
 	}
 }


### PR DESCRIPTION
Right now the labels on Y-Axis disappear from the start which makes the user unable to read when the characters reach a certain limit. Now the label text will truncate from the end when it reaches max width.

Added Ability to scroll and zoom in on bar, row and line charts. 