### PR TITLE
feat: Add dynamic filter dependencies for cascading dashboard filters

### DIFF
--- a/frontend/src2/dashboard/dashboard.ts
+++ b/frontend/src2/dashboard/dashboard.ts
@@ -216,12 +216,20 @@ function makeDashboard(name: string) {
 		)
 		if (!filter) return
 
+		const previousValue = filterStates.value[filter_name]?.value
+		const newValue = value
+
 		if (!operator) {
 			delete filterStates.value[filter_name]
+			clearDependentFilters(filter_name)
 		} else {
 			filterStates.value[filter_name] = {
 				operator,
 				value,
+			}
+
+			if (previousValue !== newValue) {
+				clearDependentFilters(filter_name)
 			}
 		}
 
@@ -254,11 +262,64 @@ function makeDashboard(name: string) {
 		}
 	}
 
-	function getDistinctColumnValues(query: string, column: string, search_term?: string) {
+	function detectCircularDependency(filterName: string, dependsOn: string): boolean {
+		if (filterName === dependsOn) return true
+
+		const visited = new Set<string>()
+		const stack = [dependsOn]
+
+		while (stack.length > 0) {
+			const current = stack.pop()!
+			if (visited.has(current)) continue
+			visited.add(current)
+
+			const filter = dashboard.doc.items.find(
+				(item) => item.type === 'filter' && item.filter_name === current
+			) as WorkbookDashboardFilter | undefined
+
+			if (filter?.depends_on) {
+				if (filter.depends_on === filterName) return true
+				stack.push(filter.depends_on)
+			}
+		}
+
+		return false
+	}
+
+	function getParentFilter(filterName: string): FilterState | null {
+		const filter = dashboard.doc.items.find(
+			(item) => item.type === 'filter' && item.filter_name === filterName
+		) as WorkbookDashboardFilter | undefined
+
+		if (!filter?.depends_on) return null
+
+		return filterStates.value[filter.depends_on] || null
+	}
+
+	function clearDependentFilters(parentFilterName: string) {
+		const dependentFilters = dashboard.doc.items.filter(
+			(item) =>
+				item.type === 'filter' &&
+				(item as WorkbookDashboardFilter).depends_on === parentFilterName
+		) as WorkbookDashboardFilter[]
+
+		dependentFilters.forEach((filter) => {
+			delete filterStates.value[filter.filter_name]
+			clearDependentFilters(filter.filter_name)
+		})
+	}
+
+	function getDistinctColumnValues(
+		query: string,
+		column: string,
+		search_term?: string,
+		adhoc_filters?: Record<string, FilterGroup>
+	) {
 		return dashboard.call('get_distinct_column_values', {
 			query: query,
 			column_name: column,
 			search_term,
+			adhoc_filters,
 		})
 	}
 
@@ -341,6 +402,9 @@ function makeDashboard(name: string) {
 		applyFilter,
 		getColumnFromFilterLink,
 
+		detectCircularDependency,
+		getParentFilter,
+		clearDependentFilters,
 		getDistinctColumnValues,
 		updateAccess,
 

--- a/frontend/src2/types/workbook.types.ts
+++ b/frontend/src2/types/workbook.types.ts
@@ -145,6 +145,8 @@ export type WorkbookDashboardFilter = {
 	filter_name: string
 	filter_type: FilterType
 	links: Record<string, string>
+	depends_on?: string
+	relationship_column?: string
 	default_operator?: FilterOperator
 	default_value?: FilterValue
 	layout: Layout

--- a/insights/insights/doctype/insights_dashboard_v3/insights_dashboard_v3.py
+++ b/insights/insights/doctype/insights_dashboard_v3/insights_dashboard_v3.py
@@ -83,7 +83,9 @@ class InsightsDashboardv3(Document):
         )
 
     @frappe.whitelist()
-    def get_distinct_column_values(self, query, column_name, search_term=None):
+    def get_distinct_column_values(
+        self, query, column_name, search_term=None, adhoc_filters=None
+    ):
         is_guest = frappe.session.user == "Guest"
         if is_guest and not self.is_public:
             raise frappe.PermissionError
@@ -91,7 +93,9 @@ class InsightsDashboardv3(Document):
         self.check_linked_filters(query, column_name)
 
         doc = frappe.get_cached_doc("Insights Query v3", query)
-        return doc.get_distinct_column_values(column_name, search_term=search_term)
+        return doc.get_distinct_column_values(
+            column_name, search_term=search_term, adhoc_filters=adhoc_filters
+        )
 
     def check_linked_filters(self, query, column_name):
         items = frappe.parse_json(self.items)

--- a/insights/insights/doctype/insights_data_source_v3/ibis_utils.py
+++ b/insights/insights/doctype/insights_data_source_v3/ibis_utils.py
@@ -319,6 +319,10 @@ class IbisQueryBuilder:
 
             filter_value = [start, end]
 
+        if filter_operator == "=" and isinstance(filter_value, (list, tuple)):
+            filter_operator = "in"
+            operator_fn = self.get_operator(filter_operator)
+
         right_value = right_column or filter_value
         return operator_fn(left, right_value)
 


### PR DESCRIPTION
Enable hierarchical filter dependencies where parent filter selections automatically filter dependent filter options (e.g., Country → Currency).

Key Features:
- Manual dependency configuration with relationship column selection
- Circular dependency detection and prevention
- Automatic value filtering with proper operator handling (in/=)
- Smart state management with dependent filter clearing
- Fallback to all values when parent is not selected

Technical:
- Add depends_on and relationship_column to filter type
- Implement circular dependency detection algorithm
- Update value providers to use parent filter values
- Add UI for dependency configuration
- Backend support for adhoc filters in distinct value queries
- Automatic operator conversion for array values


https://github.com/user-attachments/assets/d7b7dd2f-b431-4e49-affe-97b6029529c2



