### PR TITLE
feat: add option to show total in donut chart center

### DIFF
--- a/frontend/src2/charts/components/DonutChartConfigForm.vue
+++ b/frontend/src2/charts/components/DonutChartConfigForm.vue
@@ -61,6 +61,7 @@ const discrete_dimensions = computed(() =>
 			/>
 			<FormControl v-model="config.max_slices" label="Max Slices" type="number" min="1" />
 			<Toggle v-model="config.show_inline_labels" label="Inline Labels" />
+			<Checkbox v-model="config.show_total_in_center" label="Show Total in Center" />
 		</div>
 	</CollapsibleSection>
 </template>

--- a/frontend/src2/charts/helpers.ts
+++ b/frontend/src2/charts/helpers.ts
@@ -468,7 +468,52 @@ export function getDonutChartOptions(config: DonutChartConfig, result: QueryResu
 				return `${formatNumber(value, 2)} (${percent.toFixed(0)}%)`
 			},
 		},
+		graphic: getTotalGraphic(
+			total,
+			legend_position,
+			show_inline_labels,
+			config.show_total_in_center ?? false
+		),
 	}
+}
+
+function getTotalGraphic(
+	total: number,
+	legend_position: DonutChartConfig['legend_position'],
+	show_inline_labels: boolean,
+	show: boolean
+) {
+	const GRAPHIC_POSITION = {
+		bottom: { left: 'center', top: '42%' },
+		top: { left: 'center', top: '50%' },
+		left: { left: '62%', top: 'middle' },
+		right: { left: '28%', top: 'middle' },
+		inline: { left: 'center', top: 'middle' },
+	} as const
+
+	const position = show_inline_labels
+		? GRAPHIC_POSITION.inline
+		: GRAPHIC_POSITION[legend_position || 'bottom']
+
+	return [
+		{
+			type: 'text',
+			left: position.left,
+			top: position.top,
+			silent: true,
+			style: {
+				text: `${formatNumber(total, 2)}\nTOTAL`,
+				fontSize: 20,
+				fontWeight: 'bold',
+				textAlign: 'center',
+				textVerticalAlign: 'middle',
+				lineHeight: 24,
+				fill: '#333',
+			},
+			invisible: !show,
+			z: 100,
+		},
+	]
 }
 
 function getDonutChartData(

--- a/frontend/src2/types/chart.types.ts
+++ b/frontend/src2/types/chart.types.ts
@@ -100,6 +100,7 @@ export type DonutChartConfig = {
 	legend_position?: 'top' | 'bottom' | 'left' | 'right'
 	max_slices?: number
 	show_inline_labels?: boolean
+	show_total_in_center?: boolean
 }
 export type FunnelChartConfig = {
 	label_column: Dimension


### PR DESCRIPTION
  Adds checkbox to display formatted total value in donut chart center with smart positioning based on legend placement.

  This PR supersedes #423 with a refactored implementation using position constants.

  Closes #422

<img width="1238" height="523" alt="Screenshot 2025-11-05 at 5 10 32 PM" src="https://github.com/user-attachments/assets/caa1738f-41bf-42c5-9481-4da92af112fc" />
<img width="1248" height="608" alt="Screenshot 2025-11-05 at 5 10 41 PM" src="https://github.com/user-attachments/assets/71ef4259-232c-4ff0-8150-1674bb8b8e67" />
<img width="1504" height="773" alt="Screenshot 2025-11-05 at 5 10 53 PM" src="https://github.com/user-attachments/assets/78dc4825-ef31-49a5-98ec-ea836e240fb2" />

