### PR TITLE
fix: `legacy-js-api` warning

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -20,13 +20,13 @@ export default defineConfig({
 	},
 	esbuild: { loader: 'ts' },
 	css: {
-    preprocessorOptions: {
-        scss: {
-          api: 'modern-compiler', // or "modern"
-          silenceDeprecations: ["legacy-js-api"],
-        },
-    },
-  },
+		preprocessorOptions: {
+			scss: {
+				api: 'modern-compiler', // or "modern"
+				silenceDeprecations: ['legacy-js-api'],
+			},
+		},
+	},
 	resolve: {
 		alias: {
 			// https://github.com/vitejs/vite/discussions/16730#discussioncomment-13048825


### PR DESCRIPTION
Attempt to fix the following warnings:
Deprecation Warning [legacy-js-api]: The legacy JS API is deprecated and will be removed in Dart Sass 2.0.0.