### PR TITLE
Implement log scale for charts

### DIFF
--- a/frontend/src2/charts/chart.ts
+++ b/frontend/src2/charts/chart.ts
@@ -53,90 +53,6 @@ function makeChart(name: string) {
 		return useQuery(chart.doc.data_query)
 	})
 
-	const isYLogScale = computed<boolean>({
-		get() {
-			const chartType = chart.doc.chart_type
-			if (chartType === "Bubble") {
-				const config = chart.doc.config as BubbleChartConfig
-				return !!(config && config.yAxis && config.yAxis.type === 'log')
-			}
-			else if (AXIS_CHARTS.includes(chartType)) {
-				const config = chart.doc.config as AxisChartConfig
-				return !!(config && config.y_axis && config.y_axis.type === 'log')
-			}
-			else {
-				return false
-			}
-
-		},
-		set(val: boolean) {
-			const chartType = chart.doc.chart_type
-			if (chartType === "Bubble") {
-				const config = chart.doc.config as BubbleChartConfig
-				chart.doc.config = {
-					...chart.doc.config,
-					yAxis: {
-						...(config.yAxis ?? {}),
-						type: val ? 'log' : 'value',
-					},
-				}
-			}
-			else if (AXIS_CHARTS.includes(chartType)) {
-				const config = chart.doc.config as AxisChartConfig
-				chart.doc.config = {
-					...chart.doc.config,
-					y_axis: {
-						...(config.y_axis ?? {}),
-						type: val ? 'log' : 'value',
-					},
-				}
-			} else {
-				// do nothing for other chart types
-			}
-		},
-	})
-	const isXLogScale = computed<boolean>({
-		get() {
-			const chartType = chart.doc.chart_type
-			if (chartType === "Bubble") {
-				const config = chart.doc.config as BubbleChartConfig
-				return !!(config && config.xAxis && config.xAxis.type === 'log')
-			}
-			else if (AXIS_CHARTS.includes(chartType)) {
-				const config = chart.doc.config as AxisChartConfig
-				return !!(config && config.x_axis && config.x_axis.type === 'log')
-			}
-			else {
-				return false
-			}
-
-		},
-		set(val: boolean) {
-			const chartType = chart.doc.chart_type
-			if (chartType === "Bubble") {
-				const config = chart.doc.config as BubbleChartConfig
-				chart.doc.config = {
-					...chart.doc.config,
-					xAxis: {
-						...(config.xAxis ?? {}),
-						type: val ? 'log' : 'value',
-					},
-				}
-			}
-			else if (AXIS_CHARTS.includes(chartType)) {
-				const config = chart.doc.config as AxisChartConfig
-				chart.doc.config = {
-					...chart.doc.config,
-					x_axis: {
-						...(config.x_axis ?? {}),
-						type: val ? 'log' : 'value',
-					},
-				}
-			} else {
-				// do nothing for other chart types
-			}
-		},
-	})
 	async function refresh(force?: boolean, reload?: boolean) {
 		if (reload) {
 			await chart.load()
@@ -564,8 +480,6 @@ function makeChart(name: string) {
 		...toRefs(chart),
 
 		dataQuery,
-		isYLogScale,
-		isXLogScale,
 		refresh,
 		updateGranularity,
 		resetConfig,

--- a/frontend/src2/charts/components/BarChartConfigForm.vue
+++ b/frontend/src2/charts/components/BarChartConfigForm.vue
@@ -9,7 +9,6 @@ import YAxisConfig from './YAxisConfig.vue'
 const props = defineProps<{
 	dimensions: DimensionOption[]
 	columnOptions: ColumnOption[]
-	logScale: boolean
 }>()
 
 const config = defineModel<BarChartConfig>({
@@ -42,18 +41,15 @@ watchEffect(() => {
 		config.value.y_axis.stack = false
 	}
 })
-const emit = defineEmits(['update:logScale'])
-
-const logScaleModel = computed({
-	get: () => props.logScale,
-	set: (val: boolean) => emit('update:logScale', val),
-})
 </script>
 
 <template>
 	<XAxisConfig v-model="config.x_axis" :dimensions="props.dimensions"></XAxisConfig>
-
-	<YAxisConfig v-model="config.y_axis" :column-options="props.columnOptions">
+	<YAxisConfig
+		v-model="config.y_axis"
+		:column-options="props.columnOptions"
+		:show-log-scale="true"
+	>
 		<template #y-axis-settings="{ y_axis }">
 			<Toggle label="Stack" v-model="(y_axis as YAxisBar).stack" :disabled="hasAxisSplit" />
 			<Toggle
@@ -62,7 +58,6 @@ const logScaleModel = computed({
 				:disabled="hasAxisSplit"
 			/>
 			<Toggle label="Normalize" v-model="(y_axis as YAxisBar).normalize" />
-			<Toggle v-model="logScaleModel" label="Log Scale" />
 		</template>
 	</YAxisConfig>
 

--- a/frontend/src2/charts/components/BubbleChartConfigForm.vue
+++ b/frontend/src2/charts/components/BubbleChartConfigForm.vue
@@ -9,8 +9,6 @@ import { computed } from 'vue'
 const props = defineProps<{
 	dimensions: DimensionOption[]
 	columnOptions: ColumnOption[]
-	yLogScale: boolean
-	xLogScale: boolean
 }>()
 
 const config = defineModel<BubbleChartConfig>({
@@ -35,16 +33,6 @@ if (!config.value.yAxis) {
 if (!config.value.size_column) {
 	config.value.size_column = {} as Measure
 }
-const emit = defineEmits(['update:yLogScale', 'update:xLogScale'])
-
-const yLogScaleModel = computed({
-	get: () => props.yLogScale,
-	set: (val: boolean) => emit('update:yLogScale', val),
-})
-const xLogScaleModel = computed({
-	get: () => props.xLogScale,
-	set: (val: boolean) => emit('update:xLogScale', val),
-})
 </script>
 
 <template>
@@ -54,8 +42,8 @@ const xLogScaleModel = computed({
 				label="Series"
 				v-model="config.xAxis"
 				:column-options="props.columnOptions"
+				:show-log-scale="true"
 			/>
-			<Toggle v-model="xLogScaleModel" label="Log Scale" />
 		</div>
 	</CollapsibleSection>
 	<CollapsibleSection title="Y Axis">
@@ -64,8 +52,8 @@ const xLogScaleModel = computed({
 				label="Series"
 				v-model="config.yAxis"
 				:column-options="props.columnOptions"
+				:show-log-scale="true"
 			/>
-			<Toggle v-model="yLogScaleModel" label="Log Scale" />
 		</div>
 	</CollapsibleSection>
 

--- a/frontend/src2/charts/components/ChartConfigForm.vue
+++ b/frontend/src2/charts/components/ChartConfigForm.vue
@@ -72,14 +72,12 @@ const queryResult = computed(() => chartQuery.value.result)
 		v-model="props.chart.doc.config as BarChartConfig"
 		:dimensions="dimensions"
 		:column-options="columnOptions"
-		v-model:log-scale="props.chart.isYLogScale"
 	/>
 	<LineChartConfigForm
 		v-if="props.chart.doc.chart_type == 'Line'"
 		v-model="props.chart.doc.config as LineChartConfig"
 		:dimensions="dimensions"
 		:column-options="columnOptions"
-		v-model:log-scale="props.chart.isYLogScale"
 	/>
 	<MapChartConfigForm
 		v-if="props.chart.doc.chart_type == 'Map'"
@@ -96,7 +94,5 @@ const queryResult = computed(() => chartQuery.value.result)
 		v-model="props.chart.doc.config as BubbleChartConfig"
 		:dimensions="dimensions"
 		:column-options="columnOptions"
-		v-model:y-log-scale="props.chart.isYLogScale"
-		v-model:x-log-scale="props.chart.isXLogScale"
 	/>
 </template>

--- a/frontend/src2/charts/components/ChartRenderer.vue
+++ b/frontend/src2/charts/components/ChartRenderer.vue
@@ -47,6 +47,7 @@ const eChartOptions = computed(() => {
 		)
 	}
 	if (chart_type.value === 'Line') {
+		console.log('Line Chart Config:', config.value)
 		return getLineChartOptions(config.value as LineChartConfig, result.value)
 	}
 	if (chart_type.value === 'Donut') {
@@ -73,7 +74,7 @@ const locationColumn = computed(() => {
 	return result.value.columns.find(
 		(c) =>
 			FIELDTYPES.DIMENSION.includes(c.type) &&
-			c.name === mapConfig.value.location_column?.column_name
+			c.name === mapConfig.value.location_column?.column_name,
 	)
 })
 
@@ -114,7 +115,7 @@ const locationRowIndex = computed(() => {
 	return { index, reverseMap }
 })
 
-function handleMapChartClick(params:any) {
+function handleMapChartClick(params: any) {
 	if (!locationColumn.value) return null
 
 	const clickedLocation = params.name

--- a/frontend/src2/charts/components/LineChartConfigForm.vue
+++ b/frontend/src2/charts/components/LineChartConfigForm.vue
@@ -9,7 +9,6 @@ import YAxisConfig from './YAxisConfig.vue'
 const props = defineProps<{
 	dimensions: DimensionOption[]
 	columnOptions: ColumnOption[]
-	logScale: boolean
 }>()
 
 const config = defineModel<LineChartConfig>({
@@ -20,23 +19,20 @@ const config = defineModel<LineChartConfig>({
 		split_by: {},
 	}),
 })
-const emit = defineEmits(['update:logScale'])
-
-const logScaleModel = computed({
-	get: () => props.logScale,
-	set: (val: boolean) => emit('update:logScale', val),
-})
 </script>
 
 <template>
 	<XAxisConfig v-model="config.x_axis" :dimensions="props.dimensions"></XAxisConfig>
 
-	<YAxisConfig v-model="config.y_axis" :column-options="props.columnOptions">
+	<YAxisConfig
+		v-model="config.y_axis"
+		:column-options="props.columnOptions"
+		:show-log-scale="true"
+	>
 		<template #y-axis-settings="{ y_axis }">
 			<Toggle label="Curved Lines" v-model="(y_axis as YAxisLine).smooth" />
 			<Toggle label="Show Area" v-model="(y_axis as YAxisLine).show_area" />
 			<Toggle label="Show Data Points" v-model="(y_axis as YAxisLine).show_data_points" />
-			<Toggle v-model="logScaleModel" label="Log Scale" />
 		</template>
 		<template #series-settings="{ series }">
 			<Toggle label="Curved Lines" v-model="(series as SeriesLine).smooth" />

--- a/frontend/src2/charts/components/MeasurePicker.vue
+++ b/frontend/src2/charts/components/MeasurePicker.vue
@@ -19,6 +19,7 @@ const emit = defineEmits({ remove: () => true })
 const props = defineProps<{
 	label?: string
 	columnOptions: ColumnOption[]
+	showLogScale?: boolean
 }>()
 
 const measure = defineModel<Measure>({
@@ -112,10 +113,8 @@ const columnOptions = computed(() => {
 const filteredColumnOptions = computed(() => {
 	if (!searchQuery.value) return columnOptions.value
 	const query = searchQuery.value.toLowerCase()
-	
-	return columnOptions.value.filter((option) =>
-		option.label.toLowerCase().includes(query)
-	)
+
+	return columnOptions.value.filter((option) => option.label.toLowerCase().includes(query))
 })
 
 function getAggregationLabel(aggregation: AggregationType) {
@@ -218,8 +217,10 @@ const label = ref('')
 										class="flex h-7 flex-shrink-0 cursor-pointer items-center justify-between rounded px-2.5 text-base hover:bg-gray-100"
 										@click.prevent.stop="
 											() => {
-												(measure as ColumnMeasure).column_name = option.value
-												measure.data_type = option.data_type as MeasureDataType
+												;(measure as ColumnMeasure).column_name =
+													option.value
+												measure.data_type =
+													option.data_type as MeasureDataType
 												togglePopover()
 											}
 										"
@@ -298,13 +299,13 @@ const label = ref('')
 			</template>
 		</Button>
 	</div>
-
+	<Toggle v-if="props.showLogScale" label="Log Scale" v-model="measure.log_scale" />
 	<NewMeasureSelectorDialog
 		v-if="showMeasureDialog"
 		:model-value="Boolean(showMeasureDialog)"
 		@update:model-value="!$event && (showMeasureDialog = false)"
 		:column-options="props.columnOptions"
-		:measure="(measure as ExpressionMeasure)"
+		:measure="measure as ExpressionMeasure"
 		@select="updateMeasure"
 	/>
 </template>

--- a/frontend/src2/charts/components/XAxisConfig.vue
+++ b/frontend/src2/charts/components/XAxisConfig.vue
@@ -5,7 +5,11 @@ import { Dimension, DimensionOption } from '../../types/query.types'
 import CollapsibleSection from './CollapsibleSection.vue'
 import DimensionPicker from './DimensionPicker.vue'
 
-const props = defineProps<{ dimensions: DimensionOption[], showRotateLabels?: boolean}>()
+const props = defineProps<{
+	dimensions: DimensionOption[]
+	showRotateLabels?: boolean
+	showLogScale?: boolean
+}>()
 const x_axis = defineModel<AxisChartConfig['x_axis']>({
 	required: true,
 	default: () => ({}),
@@ -47,6 +51,7 @@ watchEffect(() => {
 					{ label: '90°', value: 90 },
 				]"
 			/>
+			<Toggle v-if="props.showLogScale" label="Log Scale" v-model="x_axis.log_scale" />
 			<!-- <Toggle label="Show Axis Title" />
 			<InlineFormControlLabel v-if="false" label="Axis Title Text">
 				<FormControl />

--- a/frontend/src2/charts/components/YAxisConfig.vue
+++ b/frontend/src2/charts/components/YAxisConfig.vue
@@ -11,7 +11,7 @@ import { ColumnOption, MeasureOption } from '../../types/query.types'
 import CollapsibleSection from './CollapsibleSection.vue'
 import MeasurePicker from './MeasurePicker.vue'
 
-const props = defineProps<{ columnOptions: ColumnOption[] }>()
+const props = defineProps<{ columnOptions: ColumnOption[]; showLogScale?: boolean }>()
 const y_axis = defineModel<AxisChartConfig['y_axis']>({
 	required: true,
 	default: () => ({
@@ -97,6 +97,7 @@ const updateColor = debounce((color: string, idx: number) => {
 			<Toggle label="Show Data Labels" v-model="y_axis.show_data_labels" />
 			<Toggle label="Show Axis Label" v-model="y_axis.show_axis_label" />
 			<Toggle label="Show Scrollbar" v-model="y_axis.show_scrollbar" />
+			<Toggle v-if="props.showLogScale" label="Log Scale" v-model="y_axis.log_scale" />
 			<FormControl
 				v-if="y_axis.show_axis_label"
 				v-model="y_axis.axis_label"

--- a/frontend/src2/charts/helpers.ts
+++ b/frontend/src2/charts/helpers.ts
@@ -64,8 +64,8 @@ export function getLineChartOptions(config: LineChartConfig, result: QueryResult
 		? getGranularity(config.x_axis.dimension.dimension_name, config)
 		: null
 
-	const leftYAxis = getYAxis({ min: config.y_axis.min, max: config.y_axis.max, log_type: config.y_axis.type })
-	const rightYAxis = getYAxis({ log_type: config.y_axis.type })
+	const leftYAxis = getYAxis({ min: config.y_axis.min, max: config.y_axis.max, log_type: config.y_axis.log_scale ? 'log' : 'value' })
+	const rightYAxis = getYAxis({ log_type:config.y_axis.log_scale ? 'log' : 'value' })
 	const hasRightAxis = config.y_axis.series.some((s) => s.align === 'Right')
 	const yAxis = !hasRightAxis ? [leftYAxis] : [leftYAxis, rightYAxis]
 
@@ -85,7 +85,7 @@ export function getLineChartOptions(config: LineChartConfig, result: QueryResult
 		})
 
 	const colors = getColors()
-
+	console.log(config)
 	return {
 		animation: true,
 		animationDuration: 700,
@@ -184,9 +184,9 @@ export function getBarChartOptions(config: BarChartConfig, result: QueryResult, 
 		normalized: config.y_axis.normalize,
 		min: config.y_axis.min,
 		max: config.y_axis.max,
-		log_type:config.y_axis.type
+		log_type: config.y_axis.log_scale ? 'log' : 'value'
 	})
-	const rightYAxis = getYAxis({ normalized: config.y_axis.normalize, log_type: config.y_axis.type })
+	const rightYAxis = getYAxis({ normalized: config.y_axis.normalize, log_type: config.y_axis.log_scale ? 'log' : 'value' })
 	const hasRightAxis = config.y_axis.series.some((s) => s.align === 'Right')
 	const yAxis = !hasRightAxis ? [leftYAxis] : [leftYAxis, rightYAxis]
 
@@ -934,14 +934,14 @@ export function getBubbleChartOptions(config: BubbleChartConfig, result: QueryRe
 	const yColumnLabel = result.columnOptions.find((c) => c.value === yColumnName)?.label || yColumnName
 
 	const xAxis = {
-		...getYAxis({ log_type: config.xAxis.type }),
+		...getYAxis({ log_type: config.xAxis.log_scale ? 'log' : 'value' }),
 		name: xColumnLabel,
 		nameLocation: 'middle',
 		nameGap: 25,
 	}
 
 	const yAxis = {
-		...getYAxis({ log_type: config.yAxis.type }),
+		...getYAxis({ log_type: config.yAxis.log_scale ? 'log' : 'value' }),
 		name: yColumnLabel,
 		nameLocation: 'middle',
 		nameGap: 35,

--- a/frontend/src2/types/chart.types.ts
+++ b/frontend/src2/types/chart.types.ts
@@ -1,6 +1,7 @@
 import { FormatGroupArgs } from '../query/components/formatting_utils'
-import { Dimension, Measure, AxisScaleType } from './query.types'
+import { Dimension, Measure } from './query.types'
 
+export type AxisScaleType = "value" | "log"
 export const AXIS_CHARTS = ['Bar', 'Line', 'Row']
 export type AxisChartType = (typeof AXIS_CHARTS)[number]
 
@@ -16,7 +17,7 @@ export type AxisChartConfig = {
 export type XAxis = {
 	dimension: Dimension
 	label_rotation?: number
-	type?: AxisScaleType
+	log_scale?: boolean
 }
 
 export type SplitBy = {
@@ -32,7 +33,7 @@ export type YAxis = {
 	show_axis_label?: boolean
 	show_data_labels?: boolean
 	show_scrollbar?: boolean
-	type?: AxisScaleType
+	log_scale?: boolean
 }
 export type Series = {
 	name?: string

--- a/frontend/src2/types/query.types.ts
+++ b/frontend/src2/types/query.types.ts
@@ -1,7 +1,7 @@
 import { GranularityType } from "../helpers/constants";
 
 export type TableArgs = { type: 'table'; data_source: string; table_name: string }
-export type AxisScaleType ="value" |"log"
+
 export type QueryTableArgs = {
 	type: 'query'
 	workbook: string
@@ -19,15 +19,16 @@ export type ColumnMeasure = {
 	column_name: string
 	data_type: MeasureDataType
 	aggregation: AggregationType
-	type?: AxisScaleType
+	log_scale?: boolean
 	show_scrollbar?: boolean
 }
 export type ExpressionMeasure = {
 	measure_name: string
 	expression: Expression
 	data_type: MeasureDataType
-	type?: AxisScaleType
 	show_scrollbar?: boolean
+	log_scale?: boolean
+
 }
 export type MeasureOption = Measure & { label: string; value: string }
 export type Dimension = {


### PR DESCRIPTION
### Description

This pull request adds support for configuring logarithmic scaling for both X and Y axes in Bar, Line, and Bubble charts. It introduces new properties and UI controls to allow users to toggle log scale per axis, and ensures this configuration is passed through to chart rendering logic. Additionally, it adds a "Show Scrollbar" option for Bubble chart Y axes.

### Screenshots

<img width="2208" height="1082" alt="image" src="https://github.com/user-attachments/assets/43443eae-430b-4618-8a26-bd4a375c13b0" />




ref:  #740