### PR TITLE
feat: Add dynamic filter dependencies for cascading dashboard filters

### DIFF
--- a/frontend/src2/types/workbook.types.ts
+++ b/frontend/src2/types/workbook.types.ts
@@ -145,6 +145,8 @@ export type WorkbookDashboardFilter = {
 	filter_name: string
 	filter_type: FilterType
 	links: Record<string, string>
+	depends_on?: string
+	relationship_column?: string
 	default_operator?: FilterOperator
 	default_value?: FilterValue
 	layout: Layout

--- a/insights/insights/doctype/insights_dashboard_v3/insights_dashboard_v3.py
+++ b/insights/insights/doctype/insights_dashboard_v3/insights_dashboard_v3.py
@@ -83,7 +83,9 @@ class InsightsDashboardv3(Document):
         )
 
     @frappe.whitelist()
-    def get_distinct_column_values(self, query, column_name, search_term=None):
+    def get_distinct_column_values(
+        self, query, column_name, search_term=None, adhoc_filters=None
+    ):
         is_guest = frappe.session.user == "Guest"
         if is_guest and not self.is_public:
             raise frappe.PermissionError
@@ -91,7 +93,9 @@ class InsightsDashboardv3(Document):
         self.check_linked_filters(query, column_name)
 
         doc = frappe.get_cached_doc("Insights Query v3", query)
-        return doc.get_distinct_column_values(column_name, search_term=search_term)
+        return doc.get_distinct_column_values(
+            column_name, search_term=search_term, adhoc_filters=adhoc_filters
+        )
 
     def check_linked_filters(self, query, column_name):
         items = frappe.parse_json(self.items)

--- a/insights/insights/doctype/insights_data_source_v3/ibis_utils.py
+++ b/insights/insights/doctype/insights_data_source_v3/ibis_utils.py
@@ -319,6 +319,10 @@ class IbisQueryBuilder:
 
             filter_value = [start, end]
 
+        if filter_operator == "=" and isinstance(filter_value, (list, tuple)):
+            filter_operator = "in"
+            operator_fn = self.get_operator(filter_operator)
+
         right_value = right_column or filter_value
         return operator_fn(left, right_value)
 


### PR DESCRIPTION


Enable hierarchical filter dependencies where parent filter selections automatically filter dependent filter options (e.g., Country → Currency).

Key Features:
- Manual dependency configuration with relationship column selection
- Circular dependency detection and prevention
- Automatic value filtering with proper operator handling (in/=)
- Smart state management with dependent filter clearing
- Fallback to all values when parent is not selected

Technical:
- Add depends_on and relationship_column to filter type
- Implement circular dependency detection algorithm
- Update value providers to use parent filter values
- Add UI for dependency configuration
- Backend support for adhoc filters in distinct value queries
- Automatic operator conversion for array values

https://github.com/user-attachments/assets/427dd2d1-e638-4f55-a743-ad7a21738a6e

