### PR TITLE
fix(filters): return `datetime.date` instead of string for current day

### DIFF
--- a/insights/insights/query_builders/sql_functions.py
+++ b/insights/insights/query_builders/sql_functions.py
@@ -284,7 +284,8 @@ def get_descendants(node, tree, include_self=False):
 def get_current_date_range(unit):
     today = nowdate()
     if unit == "day":
-        return [today, today]
+        today_date = getdate(today)
+        return [today_date, today_date]
     if unit == "week":
         return [get_first_day_of_week(today), get_last_day_of_week(today)]
     if unit == "month":


### PR DESCRIPTION
Fixes TypeError when comparing dates in get_date_range with include_current=True. The "day" unit was returning strings from nowdate() while all other units return datetime.date objects leading to  '<' comparison failures.