### PR TITLE
Query, chart, dashboard ordering with drag and drop

### DIFF
--- a/frontend/src2/charts/chart.ts
+++ b/frontend/src2/charts/chart.ts
@@ -405,6 +405,7 @@ const INITIAL_DOC: InsightsChartv3 = {
 	owner: '',
 	title: '',
 	workbook: '',
+	sort_order: 0,
 	query: '',
 	data_query: '',
 	chart_type: '',

--- a/frontend/src2/dashboard/dashboard.ts
+++ b/frontend/src2/dashboard/dashboard.ts
@@ -311,6 +311,7 @@ const INITIAL_DOC: InsightsDashboardv3 = {
 	owner: '',
 	title: '',
 	workbook: '',
+	sort_order: 0,
 	items: [],
 	is_public: false,
 	is_shared_with_organization: false,

--- a/frontend/src2/query/query.ts
+++ b/frontend/src2/query/query.ts
@@ -913,6 +913,7 @@ const INITIAL_DOC: InsightsQueryv3 = {
 	owner: '',
 	title: '',
 	workbook: '',
+	sort_order: 0,
 	operations: [],
 	read_only: false,
 }

--- a/frontend/src2/types/workbook.types.ts
+++ b/frontend/src2/types/workbook.types.ts
@@ -23,6 +23,7 @@ export type WorkbookListItem = {
 export type WorkbookQuery = {
 	name: string
 	title: string
+	sort_order: number
 	is_native_query?: boolean
 	is_script_query?: boolean
 	is_builder_query?: boolean
@@ -31,6 +32,7 @@ export type WorkbookQuery = {
 export type WorkbookChart = {
 	name: string
 	title: string
+	sort_order: number
 	query: string
 	chart_type: ChartType
 }
@@ -38,6 +40,7 @@ export type WorkbookChart = {
 export type WorkbookDashboard = {
 	name: string
 	title: string
+	sort_order: number
 }
 
 export type InsightsWorkbook = {
@@ -57,6 +60,7 @@ export type InsightsQueryv3 = {
 	owner: string
 	title: string
 	workbook: string
+	sort_order: number
 	operations: Operation[]
 	variables?: QueryVariable[]
 	use_live_connection?: boolean
@@ -72,6 +76,7 @@ export type InsightsChartv3 = {
 	owner: string
 	title: string
 	workbook: string
+	sort_order: number
 	query: string
 	data_query: string
 	chart_type: ChartType
@@ -92,6 +97,7 @@ export type InsightsDashboardv3 = {
 	owner: string
 	title: string
 	workbook: string
+	sort_order: number
 	items: WorkbookDashboardItem[]
 	preview_image?: string
 	share_link?: string

--- a/frontend/src2/workbook/WorkbookSidebar.vue
+++ b/frontend/src2/workbook/WorkbookSidebar.vue
@@ -32,6 +32,7 @@ const activeQueryName = computed(() => {
 				remove: (query) => workbook.removeQuery(query.name),
 				isActive: (query) => workbook.isActiveTab('query', query.name),
 				route: (query) => `/workbook/${workbook.name}/query/${query.name}`,
+				reorder: workbook.reorderQueries,
 			}"
 		>
 			<template #item-icon="{ item }">
@@ -59,6 +60,7 @@ const activeQueryName = computed(() => {
 				remove: (chart) => workbook.removeChart(chart.name),
 				isActive: (chart) => workbook.isActiveTab('chart', chart.name),
 				route: (chart) => `/workbook/${workbook.name}/chart/${chart.name}`,
+				reorder: workbook.reorderCharts,
 			}"
 		>
 			<template #item-icon="{ item }">
@@ -76,6 +78,7 @@ const activeQueryName = computed(() => {
 				remove: (dashboard) => workbook.removeDashboard(dashboard.name),
 				isActive: (dashboard) => workbook.isActiveTab('dashboard', dashboard.name),
 				route: (dashboard) => `/workbook/${workbook.name}/dashboard/${dashboard.name}`,
+				reorder: workbook.reorderDashboards,
 			}"
 		>
 			<template #item-icon>

--- a/frontend/src2/workbook/WorkbookSidebarListSection.vue
+++ b/frontend/src2/workbook/WorkbookSidebarListSection.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { Plus, X } from 'lucide-vue-next'
+import DraggableList from '../components/DraggableList.vue'
 const section = defineProps<{
 	title: string
 	emptyMessage: string
@@ -9,7 +10,14 @@ const section = defineProps<{
 	add: () => void
 	remove: (item: any) => void
 	route: (item: any) => string
+	reorder?: (oldIndex: number, newIndex: number) => void
 }>()
+
+function handleSort(oldIndex: number, newIndex: number) {
+	if (section.reorder) {
+		section.reorder(oldIndex, newIndex)
+	}
+}
 
 function setDraggedItem(event: DragEvent, row: any) {
 	if (!event.dataTransfer) return
@@ -37,30 +45,37 @@ function setDraggedItem(event: DragEvent, row: any) {
 			<div class="text-xs text-gray-500">{{ section.emptyMessage }}</div>
 		</div>
 		<div v-else class="flex flex-col border-b pb-3">
-			<div
-				v-for="(row, idx) in section.items"
-				:key="row[section.itemKey]"
-				class="group w-full cursor-pointer rounded transition-all hover:bg-gray-100"
-				:class="section.isActive(row) ? ' bg-gray-100' : ' hover:border-gray-300'"
-				draggable="true"
-				@dragstart="setDraggedItem($event, row)"
+			<DraggableList
+				v-model:items="section.items"
+				:group="section.title.toLowerCase()"
+				:item-key="section.itemKey"
+				:show-handle="true"
+				:show-empty-state="false"
+				@sort="handleSort"
 			>
-				<router-link
-					:to="route(row)"
-					class="flex h-7.5 items-center justify-between rounded pl-1.5 text-sm"
-				>
-					<div class="flex gap-1.5 overflow-hidden">
-						<slot name="item-icon" :item="row" />
-						<p class="truncate">{{ row.title }}</p>
-					</div>
-					<button
-						class="invisible cursor-pointer rounded px-1.5 py-1 transition-all hover:bg-gray-100 group-hover:visible"
-						@click.prevent.stop="section.remove(row)"
+				<template #item="{ item: row, index: idx }">
+					<div
+						class="group w-full cursor-pointer rounded transition-all hover:bg-gray-100 mb-1.5 last:mb-0"
+						:class="section.isActive(row) ? ' bg-gray-100' : ' hover:border-gray-300'"
 					>
-						<X class="h-4 w-4 text-gray-700" stroke-width="1.5" />
-					</button>
-				</router-link>
-			</div>
+						<router-link
+							:to="route(row)"
+							class="flex h-7.5 items-center justify-between rounded pl-1.5 text-sm"
+						>
+							<div class="flex gap-1.5 overflow-hidden">
+								<slot name="item-icon" :item="row" />
+								<p class="truncate">{{ row.title }}</p>
+							</div>
+							<button
+								class="invisible cursor-pointer rounded px-1.5 py-1 transition-all hover:bg-gray-100 group-hover:visible"
+								@click.prevent.stop="section.remove(row)"
+							>
+								<X class="h-4 w-4 text-gray-700" stroke-width="1.5" />
+							</button>
+						</router-link>
+					</div>
+				</template>
+			</DraggableList>
 		</div>
 	</div>
 </template>

--- a/insights/api/workbooks.py
+++ b/insights/api/workbooks.py
@@ -154,3 +154,15 @@ def update_share_permissions(workbook_name, user_permissions, organization_acces
         public_docshare.save(ignore_permissions=True)
     elif public_docshare.name:
         public_docshare.delete(ignore_permissions=True)
+
+
+@insights_whitelist()
+def reorder_items(workbook_name, updates, doctype):
+    """Update sort_order for <dt> doctype in a workbook"""
+    if not frappe.has_permission("Insights Workbook", ptype="write", doc=workbook_name):
+        frappe.throw(_("You do not have permission to edit this workbook"))
+
+    for update in updates:
+        frappe.db.set_value(doctype, update["name"], "sort_order", update["sort_order"])
+
+    frappe.db.commit()

--- a/insights/insights/doctype/insights_chart_v3/insights_chart_v3.json
+++ b/insights/insights/doctype/insights_chart_v3/insights_chart_v3.json
@@ -11,6 +11,7 @@
   "column_break_mgwd",
   "chart_type",
   "is_public",
+  "sort_order",
   "section_break_vmvi",
   "config",
   "old_name"
@@ -79,11 +80,19 @@
    "fieldtype": "Data",
    "label": "Old Name",
    "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "sort_order",
+   "fieldtype": "Int",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Sort Order"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-03-14 16:25:02.809832",
+ "modified": "2025-08-12 09:58:12.711782",
  "modified_by": "Administrator",
  "module": "Insights",
  "name": "Insights Chart v3",
@@ -114,10 +123,11 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "search_fields": "workbook, query",
  "show_title_field_in_link": 1,
- "sort_field": "creation",
- "sort_order": "DESC",
+ "sort_field": "sort_order",
+ "sort_order": "ASC",
  "states": [],
  "title_field": "title",
  "track_changes": 1

--- a/insights/insights/doctype/insights_chart_v3/insights_chart_v3.py
+++ b/insights/insights/doctype/insights_chart_v3/insights_chart_v3.py
@@ -23,6 +23,7 @@ class InsightsChartv3(Document):
         is_public: DF.Check
         old_name: DF.Data | None
         query: DF.Link | None
+        sort_order: DF.Int
         title: DF.Data | None
         workbook: DF.Link
     # end: auto-generated types

--- a/insights/insights/doctype/insights_dashboard_v3/insights_dashboard_v3.json
+++ b/insights/insights/doctype/insights_dashboard_v3/insights_dashboard_v3.json
@@ -10,6 +10,7 @@
   "column_break_owsx",
   "workbook",
   "is_public",
+  "sort_order",
   "section_break_lgpd",
   "items",
   "section_break_aocd",
@@ -78,11 +79,17 @@
    "fieldtype": "Data",
    "label": "Old Name",
    "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "sort_order",
+   "fieldtype": "Int",
+   "label": "Sort Order"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-04-11 17:23:03.687968",
+ "modified": "2025-08-12 09:58:43.484236",
  "modified_by": "Administrator",
  "module": "Insights",
  "name": "Insights Dashboard v3",

--- a/insights/insights/doctype/insights_dashboard_v3/insights_dashboard_v3.py
+++ b/insights/insights/doctype/insights_dashboard_v3/insights_dashboard_v3.py
@@ -21,10 +21,7 @@ class InsightsDashboardv3(Document):
 
     if TYPE_CHECKING:
         from frappe.types import DF
-
-        from insights.insights.doctype.insights_dashboard_chart_v3.insights_dashboard_chart_v3 import (
-            InsightsDashboardChartv3,
-        )
+        from insights.insights.doctype.insights_dashboard_chart_v3.insights_dashboard_chart_v3 import InsightsDashboardChartv3
 
         is_public: DF.Check
         items: DF.JSON | None
@@ -32,6 +29,7 @@ class InsightsDashboardv3(Document):
         old_name: DF.Data | None
         preview_image: DF.Data | None
         share_link: DF.Data | None
+        sort_order: DF.Int
         title: DF.Data | None
         workbook: DF.Link
     # end: auto-generated types

--- a/insights/insights/doctype/insights_query_v3/insights_query_v3.json
+++ b/insights/insights/doctype/insights_query_v3/insights_query_v3.json
@@ -6,6 +6,7 @@
  "field_order": [
   "title",
   "workbook",
+  "sort_order",
   "column_break_gamr",
   "use_live_connection",
   "is_script_query",
@@ -94,6 +95,12 @@
    "label": "Variables",
    "no_copy": 1,
    "options": "Insights Query Variable"
+  },
+  {
+   "default": "0",
+   "fieldname": "sort_order",
+   "fieldtype": "Int",
+   "label": "Sort Order"
   }
  ],
  "index_web_pages_for_search": 1,
@@ -103,7 +110,7 @@
    "link_fieldname": "data_query"
   }
  ],
- "modified": "2025-07-05 12:33:14.467946",
+ "modified": "2025-08-12 09:58:52.866353",
  "modified_by": "Administrator",
  "module": "Insights",
  "name": "Insights Query v3",

--- a/insights/insights/doctype/insights_query_v3/insights_query_v3.py
+++ b/insights/insights/doctype/insights_query_v3/insights_query_v3.py
@@ -25,10 +25,7 @@ class InsightsQueryv3(Document):
 
     if TYPE_CHECKING:
         from frappe.types import DF
-
-        from insights.insights.doctype.insights_query_variable.insights_query_variable import (
-            InsightsQueryVariable,
-        )
+        from insights.insights.doctype.insights_query_variable.insights_query_variable import InsightsQueryVariable
 
         is_builder_query: DF.Check
         is_native_query: DF.Check
@@ -36,6 +33,7 @@ class InsightsQueryv3(Document):
         linked_queries: DF.JSON | None
         old_name: DF.Data | None
         operations: DF.JSON | None
+        sort_order: DF.Int
         title: DF.Data | None
         use_live_connection: DF.Check
         variables: DF.Table[InsightsQueryVariable]

--- a/insights/insights/doctype/insights_workbook/insights_workbook.py
+++ b/insights/insights/doctype/insights_workbook/insights_workbook.py
@@ -52,6 +52,7 @@ class InsightsWorkbook(Document):
             fields=[
                 "name",
                 "title",
+                "sort_order",
                 "is_native_query",
                 "is_builder_query",
                 "is_script_query",
@@ -65,15 +66,16 @@ class InsightsWorkbook(Document):
                 "name",
                 "title",
                 "chart_type",
+                "sort_order",
                 "query",
             ],
-            order_by="creation asc",
+            order_by="sort_order asc",
         )
         d.dashboards = frappe.get_all(
             "Insights Dashboard v3",
             filters={"workbook": self.name},
-            fields=["name", "title"],
-            order_by="creation asc",
+            fields=["name", "title", "sort_order"],
+            order_by="sort_order asc",
         )
         d.queries = frappe.as_json(d.queries)
         d.charts = frappe.as_json(d.charts)


### PR DESCRIPTION
### Motivation:
 - It was hard for us to manage 20+ charts in a single workbook and we wanted to order them for our needs.
 - We know that we can create multiple workbooks, but it started piling up logically separate charts in the same workbook, with same topic (like Sales).

### Before:
 - Workbook sidebar ordering were **creation based** which is not ideal if you want to order them to your liking.

### After:
 - `Insights Chart v3`, `Insights Query v3`, `Insights Dashboard v3` added field called `sort_order` which represented the order of its items in Workbook Sidebar
 - Added **drag and drop** functionality to enhance user experience

### Implementation:
 - Changed `<div v-for>` to `<DraggableList>` in `frontend/src2/workbook/WorkbookSidebarListSection.vue`
 - Added new endpoint for reordering items called in `insights/api/workbooks.py`

### WARNING:
- Dragging chart onto dashboard is not working somehow!


https://github.com/user-attachments/assets/bf59c7f1-b7df-4d77-b23b-01c010c03d2f

