### PR TITLE
fix: Replace default text with placeholders in dashboard widgets

### DIFF
--- a/frontend/src2/dashboard/DashboardFilter.vue
+++ b/frontend/src2/dashboard/DashboardFilter.vue
@@ -78,7 +78,7 @@ const label = computed(() => {
 							stroke-width="1.5"
 						/>
 					</template>
-					{{ label || 'Filter' }}
+					{{ label  }}
 				</Button>
 			</template>
 			<template #body-main="{ togglePopover, isOpen }">

--- a/frontend/src2/dashboard/DashboardFilter.vue
+++ b/frontend/src2/dashboard/DashboardFilter.vue
@@ -36,7 +36,7 @@ function stringValuesProvider(search: string) {
 	return dashboard.getDistinctColumnValues(
 		sourceColumn.value.query,
 		sourceColumn.value.column,
-		search
+		search,
 	)
 }
 
@@ -46,7 +46,7 @@ wheneverChanges(
 	() => {
 		dashboard.updateFilterState(filter.filter_name, filterState.operator, filterState.value)
 	},
-	{ deep: true }
+	{ deep: true },
 )
 
 const label = computed(() => {
@@ -73,12 +73,12 @@ const label = computed(() => {
 					<template #prefix>
 						<DataTypeIcon
 							v-if="filter.filter_type"
-							:column-type="(FILTER_TYPES[filter.filter_type][0] as ColumnDataType)"
+							:column-type="FILTER_TYPES[filter.filter_type][0] as ColumnDataType"
 							class="h-4 w-4 flex-shrink-0"
 							stroke-width="1.5"
 						/>
 					</template>
-					{{ label  }}
+					{{ label }}
 				</Button>
 			</template>
 			<template #body-main="{ togglePopover, isOpen }">

--- a/frontend/src2/dashboard/DashboardFilterEditor.vue
+++ b/frontend/src2/dashboard/DashboardFilterEditor.vue
@@ -117,6 +117,7 @@ function saveEdit() {
 						class="flex-1 flex-shrink-0"
 						label="Label"
 						v-model="filter.filter_name"
+						placeholder="Enter filter label..."
 						autocomplete="off"
 					/>
 					<FormControl

--- a/frontend/src2/dashboard/DashboardText.vue
+++ b/frontend/src2/dashboard/DashboardText.vue
@@ -46,6 +46,7 @@ const editedText = ref(unref(props.item.text))
 					:content="editedText"
 					editor-class="min-h-[8rem] h-auto prose-sm cursor-text bg-gray-100 rounded p-2"
 					@change="editedText = $event"
+					placeholder="Enter your text content here..."
 				/>
 				<p class="text-xs text-gray-500">Markdown supported</p>
 			</div>

--- a/frontend/src2/dashboard/dashboard.ts
+++ b/frontend/src2/dashboard/dashboard.ts
@@ -98,7 +98,7 @@ function makeDashboard(name: string) {
 		const maxY = getMaxY()
 		dashboard.doc.items.push({
 			type: 'filter',
-			filter_name: 'Filter',
+			filter_name: '',
 			filter_type: 'String',
 			links: {},
 			layout: {

--- a/frontend/src2/dashboard/dashboard.ts
+++ b/frontend/src2/dashboard/dashboard.ts
@@ -82,7 +82,7 @@ function makeDashboard(name: string) {
 		const maxY = getMaxY()
 		dashboard.doc.items.push({
 			type: 'text',
-			text: 'Enter text here',
+			text: '',
 			layout: {
 				i: getUniqueId(),
 				x: 0,


### PR DESCRIPTION
Replace default text with placeholders in dashboard widgets.

- Fixes UX issue where default text appeared as actual content user need to clear that and enter text