### PR TITLE
fix: adhoc filter drilldown in dashboard charts

### DIFF
--- a/frontend/src2/charts/components/ChartRenderer.vue
+++ b/frontend/src2/charts/components/ChartRenderer.vue
@@ -20,8 +20,9 @@ import BaseChart from './BaseChart.vue'
 import DrillDown from './DrillDown.vue'
 import NumberChart from './NumberChart.vue'
 import TableChart from './TableChart.vue'
+import { FilterArgs } from '../../types/query.types'
 
-const props = defineProps<{ chart: Chart }>()
+const props = defineProps<{ chart: Chart ,dashboardAdhocFilters?: FilterArgs[]}>()
 
 const chart_type = computed(() => props.chart.doc.chart_type)
 const config = computed(() => props.chart.doc.config)
@@ -62,7 +63,7 @@ function onChartElementClick(params: any) {
 		}
 		const row = result.value.formattedRows[dataIndex]
 		const column = result.value.columns.find((c) => c.name === params.seriesName)!
-		drillDownQuery.value = props.chart.dataQuery.getDrillDownQuery(column, row)
+		drillDownQuery.value = props.chart.dataQuery.getDrillDownQuery(column, row,props!.dashboardAdhocFilters)
 	}
 	if (drillDownQuery.value) {
 		showDrillDown.value = true
@@ -70,7 +71,7 @@ function onChartElementClick(params: any) {
 }
 
 function onNumberChartDrillDown(column: any, row: any) {
-	drillDownQuery.value = props.chart.dataQuery.getDrillDownQuery(column, row)
+	drillDownQuery.value = props.chart.dataQuery.getDrillDownQuery(column, row,props!.dashboardAdhocFilters)
 	if (drillDownQuery.value) {
 		showDrillDown.value = true
 	}
@@ -107,7 +108,7 @@ function onNumberChartDrillDown(column: any, row: any) {
 			</template>
 		</div>
 	</div>
-
+<!-- can add adhoc options here -->
 	<DrillDown
 		v-if="drillDownQuery"
 		v-model="showDrillDown"

--- a/frontend/src2/dashboard/DashboardChart.vue
+++ b/frontend/src2/dashboard/DashboardChart.vue
@@ -50,7 +50,7 @@ wheneverChanges(
 </script>
 
 <template>
-	<ChartRenderer v-if="chart" :chart="chart" />
+	<ChartRenderer v-if="chart" :chart="chart" :dashboardAdhocFilters="dashboard.adhocFilters" />
 
 	<div v-else class="flex h-full flex-1 flex-col items-center justify-center rounded border">
 		<AlertTriangle class="h-8 w-8 text-gray-500" stroke-width="1" />
@@ -75,7 +75,7 @@ wheneverChanges(
 	>
 		<template #body>
 			<div class="h-[75vh] w-full">
-				<ChartRenderer v-if="chart" :chart="chart" />
+				<ChartRenderer v-if="chart" :chart="chart" :dashboardAdhocFilters="dashboard.adhocFilters" />
 			</div>
 		</template>
 	</Dialog>

--- a/frontend/src2/dashboard/dashboard.ts
+++ b/frontend/src2/dashboard/dashboard.ts
@@ -51,7 +51,7 @@ function makeDashboard(name: string) {
 
 	const filters = ref<Record<string, FilterArgs[]>>({})
 	const filterStates = ref<Record<string, FilterState>>({})
-
+	const adhocFilters = ref<Record<string, FilterGroup>>({})
 
 	function addChart(charts: WorkbookChart[]) {
 		const maxY = getMaxY()
@@ -166,6 +166,7 @@ function makeDashboard(name: string) {
 			}
 		})
 
+		adhocFilters.value = filtersByQuery
 		return filtersByQuery
 	}
 
@@ -285,6 +286,7 @@ function makeDashboard(name: string) {
 		filters,
 		filterStates,
 
+		adhocFilters,
 		addChart,
 		addText,
 		addFilter,

--- a/frontend/src2/query/query.ts
+++ b/frontend/src2/query/query.ts
@@ -573,10 +573,10 @@ export function makeQuery(name: string) {
 			})
 	}
 
-	function getDrillDownQuery(col: QueryResultColumn, row: QueryResultRow) {
-		if (!session.isLoggedIn) {
-			return
-		}
+function getDrillDownQuery(col: QueryResultColumn, row: QueryResultRow, adhocFilters?: FilterArgs[]) {
+	if (!session.isLoggedIn) {
+		return
+	}
 
 		const error = validateDrillDown(col, row)
 		if (error) {
@@ -587,7 +587,6 @@ export function makeQuery(name: string) {
 			})
 			return
 		}
-
 		const operations = copy(query.doc.operations)
 		const reversedOperations = operations.slice().reverse()
 
@@ -615,9 +614,24 @@ export function makeQuery(name: string) {
 		}
 
 		drill_down_query.setOperations(operations.slice(0, sliceIdx))
+
+		const dashboardFilter = ref<any>()
+
+		if (adhocFilters) {
+			dashboardFilter.value = Object.values(adhocFilters)
+				.map(obj => obj.filters)
+				.filter(Boolean)
+				.flat();
+		}
+		
+		const allFilters = [...filters]
+		if (dashboardFilter.value) {
+			allFilters.push(...dashboardFilter.value)
+		}
+
 		drill_down_query.addFilterGroup({
 			logical_operator: 'And',
-			filters: filters,
+			filters: allFilters
 		})
 
 		return drill_down_query


### PR DESCRIPTION
Issue: when filters are applied from dashboard, its not passed onto the drilldown query of the dashboard chart.

This issue adds the filter only to the dashboard chart drilldown dialog. 