### PR TITLE
fix: Preserve filter positions on dashboard operations

### DIFF
--- a/frontend/src2/dashboard/DashboardBuilder.vue
+++ b/frontend/src2/dashboard/DashboardBuilder.vue
@@ -178,7 +178,6 @@ const verticalCompact = useStorage('dashboard_vertical_compact', true)
 							dashboard.doc.items.forEach((item, idx) => {
 								item.layout = newLayout[idx]
 							})
-							dashboard.normalizeLayout()
 						}
 					"
 				>

--- a/frontend/src2/dashboard/dashboard.ts
+++ b/frontend/src2/dashboard/dashboard.ts
@@ -98,7 +98,7 @@ function makeDashboard(name: string) {
 	const filter_h = 1
 
 	function addFilter() {
-		dashboard.doc.items.push({
+		const newFilter: WorkbookDashboardItem = {
 			type: 'filter',
 			filter_name: '',
 			filter_type: 'String',
@@ -110,14 +110,56 @@ function makeDashboard(name: string) {
 				w: filter_w,
 				h: filter_h,
 			},
-		})
-		normalizeLayout()
+		}
+		dashboard.doc.items.push(newFilter)
+		positionNewFilter(newFilter)
 		editingItemIndex.value = dashboard.doc.items.length - 1
+	}
+
+	function positionNewFilter(newFilter: WorkbookDashboardItem) {
+		const items = dashboard.doc.items
+		const existingFilters = items.filter(
+			(item) => item.type === 'filter' && item !== newFilter
+		)
+
+		if (existingFilters.length === 0) {
+			newFilter.layout.x = 0
+			newFilter.layout.y = 0
+			return
+		}
+
+		const topRowY = Math.min(...existingFilters.map((item) => item.layout.y))
+		const topRowFilters = existingFilters.filter((item) => item.layout.y === topRowY)
+		const rightmostX = Math.max(
+			...topRowFilters.map((item) => item.layout.x + (item.layout.w || filter_w)),
+			0
+		)
+
+		if (rightmostX + newFilter.layout.w <= grid_cols) {
+			newFilter.layout.x = rightmostX
+			newFilter.layout.y = topRowY
+		} else {
+			newFilter.layout.x = 0
+			newFilter.layout.y = 0
+
+			existingFilters.forEach((item) => {
+				item.layout.y += filter_h
+			})
+
+			const otherItems = items.filter((item) => item.type !== 'filter')
+			if (otherItems.length > 0) {
+				const minOtherY = Math.min(...otherItems.map((item) => item.layout.y))
+				if (minOtherY <= filter_h) {
+					otherItems.forEach((item) => {
+						item.layout.y = Math.max(0, item.layout.y + filter_h)
+					})
+				}
+			}
+		}
 	}
 
 	function removeItem(index: number) {
 		dashboard.doc.items.splice(index, 1)
-		normalizeLayout()
 	}
 
 	function normalizeLayout() {


### PR DESCRIPTION
- Remove normalizeLayout() call from layout update handler to prevent filter positions from resetting when users manually move filters
- Replace normalizeLayout() with positionNewFilter() in addFilter() to place only newly added filters at the top without moving existing ones
- Remove normalizeLayout() call from removeItem() to preserve positions when deleting dashboard items

Fixes issues where filter positions were reset on:
- Tab/browser reload after manual repositioning
- Adding new filters (all filters were reset to top)
- Deleting dashboard items (remaining filters were reset)