### PR TITLE
feat(db): Read from database replica if available

### DIFF
--- a/insights/insights/doctype/insights_data_source/sources/frappe_db.py
+++ b/insights/insights/doctype/insights_data_source/sources/frappe_db.py
@@ -277,14 +277,29 @@ class FrappeDB(MariaDB):
 class SiteDB(FrappeDB):
     def __init__(self, data_source):
         self.data_source = data_source
+
+        username = frappe.conf.db_name
+        password = frappe.conf.db_password
+        database = frappe.conf.db_name
+        host = frappe.conf.db_host or "127.0.0.1"
+        port = frappe.conf.db_port or "3306"
+
+        if frappe.conf.read_from_replica:
+            if frappe.conf.different_credentials_for_replica:
+                username = frappe.conf.replica_db_user or frappe.conf.replica_db_name or username
+                password = frappe.conf.replica_db_password or password
+            database = frappe.conf.replica_db_name or database
+            host = frappe.conf.replica_host or host
+            port = frappe.conf.replica_db_port or port
+
         self.engine = get_sqlalchemy_engine(
             dialect="mysql",
             driver="pymysql",
-            username=frappe.conf.db_name,
-            password=frappe.conf.db_password,
-            database=frappe.conf.db_name,
-            host=frappe.conf.db_host or "127.0.0.1",
-            port=frappe.conf.db_port or "3306",
+            username=username,
+            password=password,
+            database=database,
+            host=host,
+            port=port,
             ssl=False,
             ssl_verify_cert=bool(not frappe.conf.developer_mode),
             charset="utf8mb4",

--- a/insights/insights/doctype/insights_data_source_v3/connectors/frappe_db.py
+++ b/insights/insights/doctype/insights_data_source_v3/connectors/frappe_db.py
@@ -28,6 +28,17 @@ def get_sitedb_connection():
     data_source.username = frappe.conf.db_name
     data_source.password = frappe.conf.db_password
     data_source.use_ssl = False
+
+    if frappe.conf.read_from_replica:
+        if frappe.conf.different_credentials_for_replica:
+            data_source.username = (
+                frappe.conf.replica_db_user or frappe.conf.replica_db_name or data_source.username
+            )
+            data_source.password = frappe.conf.replica_db_password or data_source.password
+        data_source.database_name = frappe.conf.replica_db_name or data_source.database_name
+        data_source.host = frappe.conf.replica_host or data_source.host
+        data_source.port = frappe.conf.replica_db_port or data_source.port
+
     return get_frappedb_connection(data_source)
 
 


### PR DESCRIPTION
Since Frappe v14, read-only queries can be addressed to a secondary database server (replica). This helps offload the primary server. I noticed that this framework feature was not used in Insights. This PR intends to fix that.

> https://docs.frappe.io/framework/v14/user/en/guides/database-settings/setup-read-from-secondary-db

