### PR TITLE
fix: enable multiline display for long dashboard titles in list view

### DIFF
--- a/frontend/src2/dashboard/DashboardList.vue
+++ b/frontend/src2/dashboard/DashboardList.vue
@@ -86,9 +86,9 @@ watchEffect(() => {
 						</div>
 					</router-link>
 					<div class="flex items-center justify-between gap-2">
-						<div class="flex-1">
+						<div class="flex-1 min-w-0">
 							<div class="flex items-start gap-1">
-								<p class="whitespace-normal break-words leading-tight">
+								<p class="truncate text-sm" :title="dashboard.title">
 									{{ dashboard.title }}
 								</p>
 							</div>

--- a/frontend/src2/dashboard/DashboardList.vue
+++ b/frontend/src2/dashboard/DashboardList.vue
@@ -87,8 +87,8 @@ watchEffect(() => {
 					</router-link>
 					<div class="flex items-center justify-between gap-2">
 						<div class="flex-1">
-							<div class="flex items-center gap-1">
-								<p class="truncate">
+							<div class="flex items-start gap-1">
+								<p class="whitespace-normal break-words leading-tight">
 									{{ dashboard.title }}
 								</p>
 							</div>


### PR DESCRIPTION
Fixes #596
Resolves issue where long dashboard titles were truncated in the dashboard list view. 

### before
<img width="852" height="706" alt="Screenshot 2025-09-11 at 10 51 11 PM" src="https://github.com/user-attachments/assets/4c74aca3-c9f4-4d2a-8296-90ebbde42496" />

### after

<img width="529" height="462" alt="Screenshot 2025-09-11 at 10 49 45 PM" src="https://github.com/user-attachments/assets/ca984c0d-3443-4bab-81a0-cb99efbdfbfa" />
