### PR TITLE
feat: Warehouse Tables for Native Queries

### DIFF
--- a/frontend/src2/query/components/NativeQueryEditor.vue
+++ b/frontend/src2/query/components/NativeQueryEditor.vue
@@ -1,39 +1,20 @@
 <script setup lang="ts">
 import { useTimeAgo } from '@vueuse/core'
-import { MoreHorizontal, Play, Wand2 } from 'lucide-vue-next'
+import { Play } from 'lucide-vue-next'
 import { computed, inject, ref } from 'vue'
 import Code from '../../components/Code.vue'
 import ContentEditable from '../../components/ContentEditable.vue'
-import useDataSourceStore from '../../data_source/data_source'
 import { wheneverChanges } from '../../helpers'
-import { confirmDialog } from '../../helpers/confirm_dialog'
 import { Query } from '../query'
-import useSettings from '../../settings/settings'
 import QueryDataTable from './QueryDataTable.vue'
 import DataSourceSelector from './source_selector/DataSourceSelector.vue'
 import { createToast } from '../../helpers/toasts'
 import SchemaExplorer from './SchemaExplorer.vue'
-import { Switch } from 'frappe-ui'
+import { call } from 'frappe-ui'
 
 const query = inject<Query>('query')!
 query.autoExecute = false
 query.execute()
-
-const settings = useSettings()
-function toggleDataStore(enable: boolean) {
-	const title = enable ? 'Enable Data Store' : 'Disable Data Store'
-	const message = enable
-		? 'Enabling data store use the cached table data for faster queries, but may not be up-to-date. It will also allow you to combine data from multiple sources. Cached data is updated every day.'
-		: 'Disabling data store will use the live connection to the database for queries. This will ensure that you are always querying the most up-to-date data but may be slower.'
-
-	confirmDialog({
-		title,
-		message,
-		onSuccess() {
-			query.doc.use_live_connection = !enable
-		},
-	})
-}
 
 const operation = query.getSQLOperation()
 const data_source = ref(operation ? operation.data_source : '')
@@ -83,15 +64,26 @@ function insertTextIntoEditor(text: string) {
 }
 
 const dataSourceSchema = ref<Record<string, any>>({})
-const dataSourceStore = useDataSourceStore()
+const isWarehouse = computed(() => data_source.value === 'warehouse_tables')
+
 wheneverChanges(
-	data_source,
+	() => `${data_source.value}`,
 	() => {
 		if (!data_source.value) {
 			dataSourceSchema.value = {}
 			return
 		}
-		dataSourceStore.getSchema(data_source.value).then((schema: any) => {
+		query.doc.use_live_connection = !isWarehouse.value
+
+		const schemaSource = isWarehouse.value
+			? 'insights.api.data_sources.get_warehouse_schema'
+			: 'insights.api.data_sources.get_schema'
+
+		const params = isWarehouse.value
+			? {}
+			: { data_source: data_source.value }
+
+		call(schemaSource, params).then((schema: any) => {
 			dataSourceSchema.value = schema
 		})
 	},
@@ -144,18 +136,6 @@ const completions = computed(() => {
 							placeholder="new query"
 						></ContentEditable>
 					</div>
-
-					<div
-						v-if="settings.doc.enable_data_store"
-						class="flex flex-shrink-0 items-center gap-3"
-					>
-						<span class="text-xs text-gray-600"> Enable Data Store </span>
-						<Switch
-							:modelValue="!query.doc.use_live_connection"
-							@update:modelValue="toggleDataStore"
-							size="sm"
-						/>
-					</div>
 				</div>
 				<div class="flex-1 overflow-hidden">
 					<Code
@@ -173,16 +153,6 @@ const completions = computed(() => {
 							<Play class="h-3.5 w-3.5 text-gray-700" stroke-width="1.5" />
 						</template>
 					</Button>
-					<!-- <Dropdown
-					:button="{ icon: MoreHorizontal }"
-					:options="[
-						{
-							label: 'Format SQL',
-							icon: Wand2,
-							onClick: () => format(),
-						},
-					]"
-				/> -->
 				</div>
 			</div>
 			<div
@@ -201,7 +171,7 @@ const completions = computed(() => {
 			</div>
 		</div>
 		<div class="w-64 flex-shrink-0">
-			<SchemaExplorer :schema="dataSourceSchema" @insert-text="insertTextIntoEditor" />
+			<SchemaExplorer :schema="dataSourceSchema" :useDoubleQuotes="isWarehouse" @insert-text="insertTextIntoEditor" />
 		</div>
 	</div>
 </template>

--- a/frontend/src2/query/components/NativeQueryEditor.vue
+++ b/frontend/src2/query/components/NativeQueryEditor.vue
@@ -6,15 +6,34 @@ import Code from '../../components/Code.vue'
 import ContentEditable from '../../components/ContentEditable.vue'
 import useDataSourceStore from '../../data_source/data_source'
 import { wheneverChanges } from '../../helpers'
+import { confirmDialog } from '../../helpers/confirm_dialog'
 import { Query } from '../query'
+import useSettings from '../../settings/settings'
 import QueryDataTable from './QueryDataTable.vue'
 import DataSourceSelector from './source_selector/DataSourceSelector.vue'
 import { createToast } from '../../helpers/toasts'
 import SchemaExplorer from './SchemaExplorer.vue'
+import { Switch } from 'frappe-ui'
 
 const query = inject<Query>('query')!
 query.autoExecute = false
 query.execute()
+
+const settings = useSettings()
+function toggleDataStore(enable: boolean) {
+	const title = enable ? 'Enable Data Store' : 'Disable Data Store'
+	const message = enable
+		? 'Enabling data store use the cached table data for faster queries, but may not be up-to-date. It will also allow you to combine data from multiple sources. Cached data is updated every day.'
+		: 'Disabling data store will use the live connection to the database for queries. This will ensure that you are always querying the most up-to-date data but may be slower.'
+
+	confirmDialog({
+		title,
+		message,
+		onSuccess() {
+			query.doc.use_live_connection = !enable
+		},
+	})
+}
 
 const operation = query.getSQLOperation()
 const data_source = ref(operation ? operation.data_source : '')
@@ -32,7 +51,7 @@ function execute(force: boolean = false) {
 			raw_sql: sql.value,
 			data_source: data_source.value,
 		},
-		force,
+		force
 	)
 }
 
@@ -76,7 +95,7 @@ wheneverChanges(
 			dataSourceSchema.value = schema
 		})
 	},
-	{ immediate: true },
+	{ immediate: true }
 )
 const completions = computed(() => {
 	if (!Object.keys(dataSourceSchema.value).length)
@@ -109,13 +128,34 @@ const completions = computed(() => {
 	<div class="flex flex-1 gap-4 overflow-hidden p-4">
 		<div class="flex flex-1 flex-col gap-4 overflow-hidden">
 			<div class="relative flex h-[55%] w-full flex-col rounded border">
-				<div class="flex flex-shrink-0 items-center gap-1 border-b p-1">
-					<DataSourceSelector v-model="data_source" placeholder="Select a data source" />
-					<ContentEditable
-						class="flex h-7 cursor-text items-center justify-center rounded bg-white px-2 text-base text-gray-800 focus-visible:ring-1 focus-visible:ring-gray-600"
-						v-model="query.doc.title"
-						placeholder="Untitled Dashboard"
-					></ContentEditable>
+				<div class="flex flex-shrink-0 items-center border-b h-10 px-3 gap-4 bg-white">
+					<div class="flex-shrink-0">
+						<DataSourceSelector
+							v-model="data_source"
+							placeholder="Select a data source"
+							class="!w-48"
+						/>
+					</div>
+
+					<div class="flex-1 flex justify-center">
+						<ContentEditable
+							class="w-fit min-w-[12rem] h-8 cursor-text rounded-md bg-gray-50/50 px-4 text-sm font-medium text-gray-700 text-center flex items-center justify-center transition-colors hover:bg-gray-50 focus-visible:ring-1 focus-visible:ring-gray-300"
+							v-model="query.doc.title"
+							placeholder="new query"
+						></ContentEditable>
+					</div>
+
+					<div
+						v-if="settings.doc.enable_data_store"
+						class="flex flex-shrink-0 items-center gap-3"
+					>
+						<span class="text-xs text-gray-600"> Enable Data Store </span>
+						<Switch
+							:modelValue="!query.doc.use_live_connection"
+							@update:modelValue="toggleDataStore"
+							size="sm"
+						/>
+					</div>
 				</div>
 				<div class="flex-1 overflow-hidden">
 					<Code

--- a/frontend/src2/query/components/SchemaExplorer.vue
+++ b/frontend/src2/query/components/SchemaExplorer.vue
@@ -17,6 +17,7 @@ interface TableSchema {
 
 interface Props {
 	schema: TableSchema
+	useDoubleQuotes?: boolean
 }
 
 interface Emits {
@@ -35,12 +36,19 @@ function toggleTable(tableName: string) {
 		expandedTables.value.add(tableName)
 	}
 }
+function quoteType(name: string) {
+	if (props.useDoubleQuotes) {
+		return `"${name}",`
+	}
+	return `\`${name}\``
+}
+
 function insertTableName(tableName: string) {
-	emit('insert-text', `\`${tableName}\``)
+	emit('insert-text', quoteType(tableName))
 }
 
 function insertColumnName(columnName: string) {
-	emit('insert-text', `\`${columnName}\`\,`)
+	emit('insert-text', `${quoteType(columnName)},`)
 }
 
 function getColumnIcon(type: string) {

--- a/frontend/src2/query/components/SchemaExplorer.vue
+++ b/frontend/src2/query/components/SchemaExplorer.vue
@@ -38,7 +38,7 @@ function toggleTable(tableName: string) {
 }
 function quoteType(name: string) {
 	if (props.useDoubleQuotes) {
-		return `"${name}",`
+		return `"${name}"`
 	}
 	return `\`${name}\``
 }

--- a/frontend/src2/query/components/source_selector/DataSourceSelector.vue
+++ b/frontend/src2/query/components/source_selector/DataSourceSelector.vue
@@ -2,6 +2,7 @@
 import { ChevronDown, Database, ListFilter } from 'lucide-vue-next'
 import { computed } from 'vue'
 import useDataSourceStore from '../../../data_source/data_source'
+import useSettings from '../../../settings/settings'
 
 const currentSourceName = defineModel()
 const props = defineProps({
@@ -12,14 +13,29 @@ const props = defineProps({
 })
 
 const dataSourceStore = useDataSourceStore()
+const settings = useSettings()
+
 const currentSource = computed(() => {
+	if (currentSourceName.value === 'warehouse_tables') {
+		return { name: 'warehouse_tables', title: 'Warehouse Tables' }
+	}
 	return dataSourceStore.sources.find((source) => source.name === currentSourceName.value)
 })
+
 const dataSourceOptions = computed(() => {
-	return dataSourceStore.sources.map((source) => ({
+	const options = dataSourceStore.sources.map((source) => ({
 		label: source.title,
 		value: source.name,
 	}))
+
+	if (settings.doc.enable_data_store) {
+		options.push({
+			label: 'Warehouse Tables',
+			value: 'warehouse_tables',
+		})
+	}
+
+	return options
 })
 </script>
 

--- a/insights/api/data_sources.py
+++ b/insights/api/data_sources.py
@@ -471,3 +471,45 @@ def get_schema(data_source: str):
             )
 
     return schema
+
+
+@insights_whitelist()
+def get_warehouse_schema():
+    import insights
+    from insights.insights.doctype.insights_data_source_v3.data_warehouse import (
+        WarehouseTable,
+    )
+
+    tables = frappe.get_list(
+        "Insights Table v3",
+        filters={"stored": 1},
+        fields=["table", "label", "data_source"],
+    )
+
+    schema = {}
+    for table in tables:
+        warehouse_name = WarehouseTable.format_table_name(table.data_source, table.table)
+
+        try:
+            t = insights.warehouse.db.table(warehouse_name)
+        except Exception:
+            continue
+
+        columns = []
+        for col_name, col_type in t.schema().items():
+            columns.append(
+                frappe._dict(
+                    column=col_name,
+                    label=col_name,
+                    type=to_insights_type(col_type),
+                )
+            )
+
+        schema[warehouse_name] = {
+            "table": warehouse_name,
+            "label": table.label,
+            "data_source": table.data_source,
+            "columns": columns,
+        }
+
+    return schema

--- a/insights/insights/doctype/insights_data_source_v3/ibis_utils.py
+++ b/insights/insights/doctype/insights_data_source_v3/ibis_utils.py
@@ -493,13 +493,6 @@ class IbisQueryBuilder:
     def apply_custom_operation(self, operation):
         return self.evaluate_expression(operation.expression.expression)
 
-    SQLGLOT_DIALECT_MAP = {
-        "MariaDB": "mysql",
-        "PostgreSQL": "postgres",
-        "SQLite": "sqlite",
-        "DuckDB": "duckdb",
-    }
-
     def apply_sql(self, sql_args):
         data_source = sql_args.data_source
         raw_sql = sql_args.raw_sql
@@ -507,7 +500,7 @@ class IbisQueryBuilder:
         raw_sql = sqlparse.format(sql=raw_sql, strip_comments=True)
 
         if not self.use_live_connection:
-            return self.use_sql_warehouse(raw_sql, data_source)
+            return self.apply_sql_to_warehouse(raw_sql)
 
         ds = frappe.get_doc("Insights Data Source v3", data_source)
         db = ds._get_ibis_backend()
@@ -596,48 +589,13 @@ class IbisQueryBuilder:
 
         return results
 
-    def use_sql_warehouse(self, raw_sql, data_source):
-        ds = frappe.get_doc("Insights Data Source v3", data_source)
-        source_dialect = self.SQLGLOT_DIALECT_MAP.get(ds.database_type, "mysql")
-
-        parsed = sg.parse_one(raw_sql, dialect=source_dialect)
-
-        # get CTEs from the tables used and exclude them
-        tables = {t.name for t in parsed.find_all(sg.exp.Table)}
-        cte_aliases = {c.alias for c in parsed.find_all(sg.exp.CTE)}
-        tables = tables - cte_aliases
-
-        InsightsTablev3.bulk_create(data_source, list(tables))
-
-        replace_map = {}
-        for table_name in tables:
-            t = InsightsTablev3.get_ibis_table(data_source, table_name, use_live_connection=False)
-            replace_map[table_name] = ibis.to_sql(t)
-
-        transpiled_sql = sg.transpile(raw_sql, read=source_dialect, write="duckdb")[0]
-
-        # We inject our warehouse CTEs after the 'WITH' keyword
-        # FIX: When combining two sets of CTEs we cant have two WITH keywords in one query
-        if replace_map:
-            with_clauses = []
-            for name, sql in replace_map.items():
-                quoted_name = sg.to_identifier(name)
-                with_clauses.append(f"{quoted_name} AS ({sql})")
-
-            with_clause_sql = ", ".join(with_clauses)
-            transpiled_stripped = transpiled_sql.strip()
-            if transpiled_stripped.upper().startswith("WITH"):
-                transpiled_sql = re.sub(
-                    r"(\bWITH\b)",
-                    f"WITH {with_clause_sql},",
-                    transpiled_stripped,
-                    count=1,
-                    flags=re.IGNORECASE,
-                )
-            else:
-                transpiled_sql = f"WITH {with_clause_sql} {transpiled_stripped}"
-
-        return insights.warehouse.db.sql(transpiled_sql)
+    def apply_sql_to_warehouse(self, raw_sql):
+        if not raw_sql.strip().lower().startswith(("select", "with")):
+            frappe.throw(
+                "SQL query must start with a SELECT or WITH statement",
+                title="Invalid SQL Query",
+            )
+        return insights.warehouse.db.sql(raw_sql)
 
     def apply_code(self, code_args):
         code = code_args.code

--- a/insights/insights/doctype/insights_data_source_v3/ibis_utils.py
+++ b/insights/insights/doctype/insights_data_source_v3/ibis_utils.py
@@ -493,14 +493,24 @@ class IbisQueryBuilder:
     def apply_custom_operation(self, operation):
         return self.evaluate_expression(operation.expression.expression)
 
+    SQLGLOT_DIALECT_MAP = {
+        "MariaDB": "mysql",
+        "PostgreSQL": "postgres",
+        "SQLite": "sqlite",
+        "DuckDB": "duckdb",
+    }
+
     def apply_sql(self, sql_args):
         data_source = sql_args.data_source
         raw_sql = sql_args.raw_sql
 
+        raw_sql = sqlparse.format(sql=raw_sql, strip_comments=True)
+
+        if not self.use_live_connection:
+            return self.use_sql_warehouse(raw_sql, data_source)
+
         ds = frappe.get_doc("Insights Data Source v3", data_source)
         db = ds._get_ibis_backend()
-
-        raw_sql = sqlparse.format(sql=raw_sql, strip_comments=True)
 
         # TODO: apply user permissions by default
         check_permissions = frappe.db.get_single_value(
@@ -585,6 +595,49 @@ class IbisQueryBuilder:
             )
 
         return results
+
+    def use_sql_warehouse(self, raw_sql, data_source):
+        ds = frappe.get_doc("Insights Data Source v3", data_source)
+        source_dialect = self.SQLGLOT_DIALECT_MAP.get(ds.database_type, "mysql")
+
+        parsed = sg.parse_one(raw_sql, dialect=source_dialect)
+
+        # get CTEs from the tables used and exclude them
+        tables = {t.name for t in parsed.find_all(sg.exp.Table)}
+        cte_aliases = {c.alias for c in parsed.find_all(sg.exp.CTE)}
+        tables = tables - cte_aliases
+
+        InsightsTablev3.bulk_create(data_source, list(tables))
+
+        replace_map = {}
+        for table_name in tables:
+            t = InsightsTablev3.get_ibis_table(data_source, table_name, use_live_connection=False)
+            replace_map[table_name] = ibis.to_sql(t)
+
+        transpiled_sql = sg.transpile(raw_sql, read=source_dialect, write="duckdb")[0]
+
+        # We inject our warehouse CTEs after the 'WITH' keyword
+        # FIX: When combining two sets of CTEs we cant have two WITH keywords in one query
+        if replace_map:
+            with_clauses = []
+            for name, sql in replace_map.items():
+                quoted_name = sg.to_identifier(name)
+                with_clauses.append(f"{quoted_name} AS ({sql})")
+
+            with_clause_sql = ", ".join(with_clauses)
+            transpiled_stripped = transpiled_sql.strip()
+            if transpiled_stripped.upper().startswith("WITH"):
+                transpiled_sql = re.sub(
+                    r"(\bWITH\b)",
+                    f"WITH {with_clause_sql},",
+                    transpiled_stripped,
+                    count=1,
+                    flags=re.IGNORECASE,
+                )
+            else:
+                transpiled_sql = f"WITH {with_clause_sql} {transpiled_stripped}"
+
+        return insights.warehouse.db.sql(transpiled_sql)
 
     def apply_code(self, code_args):
         code = code_args.code


### PR DESCRIPTION
This PR adds functionality to query tables stored in parquet files using DuckDB in SQL editor

ToDo:

- [ ]  add import job button instead of toggle
- [ ] handle permissions
