### PR TITLE
fix: donut chart legend + inline labels conflict

### DIFF
--- a/frontend/src2/charts/chart.ts
+++ b/frontend/src2/charts/chart.ts
@@ -459,6 +459,9 @@ function transformChartDoc(doc: any) {
 		// @ts-ignore
 		doc.config.label_position = doc.config.label_position || 'left'
 	}
+	if (doc.chart_type === 'Donut') {
+		doc.config.legend_position = doc.config.legend_position || 'bottom'
+	}
 
 	doc.config = setDimensionNames(doc.config)
 

--- a/frontend/src2/charts/helpers.ts
+++ b/frontend/src2/charts/helpers.ts
@@ -388,8 +388,11 @@ export function getDonutChartOptions(config: DonutChartConfig, result: QueryResu
 		top = 'middle'
 		padding = [30, 0, 30, 0]
 	}
-	if (show_inline_labels) {
+
+	if (!show_inline_labels) {
+	} else {
 		center = ['50%', '50%']
+		radius = ['45%', '75%']
 	}
 
 	return {
@@ -437,7 +440,9 @@ export function getDonutChartOptions(config: DonutChartConfig, result: QueryResu
 						return `${ellipsis(name, 20)} (${percentage.toFixed(0)}%)`
 					},
 			  }
-			: null,
+			: {
+					show: false,
+			  },
 		tooltip: {
 			trigger: 'item',
 			confine: true,


### PR DESCRIPTION
### Bug Fix
Fixes donut chart showing both legend and inline labels simultaneously.

### Changes
- Fixed positioning logic when inline labels enabled
- Added default legend position for new charts
- Legend now properly hidden when inline labels on
