### PR TITLE
Fix: Add missing PostgreSQL dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "ibis-framework[mysql]",
     "ibis-framework[sqlite]",
     "ibis-framework[clickhouse]",
+    "ibis-framework[postgres]",
     # "ibis-framework[mssql]",
     # "ibis-framework[bigquery]",
 ]


### PR DESCRIPTION
### Summary
Adds `ibis-framework[postgres]` to project dependencies to fix PostgreSQL connection errors.

Fixes #664 

### Problem
PostgreSQL is supported as a data source, but the required `psycopg` dependency was not included in the package dependencies, causing connection attempts to fail with:
```
ModuleNotFoundError: No module named 'psycopg'
```

### Changes
- Added `ibis-framework[postgres]` to dependencies in `pyproject.toml`

### Testing
- [x] Verified PostgreSQL connection works after installing updated dependencies
- [x] Confirmed no conflicts with existing dependencies

### Impact
- Users can now connect to PostgreSQL databases without manually installing additional packages
- Fixes the `DataSourceConnectionError` when testing PostgreSQL connections

### Notes
This follows the same pattern as other database backends (mysql, sqlite, clickhouse) which are already included in dependencies.