### PR TITLE
fix: apply role & user permissions by default on site db

### DIFF
--- a/insights/insights/doctype/insights_table_v3/insights_table_v3.py
+++ b/insights/insights/doctype/insights_table_v3/insights_table_v3.py
@@ -147,6 +147,8 @@ def apply_user_permissions(t, data_source, table_name):
         final_query = " UNION ALL ".join(child_perm_queries)
         return t.sql(final_query)
 
+    return t.filter(False)
+
 
 def get_perm_sql_query(doctype, parent_doctype=None):
     return str(


### PR DESCRIPTION
When applying role & user permissions for `Site DB` data source, get the SQL query from `get_list` with

```python
> frappe.get_list("ToDo", "*", run=False)
> "SELECT ...columns FROM tabToDo WHERE <user_permissions>"
```
Then use this query as table: `t.sql(query)`

For child tables,
- Find all possible parent doctypes
- Filter out permitted ones
- Store perm queries with `frappe.get_list(child_doctype, parent_doctype, run=True)` for each parent doctype
- `UNION ALL` all of these queries to get the child table query