### PR TITLE
feat: restore deleted workbook from desk

### DIFF
--- a/insights/insights/doctype/insights_workbook/insights_workbook.py
+++ b/insights/insights/doctype/insights_workbook/insights_workbook.py
@@ -45,6 +45,130 @@ class InsightsWorkbook(Document):
         for f in frappe.get_all("Insights Folder", {"workbook": self.name}):
             frappe.delete_doc("Insights Folder", f.name, force=True, ignore_permissions=True)
 
+    def after_insert(self):
+        # If this is a restored workbook (has data_backup) then restore child documents
+        if not self.data_backup:
+            # This is a normal new workbook and not a restored one(skip restore)
+            return
+
+        # Parse backup data
+        backup = frappe.parse_json(self.data_backup)
+        backup = deep_convert_dict_to_dict(backup)
+
+        self.restore_workbook_contents(backup, self.name, ignore_permissions=True)
+        self.db_set("data_backup", None)
+
+    def restore_workbook_contents(self, workbook_data, target_workbook_name, ignore_permissions=False):
+        """
+        Shared method to restore/import workbook contents
+        """
+        old_workbook_name = workbook_data.get("name")
+
+        # Create ID mapping
+        id_map = {old_workbook_name: target_workbook_name}
+
+        # Restore logic
+        for folder in workbook_data.get("dependencies", {}).get("folders", []):
+            folder = deep_convert_dict_to_dict(folder)
+            old_folder_name = folder["name"]
+            new_folder = frappe.new_doc("Insights Folder")
+            new_folder.title = folder["title"]
+            new_folder.type = folder["type"]
+            new_folder.sort_order = folder["sort_order"]
+            new_folder.workbook = target_workbook_name
+            new_folder.insert(ignore_permissions=ignore_permissions)
+            id_map[old_folder_name] = new_folder.name
+
+        query_sort_order = 0
+        for name, query in workbook_data.get("dependencies", {}).get("queries", {}).items():
+            query = deep_convert_dict_to_dict(query)
+            new_query = frappe.new_doc("Insights Query v3")
+            new_query.update(query)
+            new_query.workbook = target_workbook_name
+
+            if query.get("folder") and query.get("folder") in id_map:
+                new_query.folder = id_map[query.get("folder")]
+
+            if not hasattr(new_query, 'sort_order') or new_query.sort_order is None:
+                new_query.sort_order = query_sort_order
+                query_sort_order += 1
+
+            new_query.insert(ignore_permissions=ignore_permissions)
+            id_map[name] = new_query.name
+
+        for name, _ in workbook_data.get("dependencies", {}).get("queries", {}).items():
+            new_query = frappe.get_doc("Insights Query v3", id_map[name])
+            operations = deep_convert_dict_to_dict(frappe.parse_json(new_query.operations))
+
+            should_update = False
+            for op in operations:
+                if (
+                    not op.get("table")
+                    or not op.get("table").get("type")
+                    or not op.get("table").get("query_name")
+                ):
+                    continue
+
+                ref_query = op.table.query_name
+                if ref_query in id_map:
+                    op.table.query_name = id_map[ref_query]
+                    should_update = True
+
+            if should_update:
+                new_query.db_set("operations", frappe.as_json(operations))
+
+        chart_sort_order = 0
+        for name, chart in workbook_data.get("dependencies", {}).get("charts", {}).items():
+            chart = deep_convert_dict_to_dict(chart)
+            new_chart = frappe.new_doc("Insights Chart v3")
+            new_chart.update(chart)
+            new_chart.workbook = target_workbook_name
+
+            if chart.get("query") and chart.get("query") in id_map:
+                new_chart.query = id_map[chart.get("query")]
+
+            if chart.get("folder") and chart.get("folder") in id_map:
+                new_chart.folder = id_map[chart.get("folder")]
+
+            if not hasattr(new_chart, 'sort_order') or new_chart.sort_order is None:
+                new_chart.sort_order = chart_sort_order
+                chart_sort_order += 1
+
+            new_chart.insert(ignore_permissions=ignore_permissions)
+            id_map[name] = new_chart.name
+
+        for _, dashboard in workbook_data.get("dependencies", {}).get("dashboards", {}).items():
+            dashboard = deep_convert_dict_to_dict(dashboard)
+            new_dashboard = frappe.new_doc("Insights Dashboard v3")
+            new_dashboard.update(dashboard)
+            new_dashboard.workbook = target_workbook_name
+
+            items = deep_convert_dict_to_dict(frappe.parse_json(dashboard["items"]))
+            for item in items:
+                if item.get("type") == "chart" and item.get("chart") and item.get("chart") in id_map:
+                    item["chart"] = id_map.get(item["chart"])
+
+                if item.get("type") == "filter" and item.get("links"):
+                    new_links = {}
+                    for chart_name, field in item["links"].items():
+                        if chart_name not in id_map or not field or "`.`" not in field:
+                            continue
+
+                        chart = id_map[chart_name]
+                        field_query = field.split("`.`")[0].replace("`", "")
+                        field_name = field.split("`.`")[1].replace("`", "")
+
+                        if field_query not in id_map:
+                            continue
+
+                        query_name = id_map[field_query]
+                        new_links[chart] = f"`{query_name}`.`{field_name}`"
+
+                    item["links"] = new_links
+
+            new_dashboard.items = frappe.as_json(items)
+            new_dashboard.insert(ignore_permissions=ignore_permissions)
+
     def as_dict(self, *args, **kwargs):
         d = super().as_dict(*args, **kwargs)
 
@@ -251,111 +375,6 @@ def import_workbook(workbook):
     new_workbook = frappe.new_doc("Insights Workbook")
     new_workbook.title = workbook["doc"]["title"]
     new_workbook.insert()
-
-    id_map = {}
-
-    # Copy folders first
-    for folder in workbook.dependencies.get("folders", []):
-        folder = deep_convert_dict_to_dict(folder)
-        old_folder_name = folder["name"]
-        new_folder = frappe.new_doc("Insights Folder")
-        new_folder.title = folder["title"]
-        new_folder.type = folder["type"]
-        new_folder.sort_order = folder["sort_order"]
-        new_folder.workbook = new_workbook.name
-        new_folder.insert()
-        id_map[old_folder_name] = new_folder.name
-
-    # Copy queries, charts, and dashboards
-    query_sort_order = 0
-    for name, query in workbook.dependencies.queries.items():
-        query = deep_convert_dict_to_dict(query)
-        new_query = frappe.new_doc("Insights Query v3")
-        new_query.update(query)
-        new_query.workbook = new_workbook.name
-        # map folder to new folder ID
-        if query.get("folder") and query.get("folder") in id_map:
-            new_query.folder = id_map[query.get("folder")]
-        if not hasattr(new_query, 'sort_order') or new_query.sort_order is None:
-            new_query.sort_order = query_sort_order
-            query_sort_order += 1
-        new_query.insert()
-        id_map[name] = new_query.name
-
-    # update old query names with new query names
-    for name, _ in workbook.dependencies.queries.items():
-        new_query = frappe.get_doc("Insights Query v3", id_map[name])
-        operations = deep_convert_dict_to_dict(frappe.parse_json(new_query.operations))
-
-        should_update = False
-        for op in operations:
-            if (
-                not op.get("table")
-                or not op.get("table").get("type")
-                or not op.get("table").get("query_name")
-            ):
-                continue
-
-            ref_query = op.table.query_name
-            if ref_query in id_map:
-                op.table.query_name = id_map[ref_query]
-                should_update = True
-
-        if should_update:
-            new_query.db_set(
-                "operations",
-                frappe.as_json(operations),
-                update_modified=False,
-            )
-
-    chart_sort_order = 0
-    for name, chart in workbook.dependencies.charts.items():
-        chart = deep_convert_dict_to_dict(chart)
-        new_chart = frappe.new_doc("Insights Chart v3")
-        new_chart.update(chart)
-        new_chart.workbook = new_workbook.name
-        if chart.query in id_map:
-            new_chart.query = id_map[chart.query]
-        # map folder to new folder ID
-        if chart.get("folder") and chart.get("folder") in id_map:
-            new_chart.folder = id_map[chart.get("folder")]
-        if not hasattr(new_chart, 'sort_order') or new_chart.sort_order is None:
-            new_chart.sort_order = chart_sort_order
-            chart_sort_order += 1
-        new_chart.insert()
-        id_map[name] = new_chart.name
-
-    for _, dashboard in workbook.dependencies.dashboards.items():
-        dashboard = deep_convert_dict_to_dict(dashboard)
-        new_dashboard = frappe.new_doc("Insights Dashboard v3")
-        new_dashboard.update(dashboard)
-        new_dashboard.workbook = new_workbook.name
-
-        items = deep_convert_dict_to_dict(frappe.parse_json(dashboard["items"]))
-        for item in items:
-            if item.type == "chart" and item.chart and item.chart in id_map:
-                item.chart = id_map.get(item.chart)
-
-            if item.type == "filter" and item.links:
-                new_links = {}
-
-                for chart_name, field in item.links.items():
-                    if chart_name not in id_map or not field or "`.`" not in field:
-                        continue
-
-                    chart = id_map[chart_name]
-                    field_query = field.split("`.`")[0].replace("`", "")
-                    field_name = field.split("`.`")[1].replace("`", "")
-
-                    if field_query not in id_map:
-                        continue
-
-                    query_name = id_map[field_query]
-                    new_links[chart_name] = f"`{query_name}`.`{field_name}`"
-
-                item.links = new_links
-
-        new_dashboard.items = frappe.as_json(items)
-        new_dashboard.insert()
+    new_workbook.restore_workbook_contents(workbook, new_workbook.name,)
 
     return new_workbook.name


### PR DESCRIPTION
reuses import_workbook method to save backup and restore workbook after deletion from deleted documents list

- refactored the code to use shared method for import and restore 
- backups all the linked queries, charts, folders and dashboards
