### PR TITLE
fix: suppress Ibis UTC warning in mysql connection

### DIFF
--- a/insights/insights/doctype/insights_data_source_v3/connectors/mariadb.py
+++ b/insights/insights/doctype/insights_data_source_v3/connectors/mariadb.py
@@ -1,9 +1,22 @@
 # Copyright (c) 2022, Frappe Technologies Pvt. Ltd. and contributors
 # For license information, please see license.txt
 
+import warnings
+from functools import wraps
+
 import ibis
 
 
+def suppress_ibis_utc_warning(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", message="Unable to set session timezone")
+            return func(*args, **kwargs)
+    return wrapper
+
+
+@suppress_ibis_utc_warning
 def get_mariadb_connection(data_source):
     password = data_source.get_password(raise_exception=False)
     data_source.port = int(data_source.port or 3306)


### PR DESCRIPTION
added a decorator to suppress the "Unable to set session timezone to UTC" warning when ibis tries to connect MySQL session timezone but lacks the necessary configuration