### PR TITLE
fix: include Custom Fields when checking child table permissions

### DIFF
--- a/insights/insights/doctype/insights_table_v3/insights_table_v3.py
+++ b/insights/insights/doctype/insights_table_v3/insights_table_v3.py
@@ -163,6 +163,19 @@ def get_allowed_documents(doctype):
             distinct=True,
         )
 
+        custom_parent_doctypes = frappe.get_all(
+            "Custom Field",
+            filters={
+                "fieldtype": ["in", ["Table", "Table MultiSelect"]],
+                "options": child_doctype,
+            },
+            pluck="dt",
+            distinct=True,
+        )
+
+        # Combine and deduplicate parent doctypes
+        parent_doctypes = list(set(parent_doctypes + custom_parent_doctypes))
+
         # FIX: check permission of the parent and not the child table
         parent_doctypes = [p for p in parent_doctypes if frappe.has_permission(p, "read")]
 


### PR DESCRIPTION
- Modified get_allowed_documents to query both DocField and Custom Field
- Combined and deduplicated parent doctypes to prevent duplicate checks
- Fixes issue where child tables linked via Custom Fields return WHERE FALSE

Fixes #755