### PR TITLE
fix: strip HTML tags from dashboard table cells for clean text display

### DIFF
--- a/frontend/src/utils/query/results.js
+++ b/frontend/src/utils/query/results.js
@@ -44,7 +44,7 @@ export function getFormattedResult(data) {
 			}
 			
 			if (FIELDTYPES.TEXT.includes(columnType) && typeof cell === 'string' && cell.includes('<')) {
-				cell = cell.replace(/(<!--.*?-->|<[^>]*>)/g, '').replace(/\s+/g, ' ').trim()
+				cell = cell.replace(/<[^>]+>/g, '').replace(/\s+/g, ' ').trim()
 			}
 			return cell
 		})

--- a/frontend/src/utils/query/results.js
+++ b/frontend/src/utils/query/results.js
@@ -42,9 +42,13 @@ export function getFormattedResult(data) {
 					cell = applyColumnFormatOption(safeJSONParse(formatOption), cell)
 				}
 			}
-			
-			if (FIELDTYPES.TEXT.includes(columnType) && typeof cell === 'string' && cell.includes('<')) {
-				cell = cell.replace(/<[^>]+>/g, '').replace(/\s+/g, ' ').trim()
+
+			if (FIELDTYPES.TEXT.includes(columnType) && typeof cell === 'string' && cell) {
+				const htmlTagRegex = /<[^>]*>/g
+				if (htmlTagRegex.test(cell)) {
+					htmlTagRegex.lastIndex = 0
+					cell = cell.replace(htmlTagRegex, '').replace(/\s+/g, ' ').trim()
+				}
 			}
 			return cell
 		})

--- a/frontend/src/utils/query/results.js
+++ b/frontend/src/utils/query/results.js
@@ -42,6 +42,10 @@ export function getFormattedResult(data) {
 					cell = applyColumnFormatOption(safeJSONParse(formatOption), cell)
 				}
 			}
+			
+			if (FIELDTYPES.TEXT.includes(columnType) && typeof cell === 'string' && cell.includes('<')) {
+				cell = cell.replace(/(<!--.*?-->|<[^>]*>)/g, '').replace(/\s+/g, ' ').trim()
+			}
 			return cell
 		})
 	})

--- a/frontend/src2/query/helpers.ts
+++ b/frontend/src2/query/helpers.ts
@@ -128,6 +128,10 @@ export function getFormattedRows(result: QueryResult, operations: Operation[]) {
 				const granularity = getGranularity(column.name) as GranularityType
 				formattedRow[column.name] = getFormattedDate(row[column.name], granularity)
 			}
+
+			if (FIELDTYPES.TEXT.includes(column.type) && typeof row[column.name] === 'string' && row[column.name].includes('<')) {
+				formattedRow[column.name] = row[column.name].replace(/(<!--.*?-->|<[^>]*>)/g, '').replace(/\s+/g, ' ').trim()
+			}
 		})
 		return formattedRow
 	})

--- a/frontend/src2/query/helpers.ts
+++ b/frontend/src2/query/helpers.ts
@@ -130,7 +130,7 @@ export function getFormattedRows(result: QueryResult, operations: Operation[]) {
 			}
 
 			if (FIELDTYPES.TEXT.includes(column.type) && typeof row[column.name] === 'string' && row[column.name].includes('<')) {
-				formattedRow[column.name] = row[column.name].replace(/(<!--.*?-->|<[^>]*>)/g, '').replace(/\s+/g, ' ').trim()
+				formattedRow[column.name] = row[column.name].replace(/<[^>]+>/g, '').replace(/\s+/g, ' ').trim()
 			}
 		})
 		return formattedRow

--- a/frontend/src2/query/helpers.ts
+++ b/frontend/src2/query/helpers.ts
@@ -129,8 +129,15 @@ export function getFormattedRows(result: QueryResult, operations: Operation[]) {
 				formattedRow[column.name] = getFormattedDate(row[column.name], granularity)
 			}
 
-			if (FIELDTYPES.TEXT.includes(column.type) && typeof row[column.name] === 'string' && row[column.name].includes('<')) {
-				formattedRow[column.name] = row[column.name].replace(/<[^>]+>/g, '').replace(/\s+/g, ' ').trim()
+			if (FIELDTYPES.TEXT.includes(column.type) && typeof row[column.name] === 'string' && row[column.name]) {
+				const htmlTagRegex = /<[^>]*>/g
+				if (htmlTagRegex.test(row[column.name])) {
+					htmlTagRegex.lastIndex = 0
+					formattedRow[column.name] = row[column.name]
+						.replace(htmlTagRegex, '')
+						.replace(/\s+/g, ' ')
+						.trim()
+				}
 			}
 		})
 		return formattedRow


### PR DESCRIPTION
### Problem
Dashboard tables in Insights app were displaying raw HTML tags instead of clean text, making data unreadable and unprofessional.

**Before:**

<img width="938" height="221" alt="Screenshot 2025-09-01 at 11 12 30 AM" src="https://github.com/user-attachments/assets/9802f6d1-35b2-482b-8569-08c5af4f35de" />



**After:**


<img width="932" height="238" alt="Screenshot 2025-09-01 at 11 37 28 AM" src="https://github.com/user-attachments/assets/c061889b-fd3d-46eb-b343-c7be6e0bbe24" />

closes: #630 
