### PR TITLE
feat: Add color customization for dashboard number charts

### DIFF
--- a/frontend/src2/charts/components/NumberChart.vue
+++ b/frontend/src2/charts/components/NumberChart.vue
@@ -51,6 +51,7 @@ const cards = computed(() => {
 		const prefix = getNumberOption(idx, 'prefix')
 		const suffix = getNumberOption(idx, 'suffix')
 		const decimal = getNumberOption(idx, 'decimal')
+		const color = getNumberOption(idx, 'color')
 		const shorten_numbers = getNumberOption(idx, 'shorten_numbers')
 
 		return {
@@ -62,6 +63,7 @@ const cards = computed(() => {
 			percentDelta: getFormattedValue(percentDelta, decimal, shorten_numbers),
 			prefix,
 			suffix,
+			color,
 		}
 	})
 })
@@ -102,6 +104,7 @@ function onDoubleClick(measure_name: string) {
 					percentDelta,
 					prefix,
 					suffix,
+					color,
 				} in cards"
 				:key="measure_name"
 				class="flex max-h-[140px] items-center gap-2 overflow-hidden rounded bg-white px-6 pt-5 shadow cursor-pointer"
@@ -112,7 +115,10 @@ function onDoubleClick(measure_name: string) {
 					<span class="truncate text-sm font-medium">
 						{{ measure_name }}
 					</span>
-					<div class="flex-1 flex-shrink-0 truncate text-[24px] font-semibold leading-10">
+					<div
+						class="flex-1 flex-shrink-0 truncate text-[24px] font-semibold leading-10"
+						:style="color && typeof color === 'string' ? { color: color } : {}"
+					>
 						{{ prefix }}{{ currentValue }}{{ suffix }}
 					</div>
 					<div

--- a/frontend/src2/charts/components/NumberChartConfigForm.vue
+++ b/frontend/src2/charts/components/NumberChartConfigForm.vue
@@ -27,7 +27,7 @@ const config = defineModel<NumberChartConfig>({
 })
 
 const date_dimensions = computed(() =>
-	props.dimensions.filter((d) => FIELDTYPES.DATE.includes(d.data_type))
+	props.dimensions.filter((d) => FIELDTYPES.DATE.includes(d.data_type)),
 )
 
 watchEffect(() => {
@@ -107,6 +107,15 @@ function setNumberOption(index: number, option: keyof NumberColumnOptions, value
 											type="number"
 										/>
 									</InlineFormControlLabel>
+									<InlineFormControlLabel label="Color">
+										<ColorInput
+											:model-value="getNumberOption(index, 'color')"
+											@update:model-value="
+												setNumberOption(index, 'color', $event)
+											"
+											placement="left-start"
+										/>
+									</InlineFormControlLabel>
 
 									<Toggle
 										label="Show short numbers"
@@ -131,7 +140,7 @@ function setNumberOption(index: number, option: keyof NumberColumnOptions, value
 			<DimensionPicker
 				label="Date"
 				:options="date_dimensions"
-				:model-value="(config.date_column as Dimension)"
+				:model-value="config.date_column as Dimension"
 				@update:model-value="config.date_column = $event || {}"
 			/>
 

--- a/frontend/src2/types/chart.types.ts
+++ b/frontend/src2/types/chart.types.ts
@@ -90,6 +90,7 @@ export type NumberColumnOptions = {
 	decimal?: number
 	prefix?: string
 	suffix?: string
+	color?: string
 }
 
 export type DonutChartConfig = {


### PR DESCRIPTION
# Number Chart Color Customization

## 🎯 Summary
This PR introduces color customization capabilities for dashboard number charts, allowing users to personalize individual columns with custom colors for better visual distinction and branding.

## ✨ Features Added

### 🌈 Number Chart Color Customization
- **Per-Column Colors**: Individual color selection for each number chart column
- **Visual Color Picker**: Integrated ColorInput component for intuitive color selection
- **Dynamic Styling**: Real-time color application using Vue's reactive `:style` binding
- **Fallback Support**: Graceful degradation to default colors when custom colors aren't configured

## 🔧 Implementation Details

### Technical Approach
- Leverages existing Frappe ColorInput component for UI consistency
- Uses Vue.js reactive data binding for immediate visual feedback
- Follows Frappe's standard data persistence patterns
- Maintains backward compatibility with existing number charts

## 🎨 User Experience

### Color Configuration Workflow
1. Access number chart column option
2. Select individual colors for each data column using color picker
3. Preview color changes applied instantly to number values

<img width="1590" height="780" alt="Screenshot From 2025-09-06 12-00-05" src="https://github.com/user-attachments/assets/9c49caca-60f3-495f-b2a6-106c82a21eb8" />
