### PR TITLE
fix: prevent cleanup of non-existing insights folders

### DIFF
--- a/insights/insights/doctype/insights_chart_v3/insights_chart_v3.py
+++ b/insights/insights/doctype/insights_chart_v3/insights_chart_v3.py
@@ -51,6 +51,9 @@ class InsightsChartv3(Document):
 
     def cleanup_empty_folder(self, folder_name):
         """Delete folder if it has no queries or charts"""
+        if not frappe.db.exists("Insights Folder", folder_name):
+            return
+
         folder = frappe.get_doc("Insights Folder", folder_name)
         folder_type = folder.type
 

--- a/insights/insights/doctype/insights_query_v3/insights_query_v3.py
+++ b/insights/insights/doctype/insights_query_v3/insights_query_v3.py
@@ -72,6 +72,9 @@ class InsightsQueryv3(Document):
 
     def cleanup_empty_folder(self, folder_name):
         """Delete folder if it has no queries or charts"""
+        if not frappe.db.exists("Insights Folder", folder_name):
+            return
+
         folder = frappe.get_doc("Insights Folder", folder_name)
         folder_type = folder.type
 


### PR DESCRIPTION
When deleting multiple workbooks simultaneously, the system sometimes crashes during the deletion of a folder that no longer exists. I believe that implementing this code resolves the 'Folder not found' error that's blocking the deletion process.