### PR TITLE
fix: add permission check for opening workbook in dashboard

### DIFF
--- a/frontend/src2/dashboard/Dashboard.vue
+++ b/frontend/src2/dashboard/Dashboard.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import { Breadcrumbs, call } from 'frappe-ui'
 import { RefreshCcw } from 'lucide-vue-next'
-import {provide, ref } from 'vue'
+import {computed, provide, ref } from 'vue'
 import { useRouter } from 'vue-router'
-import { downloadImage, waitUntil } from '../helpers'
+import { downloadImage, waitUntil, wheneverChanges } from '../helpers'
 import useDashboard from './dashboard'
 import DashboardItem from './DashboardItem.vue'
 import VueGridLayout from './VueGridLayout.vue'
@@ -23,13 +23,8 @@ const router = useRouter()
 function openWorkbook() {
 	router.push(`/workbook/${dashboard.doc.workbook}`)
 }
-const canOpenWorkbook = ref(false)
 await waitUntil(() => dashboard.isloaded)
-await call('frappe.client.has_permission',{
-		doctype: 'Insights Workbook',
-		docname: dashboard.doc.workbook,
-		ptype: 'read',
-	}).then((res:any) => canOpenWorkbook.value = res.has_permission)
+const canOpenWorkbook = ref(dashboard.doc.has_workbook_access)
 
 const dashboardContainer = ref<HTMLElement | null>(null)
 async function downloadDashboardImage() {

--- a/frontend/src2/dashboard/Dashboard.vue
+++ b/frontend/src2/dashboard/Dashboard.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import { Breadcrumbs, call } from 'frappe-ui'
 import { RefreshCcw } from 'lucide-vue-next'
-import { provide, ref } from 'vue'
+import {provide, ref } from 'vue'
 import { useRouter } from 'vue-router'
-import { downloadImage } from '../helpers'
+import { downloadImage, waitUntil } from '../helpers'
 import useDashboard from './dashboard'
 import DashboardItem from './DashboardItem.vue'
 import VueGridLayout from './VueGridLayout.vue'
@@ -23,6 +23,13 @@ const router = useRouter()
 function openWorkbook() {
 	router.push(`/workbook/${dashboard.doc.workbook}`)
 }
+const canOpenWorkbook = ref(false)
+await waitUntil(() => dashboard.isloaded)
+await call('frappe.client.has_permission',{
+		doctype: 'Insights Workbook',
+		docname: dashboard.doc.workbook,
+		ptype: 'read',
+	}).then((res:any) => canOpenWorkbook.value = res.has_permission)
 
 const dashboardContainer = ref<HTMLElement | null>(null)
 async function downloadDashboardImage() {
@@ -57,12 +64,13 @@ const verticalCompact = useStorage('dashboard_vertical_compact', true)
 						icon: 'download',
 						onClick: downloadDashboardImage,
 					},
-					{
+					 canOpenWorkbook ? {
 						label: 'Open Workbook',
 						variant: 'outline',
 						icon: 'external-link',
 						onClick: openWorkbook,
-					},
+					} : null
+					,
 				]"
 			/>
 		</div>

--- a/frontend/src2/dashboard/dashboard.ts
+++ b/frontend/src2/dashboard/dashboard.ts
@@ -353,6 +353,7 @@ const INITIAL_DOC: InsightsDashboardv3 = {
 	people_with_access: [],
 	read_only: false,
 	vertical_compact: true,
+	has_workbook_access: false,
 }
 
 function getDashboardResource(name: string) {

--- a/frontend/src2/types/workbook.types.ts
+++ b/frontend/src2/types/workbook.types.ts
@@ -104,6 +104,7 @@ export type InsightsDashboardv3 = {
 	}[]
 	read_only: boolean
 	vertical_compact: boolean
+	has_workbook_access: boolean
 }
 
 export type WorkbookDashboardItem =

--- a/insights/insights/doctype/insights_dashboard_v3/insights_dashboard_v3.py
+++ b/insights/insights/doctype/insights_dashboard_v3/insights_dashboard_v3.py
@@ -63,7 +63,9 @@ class InsightsDashboardv3(Document):
             access = self.get_acess_data()
             d.people_with_access = access[0]
             d.is_shared_with_organization = access[1]
-
+        d.has_workbook_access = frappe.has_permission(
+            "Insights Workbook", ptype="read", doc=self.workbook
+        )
         return d
 
     def before_save(self):


### PR DESCRIPTION
shows 'open workbook'  option in dashboards page only when users have read permission for it