### PR TITLE
If this is not done, insights will be unable to communicate with erpnext, and an error will occur during the installation process.

### DIFF
--- a/insights/insights/doctype/insights_data_source/sources/frappe_db.py
+++ b/insights/insights/doctype/insights_data_source/sources/frappe_db.py
@@ -211,7 +211,7 @@ class FrappeDB(MariaDB):
             host=host,
             port=port,
             ssl=use_ssl,
-            ssl_verify_cert=True,
+            ssl_verify_cert=False,
             charset="utf8mb4",
             use_unicode=True,
             connect_args={"connect_timeout": 1, "read_timeout": 1, "write_timeout": 1},

--- a/insights/insights/doctype/insights_data_source/sources/frappe_db.py
+++ b/insights/insights/doctype/insights_data_source/sources/frappe_db.py
@@ -211,7 +211,7 @@ class FrappeDB(MariaDB):
             host=host,
             port=port,
             ssl=use_ssl,
-            ssl_verify_cert=True,
+            ssl_verify_cert=False,
             charset="utf8mb4",
             use_unicode=True,
             connect_args={"connect_timeout": 1, "read_timeout": 1, "write_timeout": 1},
@@ -316,7 +316,7 @@ class SiteDB(FrappeDB):
             host=credentials["host"],
             port=credentials["port"],
             ssl=False,
-            ssl_verify_cert=bool(not frappe.conf.developer_mode),
+            ssl_verify_cert=False,
             charset="utf8mb4",
             use_unicode=True,
         )

--- a/insights/insights/doctype/insights_data_source/sources/frappe_db.py
+++ b/insights/insights/doctype/insights_data_source/sources/frappe_db.py
@@ -211,7 +211,7 @@ class FrappeDB(MariaDB):
             host=host,
             port=port,
             ssl=use_ssl,
-            ssl_verify_cert=False,
+            ssl_verify_cert=True,
             charset="utf8mb4",
             use_unicode=True,
             connect_args={"connect_timeout": 1, "read_timeout": 1, "write_timeout": 1},
@@ -316,7 +316,7 @@ class SiteDB(FrappeDB):
             host=credentials["host"],
             port=credentials["port"],
             ssl=False,
-            ssl_verify_cert=False,
+            ssl_verify_cert=True,
             charset="utf8mb4",
             use_unicode=True,
         )

--- a/insights/insights/doctype/insights_data_source/sources/frappe_db.py
+++ b/insights/insights/doctype/insights_data_source/sources/frappe_db.py
@@ -316,7 +316,7 @@ class SiteDB(FrappeDB):
             host=credentials["host"],
             port=credentials["port"],
             ssl=False,
-            ssl_verify_cert=True,
+            ssl_verify_cert=False,
             charset="utf8mb4",
             use_unicode=True,
         )

--- a/insights/insights/doctype/insights_data_source/sources/mariadb.py
+++ b/insights/insights/doctype/insights_data_source/sources/mariadb.py
@@ -105,7 +105,7 @@ class MariaDB(BaseDatabase):
             host=host,
             port=port,
             ssl=use_ssl,
-            ssl_verify_cert=use_ssl,
+            ssl_verify_cert=False,
             charset="utf8mb4",
             use_unicode=True,
             connect_args={"connect_timeout": 1},


### PR DESCRIPTION
Problem Description：
https://github.com/frappe/insights/issues/763