### PR TITLE
fix: redis host in docker setup

### DIFF
--- a/docker/init.sh
+++ b/docker/init.sh
@@ -14,9 +14,9 @@ cd frappe-bench
 
 # Use containers instead of localhost
 bench set-mariadb-host mariadb
-bench set-redis-cache-host redis:6379
-bench set-redis-queue-host redis:6379
-bench set-redis-socketio-host redis:6379
+bench set-redis-cache-host redis://redis:6379
+bench set-redis-queue-host redis://redis:6379
+bench set-redis-socketio-host redis://redis:6379
 
 # Remove redis, watch from Procfile
 sed -i '/redis/d' ./Procfile


### PR DESCRIPTION
Fixes [#681](https://github.com/frappe/insights/issues/681)

Resolves **redis connection error** in docker setup by adding redis scheme.