### PR TITLE
feat: views

### DIFF
--- a/insights/api/data_sources.py
+++ b/insights/api/data_sources.py
@@ -58,9 +58,7 @@ def get_table_columns(data_source, table):
 @insights_whitelist()
 def get_table_name(data_source, table):
     check_table_permission(data_source, table)
-    return frappe.get_value(
-        "Insights Table", {"data_source": data_source, "table": table}, "name"
-    )
+    return frappe.get_value("Insights Table", {"data_source": data_source, "table": table}, "name")
 
 
 @insights_whitelist()
@@ -86,9 +84,7 @@ def get_tables(data_source=None, with_query_tables=False):
 
 
 @insights_whitelist()
-def create_table_link(
-    data_source, primary_table, foreign_table, primary_key, foreign_key
-):
+def create_table_link(data_source, primary_table, foreign_table, primary_key, foreign_key):
     check_table_permission(data_source, primary_table.get("value"))
     check_table_permission(data_source, foreign_table.get("value"))
 
@@ -232,15 +228,11 @@ def fetch_column_values(data_source, table, column, search_text=None):
 
 @insights_whitelist()
 def get_relation(data_source, table_one, table_two):
-    table_one_doc = InsightsTable.get_doc(
-        {"data_source": data_source, "table": table_one}
-    )
+    table_one_doc = InsightsTable.get_doc({"data_source": data_source, "table": table_one})
     if not table_one_doc:
         frappe.throw(f"Table {table_one} not found")
 
-    table_two_doc = InsightsTable.get_doc(
-        {"data_source": data_source, "table": table_two}
-    )
+    table_two_doc = InsightsTable.get_doc({"data_source": data_source, "table": table_two})
     if not table_two_doc:
         frappe.throw(f"Table {table_two} not found")
 
@@ -333,9 +325,16 @@ def get_data_source_tables(data_source=None, search_term=None, limit=100):
 @validate_type
 def get_data_source_table(data_source: str, table_name: str):
     check_table_permission(data_source, table_name)
-    ds = frappe.get_doc("Insights Data Source v3", data_source)
-    q = ds.get_ibis_table(table_name).head(100)
-    data, time_taken = execute_ibis_query(q, cache_expiry=24 * 60 * 60)
+    doc = frappe.get_doc(
+        "Insights Table v3",
+        {
+            "data_source": data_source,
+            "table": table_name,
+        },
+    )
+    t = doc.get_ibis_table(data_source, table_name)
+    q = t.head(100)
+    data, _ = execute_ibis_query(q, cache_expiry=24 * 60 * 60)
 
     return {
         "table_name": table_name,

--- a/insights/insights/doctype/insights_table_v3/insights_table_v3.json
+++ b/insights/insights/doctype/insights_table_v3/insights_table_v3.json
@@ -7,6 +7,8 @@
  "field_order": [
   "table",
   "label",
+  "is_view",
+  "view_script",
   "column_break_3",
   "data_source",
   "last_synced_on",
@@ -66,11 +68,23 @@
    "fieldtype": "Code",
    "label": "Before Import Script",
    "options": "Python"
+  },
+  {
+   "default": "0",
+   "fieldname": "is_view",
+   "fieldtype": "Check",
+   "label": "Is View",
+   "set_only_once": 1
+  },
+  {
+   "fieldname": "view_script",
+   "fieldtype": "Code",
+   "label": "View Script"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-10-01 12:49:40.113177",
+ "modified": "2025-10-29 17:07:51.547198",
  "modified_by": "Administrator",
  "module": "Insights",
  "name": "Insights Table v3",


### PR DESCRIPTION
Adds support for view-based tables in the `Insights Table v3` doctype.
A new “Is View” checkbox and “View Script” field let you define tables using Ibis expressions instead of physical database tables. This feature currently works from the Desk view and will be integrated into the Insights frontend later.

- [x] add `is_view` checkbox to table doctype 
- [x] add `view_script` to write ibis query for the view
- [x] execute script and build view
- [ ] DRY