### PR TITLE
fix: show `null` values as `null` instead of `0`

### DIFF
--- a/frontend/src2/components/DataTable.vue
+++ b/frontend/src2/components/DataTable.vue
@@ -249,6 +249,7 @@ const colorByValues = computed(() => {
 })
 
 function _formatNumber(value: any) {
+	if (value === null || value === undefined) return 'null'
 	return props.compactNumbers ? getShortNumber(value) : formatNumber(value)
 }
 </script>


### PR DESCRIPTION
<img width="1904" height="1064" alt="image" src="https://github.com/user-attachments/assets/b844194a-1734-40d3-9bdb-3032455eadaa" />
