### PR TITLE
Add "Others" column when split values

### DIFF
--- a/insights/insights/doctype/insights_data_source_v3/ibis_utils.py
+++ b/insights/insights/doctype/insights_data_source_v3/ibis_utils.py
@@ -458,29 +458,19 @@ class IbisQueryBuilder:
             # remaining values into an "Others" group so charts show the rest.
             # This currently supports the common case of a single pivot column.
             if len(names) == max_names and len(columns) == 1:
-                # extract top values (names is an ndarray of shape (n, 1))
-                try:
-                    top_values = [str(row[0]) for row in names]
-                except Exception:
-                    top_values = [str(v) for v in names.flatten()]
+                selected_names = [str(v) for v in names.flatten()]
 
                 col_name = columns[0].get_name()
                 col_expr = getattr(self.query, col_name)
 
-                # replace values not in top_values with 'Others'
+                # replace values not in selected_names with 'Others'
                 # use ibis.case() since ibis.where isn't available on the module
-                others_expr = (
-                    ibis.case()
-                    .when(col_expr.isin(top_values), col_expr)
-                    .else_('Others')
-                    .end()
-                    .name(col_name)
-                )
+                others_expr = ibis.cases((col_expr.isin(selected_names), col_expr), else_="Others")
                 self.query = self.query.mutate(**{col_name: others_expr})
 
                 # ensure the pivot names include the 'Others' bucket
-                names = list(map(str, top_values))
-                names.append('Others')
+                names = list(map(str, selected_names))
+                names.append("Others")
 
             return self.query.pivot_wider(
                 id_cols=[row.get_name() for row in rows],


### PR DESCRIPTION
# Before:

### Incorrect: 
Only **5 stores** displaying with an aggregated sum of **~5M**
<img width="1253" height="899" alt="Képernyőkép 2025-12-30 10-20-19" src="https://github.com/user-attachments/assets/02a2e2c2-2035-42df-89a0-5419902d452a" />

### Correct: 
All stores displayed with an aggregated sum of **~10M**, by setting the **Max Split Values to 20**

<img width="1253" height="899" alt="Képernyőkép 2025-12-30 10-20-29" src="https://github.com/user-attachments/assets/5cd12eac-ccf0-426e-ba99-d192ac44ccdb" />


# After:

All 12 stores are displayed with an aggregated sum of **~10M** (NO CHANGE)

<img width="1253" height="899" alt="Képernyőkép 2025-12-30 10-09-45" src="https://github.com/user-attachments/assets/2d72f962-79bf-4ca6-a157-cd9e7d59fb7c" />

Only **5 stores** are displayed + **1 (Others)**, with equal aggregated sum of **~10M**

<img width="1253" height="899" alt="Képernyőkép 2025-12-30 10-10-07" src="https://github.com/user-attachments/assets/9e5039b3-79fd-48db-beb2-8e2193977745" />

Close: #731 