### PR TITLE
Fix: Dashboard cards stay in place when there is empty space above

### DIFF
--- a/frontend/src2/dashboard/VueGridLayout.vue
+++ b/frontend/src2/dashboard/VueGridLayout.vue
@@ -58,7 +58,7 @@ const options = reactive({
 	isDraggable: computed(() => !props.disabled),
 	isResizable: computed(() => !props.disabled),
 	responsive: true,
-	verticalCompact: true,
+	verticalCompact: false,
 	preventCollision: false,
 	useCssTransforms: true,
 	cols: {


### PR DESCRIPTION
Cards now stay where placed, even if there is empty space above
Improves dashboard editing experience

Fixes #578