### PR TITLE
deps: Bump pandas and duckdb for Python 3.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,12 +8,12 @@ requires-python = ">=3.10"
 readme = "README.md"
 dynamic = ["version"]
 dependencies = [
-    "pandas~=2.2.2",
+    "pandas~=2.3.3",
     "SQLAlchemy==2.0.41",
     "python-telegram-bot==21.4",
-    "duckdb~=1.3.0",
+    "duckdb~=1.4.3",
     "sqlglot<28.0.0",
-    "ibis-framework~=10.5.0",
+    "ibis-framework~=11.0.0",
     "ibis-framework[duckdb]",
     "ibis-framework[mysql]",
     "ibis-framework[sqlite]",


### PR DESCRIPTION
`pandas 2.3.3` minor and `duckdb 1.4.2 to 1.4.3` minor and `ibis-framework~=11.0.0` MAJOR are the only versions that include built wheels for Python 3.14

Without prebuilt wheels, then they must be built locally which means that updates and CI pipelines take significantly longer to run.

Did not test the change. Only the installation