### PR TITLE
fix: `TypeError: 'NoneType' object is not iterable` error

### DIFF
--- a/insights/patches/normalize_workbook.py
+++ b/insights/patches/normalize_workbook.py
@@ -21,10 +21,9 @@ def execute():
     for wb in workbooks:
         workbook = frappe.get_doc("Insights Workbook", wb)
 
-        queries = frappe.parse_json(workbook.queries)
-        charts = frappe.parse_json(workbook.charts)
-        dashboards = frappe.parse_json(workbook.dashboards)
-
+        queries = frappe.parse_json(workbook.queries) or []
+        charts = frappe.parse_json(workbook.charts) or []
+        dashboards = frappe.parse_json(workbook.dashboards) or []
         query_name_to_doc = {}
         chart_name_to_doc = {}
 


### PR DESCRIPTION
Fixes migration failures for users with `None` as value in workbook data