### PR TITLE
feat: add force execution option to SQL editor

### DIFF
--- a/frontend/src2/index.css
+++ b/frontend/src2/index.css
@@ -52,3 +52,7 @@ body {
 .fade-leave-to {
 	opacity: 0;
 }
+
+.lucide {
+	stroke-width: 1.5;
+}

--- a/frontend/src2/query/components/NativeQueryEditor.vue
+++ b/frontend/src2/query/components/NativeQueryEditor.vue
@@ -1,15 +1,14 @@
 <script setup lang="ts">
 import { useTimeAgo } from '@vueuse/core'
-import { LoadingIndicator } from 'frappe-ui'
-import { Play, Wand2 } from 'lucide-vue-next'
+import { MoreHorizontal, Play } from 'lucide-vue-next'
 import { computed, inject, ref } from 'vue'
 import Code from '../../components/Code.vue'
-import { Query } from '../query'
 import ContentEditable from '../../components/ContentEditable.vue'
-import DataSourceSelector from './source_selector/DataSourceSelector.vue'
-import { wheneverChanges } from '../../helpers'
 import useDataSourceStore from '../../data_source/data_source'
+import { wheneverChanges } from '../../helpers'
+import { Query } from '../query'
 import QueryDataTable from './QueryDataTable.vue'
+import DataSourceSelector from './source_selector/DataSourceSelector.vue'
 
 const query = inject<Query>('query')!
 query.autoExecute = false
@@ -103,16 +102,16 @@ const completions = computed(() => {
 						<Play class="h-3.5 w-3.5 text-gray-700" stroke-width="1.5" />
 					</template>
 				</Button>
-				<Button @click="execute(true)" label="Force Execute">
-					<template #prefix>
-						<Play class="h-3.5 w-3.5 text-gray-700" stroke-width="1.5" />
-					</template>
-				</Button>
-				<Button @click="" label="Format">
-					<template #prefix>
-						<Wand2 class="h-3.5 w-3.5 text-gray-700" stroke-width="1.5" />
-					</template>
-				</Button>
+				<Dropdown
+					:button="{ icon: MoreHorizontal }"
+					:options="[
+						{
+							label: 'Force Execute',
+							icon: Play,
+							onClick: () => execute(true),
+						},
+					]"
+				/>
 			</div>
 		</div>
 		<div

--- a/frontend/src2/query/components/NativeQueryEditor.vue
+++ b/frontend/src2/query/components/NativeQueryEditor.vue
@@ -18,7 +18,7 @@ query.execute()
 const operation = query.getSQLOperation()
 const data_source = ref(operation ? operation.data_source : '')
 const sql = ref(operation ? operation.raw_sql : '')
-function execute() {
+function execute(force: boolean = false) {
 	if (!data_source.value) {
 		createToast({
 			title: 'Please select a data source first',
@@ -26,10 +26,13 @@ function execute() {
 		})
 		return
 	}
-	query.setSQL({
-		raw_sql: sql.value,
-		data_source: data_source.value,
-	})
+	query.setSQL(
+		{
+			raw_sql: sql.value,
+			data_source: data_source.value,
+		},
+		force,
+	)
 }
 
 const dataSourceSchema = ref<Record<string, any>>({})
@@ -95,7 +98,12 @@ const completions = computed(() => {
 				/>
 			</div>
 			<div class="flex flex-shrink-0 gap-1 border-t p-1">
-				<Button @click="execute" label="Execute">
+				<Button @click="execute(false)" label="Execute">
+					<template #prefix>
+						<Play class="h-3.5 w-3.5 text-gray-700" stroke-width="1.5" />
+					</template>
+				</Button>
+				<Button @click="execute(true)" label="Force Execute">
 					<template #prefix>
 						<Play class="h-3.5 w-3.5 text-gray-700" stroke-width="1.5" />
 					</template>

--- a/frontend/src2/query/components/ScriptQueryEditor.vue
+++ b/frontend/src2/query/components/ScriptQueryEditor.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { useTimeAgo } from '@vueuse/core'
-import { LoadingIndicator } from 'frappe-ui'
-import { Bug, Play, Braces } from 'lucide-vue-next'
+import { Braces, Bug, MoreHorizontal, Play } from 'lucide-vue-next'
 import { inject, ref } from 'vue'
 import Code from '../../components/Code.vue'
 import ContentEditable from '../../components/ContentEditable.vue'
@@ -38,11 +37,12 @@ function openVariablesDialog() {
 }
 
 function handleSaveVariables(variables: any[]) {
-	query.updateVariables(variables).then(() => {
-		showVariablesDialog.value = false
-	}).catch((error) => {
-
-	})
+	query
+		.updateVariables(variables)
+		.then(() => {
+			showVariablesDialog.value = false
+		})
+		.catch((error) => {})
 }
 </script>
 
@@ -91,16 +91,26 @@ function handleSaveVariables(variables: any[]) {
 						<Play class="h-3.5 w-3.5 text-gray-700" stroke-width="1.5" />
 					</template>
 				</Button>
-				<Button @click="openVariablesDialog" label="Variables">
-					<template #prefix>
-						<Braces class="h-3.5 w-3.5 text-gray-700" stroke-width="1.5" />
-					</template>
-				</Button>
-				<Button @click="showLogs = !showLogs" label="Logs">
-					<template #prefix>
-						<Bug class="h-3.5 w-3.5 text-gray-700" stroke-width="1.5" />
-					</template>
-				</Button>
+				<Dropdown
+					:button="{ icon: MoreHorizontal }"
+					:options="[
+						{
+							label: 'Force Run',
+							icon: Play,
+							onClick: () => query.execute(true),
+						},
+						{
+							label: 'Variables',
+							icon: Braces,
+							onClick: openVariablesDialog,
+						},
+						{
+							label: 'Logs',
+							icon: Bug,
+							onClick: () => (showLogs = !showLogs),
+						},
+					]"
+				/>
 			</div>
 		</div>
 

--- a/frontend/src2/query/query.ts
+++ b/frontend/src2/query/query.ts
@@ -530,12 +530,12 @@ export function makeQuery(name: string) {
 		return query.doc.operations.find((op) => op.type === 'sql')
 	}
 
-	function setSQL(args: SQLArgs) {
+	function setSQL(args: SQLArgs, force: boolean = false) {
 		query.doc.operations = []
 		if (args.raw_sql.trim().length) {
 			query.doc.operations.push(sql(args))
 			activeOperationIdx.value = 0
-			execute()
+			execute(force)
 		} else {
 			activeOperationIdx.value = -1
 		}


### PR DESCRIPTION
feat: Add `Force Execute` option to bypass SQL result cache

 - Cached SQL results were making it difficult to debug queries, especially after inserting new data. Re-running the same SQL would return stale results due to caching, rather than reflecting the latest data.

 - This PR adds a Force Execute button to the SQL editor, allowing users to explicitly bypass the cache and run the query fresh.



https://github.com/user-attachments/assets/2a0217a4-22bf-48c4-a198-3b18a03db6f0

