### PR TITLE
feat: apply other dashboard filters when fetching values of a filter

### DIFF
--- a/frontend/src2/dashboard/DashboardFilter.vue
+++ b/frontend/src2/dashboard/DashboardFilter.vue
@@ -33,10 +33,15 @@ const sourceColumn = computed(() => {
 
 function stringValuesProvider(search: string) {
 	if (!sourceColumn.value) return Promise.resolve([])
+
+	const firstLinkedChart = Object.keys(filter.links)?.[0]
+	const adhocFilters = firstLinkedChart ? dashboard.getAdhocFilters(firstLinkedChart) : undefined
+
 	return dashboard.getDistinctColumnValues(
 		sourceColumn.value.query,
 		sourceColumn.value.column,
 		search,
+		adhocFilters,
 	)
 }
 

--- a/frontend/src2/dashboard/dashboard.ts
+++ b/frontend/src2/dashboard/dashboard.ts
@@ -254,11 +254,17 @@ function makeDashboard(name: string) {
 		}
 	}
 
-	function getDistinctColumnValues(query: string, column: string, search_term?: string) {
+	function getDistinctColumnValues(
+		query: string,
+		column: string,
+		search_term?: string,
+		adhocFilters?: Record<string, FilterGroup>
+	) {
 		return dashboard.call('get_distinct_column_values', {
 			query: query,
 			column_name: column,
 			search_term,
+			adhoc_filters: adhocFilters,
 		})
 	}
 

--- a/insights/insights/doctype/insights_dashboard_v3/insights_dashboard_v3.py
+++ b/insights/insights/doctype/insights_dashboard_v3/insights_dashboard_v3.py
@@ -21,7 +21,10 @@ class InsightsDashboardv3(Document):
 
     if TYPE_CHECKING:
         from frappe.types import DF
-        from insights.insights.doctype.insights_dashboard_chart_v3.insights_dashboard_chart_v3 import InsightsDashboardChartv3
+
+        from insights.insights.doctype.insights_dashboard_chart_v3.insights_dashboard_chart_v3 import (
+            InsightsDashboardChartv3,
+        )
 
         is_public: DF.Check
         items: DF.JSON | None
@@ -63,9 +66,7 @@ class InsightsDashboardv3(Document):
             access = self.get_acess_data()
             d.people_with_access = access[0]
             d.is_shared_with_organization = access[1]
-        d.has_workbook_access = frappe.has_permission(
-            "Insights Workbook", ptype="read", doc=self.workbook
-        )
+        d.has_workbook_access = frappe.has_permission("Insights Workbook", ptype="read", doc=self.workbook)
         return d
 
     def before_save(self):
@@ -75,15 +76,11 @@ class InsightsDashboardv3(Document):
     def set_linked_charts(self):
         self.set(
             "linked_charts",
-            [
-                {"chart": item["chart"]}
-                for item in frappe.parse_json(self.items)
-                if item["type"] == "chart"
-            ],
+            [{"chart": item["chart"]} for item in frappe.parse_json(self.items) if item["type"] == "chart"],
         )
 
     @frappe.whitelist()
-    def get_distinct_column_values(self, query, column_name, search_term=None):
+    def get_distinct_column_values(self, query, column_name, search_term=None, adhoc_filters=None):
         is_guest = frappe.session.user == "Guest"
         if is_guest and not self.is_public:
             raise frappe.PermissionError
@@ -91,7 +88,9 @@ class InsightsDashboardv3(Document):
         self.check_linked_filters(query, column_name)
 
         doc = frappe.get_cached_doc("Insights Query v3", query)
-        return doc.get_distinct_column_values(column_name, search_term=search_term)
+        return doc.get_distinct_column_values(
+            column_name, search_term=search_term, adhoc_filters=adhoc_filters
+        )
 
     def check_linked_filters(self, query, column_name):
         items = frappe.parse_json(self.items)
@@ -102,11 +101,7 @@ class InsightsDashboardv3(Document):
             pattern = "^`([^`]+)`\\.`([^`]+)`$"
             for linked_column in linked_columns:
                 match = re.match(pattern, linked_column)
-                if (
-                    match
-                    and match.groups()[0] == query
-                    and match.groups()[1] == column_name
-                ):
+                if match and match.groups()[0] == query and match.groups()[1] == column_name:
                     return True
 
         raise frappe.PermissionError
@@ -187,9 +182,7 @@ class InsightsDashboardv3(Document):
 
     @frappe.whitelist()
     def update_access(self, data):
-        if not frappe.has_permission(
-            "Insights Dashboard v3", ptype="share", doc=self.name
-        ):
+        if not frappe.has_permission("Insights Dashboard v3", ptype="share", doc=self.name):
             frappe.throw("You do not have permission to share this dashboard")
 
         data = frappe.parse_json(data)


### PR DESCRIPTION
This enables dependent filters, for eg. apply a country filter first, filters the state filter options for that country only. 