### PR TITLE
fix: Handle exceptions when sending alerts and log errors

### DIFF
--- a/insights/insights/doctype/insights_alert/insights_alert.py
+++ b/insights/insights/doctype/insights_alert/insights_alert.py
@@ -159,10 +159,14 @@ class InsightsAlert(Document):
 def send_alerts():
     alerts = frappe.get_all("Insights Alert", filters={"disabled": 0})
     for alert in alerts:
-        alert_doc = frappe.get_cached_doc("Insights Alert", alert.name)
-        if alert_doc.is_event_due():
-            alert_doc.send_alert()
+        try:
+            alert_doc = frappe.get_cached_doc("Insights Alert", alert.name)
+            if alert_doc.is_event_due():
+                alert_doc.send_alert()
             frappe.db.commit()
+        except Exception:
+            frappe.db.rollback()
+            frappe.log_error(title=f"Failed to send alert: {alert.name}")
 
 
 class TelegramAlert:


### PR DESCRIPTION
This fixes Scheduled alerts breaking when a single instance throws an error See #737 

Wraps the alert sending in a try-catch and logs the error for visibility