### PR TITLE
fix: fetch favorite dashboards separately

### DIFF
--- a/frontend/src2/dashboard/DashboardList.vue
+++ b/frontend/src2/dashboard/DashboardList.vue
@@ -12,9 +12,7 @@ watchEffect(() => {
 	store.fetchDashboards(searchQuery.value)
 })
 
-const favorites = computed(() => {
-	return store.dashboards.filter((d) => d.is_favourite)
-})
+const favorites = computed(() => store.favorites)
 
 const router = useRouter()
 const dropdownOptions = (dashboard: DashboardListItem) => {

--- a/frontend/src2/dashboard/dashboards.ts
+++ b/frontend/src2/dashboard/dashboards.ts
@@ -1,4 +1,4 @@
-import { useTimeAgo } from '@vueuse/core'
+import { get, useTimeAgo } from '@vueuse/core'
 import { call } from 'frappe-ui'
 import { reactive, ref } from 'vue'
 import { createInfoToast, createSuccessToast } from '../helpers/toasts'
@@ -19,21 +19,27 @@ export type DashboardListItem = {
 }
 
 const dashboards = ref<DashboardListItem[]>([])
+const favorites = ref<DashboardListItem[]>([])
 
 const loading = ref(false)
+const mapTimeAgo = (dashboard: any) => ({
+	...dashboard,
+	created_from_now: useTimeAgo(dashboard.creation),
+	modified_from_now: useTimeAgo(dashboard.modified),
+})
 async function fetchDashboards(search_term?: string, limit: number = 50) {
 	loading.value = true
-	dashboards.value = await call('insights.api.dashboards.get_dashboards', {
-		search_term,
-		limit,
-	})
-	dashboards.value = dashboards.value.map((dashboard: any) => ({
-		...dashboard,
-		created_from_now: useTimeAgo(dashboard.creation),
-		modified_from_now: useTimeAgo(dashboard.modified),
-	}))
+
+	const [regular, fav] = await Promise.all([
+		call('insights.api.dashboards.get_dashboards', { search_term, limit }),
+		call('insights.api.dashboards.get_dashboards',{get_favorites: true}),
+	])
+	console.log('dashboards', regular)
+	console.log('dashboards', fav)
+
+	dashboards.value = regular.map(mapTimeAgo)
+	favorites.value = fav.map(mapTimeAgo)
 	loading.value = false
-	return dashboards.value
 }
 
 const updatingPreviewImage = ref<Record<string, boolean>>({})
@@ -70,6 +76,7 @@ export default function useDashboardStore() {
 
 	return reactive({
 		dashboards,
+		favorites,
 		loading,
 		fetchDashboards,
 

--- a/frontend/src2/dashboard/dashboards.ts
+++ b/frontend/src2/dashboard/dashboards.ts
@@ -34,8 +34,6 @@ async function fetchDashboards(search_term?: string, limit: number = 50) {
 		call('insights.api.dashboards.get_dashboards', { search_term, limit }),
 		call('insights.api.dashboards.get_dashboards',{get_favorites: true}),
 	])
-	console.log('dashboards', regular)
-	console.log('dashboards', fav)
 
 	dashboards.value = regular.map(mapTimeAgo)
 	favorites.value = fav.map(mapTimeAgo)

--- a/insights/api/dashboards.py
+++ b/insights/api/dashboards.py
@@ -75,13 +75,14 @@ def add_chart_to_dashboard(dashboard: str, chart: str):
 
 
 @insights_whitelist()
-def get_dashboards(search_term: str | None = None, limit: int = 50):
+def get_dashboards(search_term: str | None = None, limit: int = 50, get_favorites: bool = False):
     dashboards = frappe.get_list(
         "Insights Dashboard v3",
         or_filters={
             "name": ["like", f"%{search_term}%" if search_term else "%"],
             "title": ["like", f"%{search_term}%" if search_term else "%"],
         },
+        filters=  {"_liked_by": ["like", f"%{frappe.session.user}%"]} if get_favorites else {},
         fields=[
             "name",
             "title",
@@ -93,7 +94,7 @@ def get_dashboards(search_term: str | None = None, limit: int = 50):
             "_liked_by",
         ],
         order_by="creation desc",
-        limit=limit,
+        limit=limit if not get_favorites else 0,
     )
 
     for dashboard in dashboards:

--- a/insights/api/dashboards.py
+++ b/insights/api/dashboards.py
@@ -12,9 +12,7 @@ def get_dashboard_list():
     )
     for dashboard in dashboards:
         if dashboard._liked_by:
-            dashboard["is_favourite"] = frappe.session.user in frappe.as_json(
-                dashboard._liked_by
-            )
+            dashboard["is_favourite"] = frappe.session.user in frappe.as_json(dashboard._liked_by)
         dashboard["charts"] = frappe.get_all(
             "Insights Dashboard Item",
             filters={
@@ -82,7 +80,7 @@ def get_dashboards(search_term: str | None = None, limit: int = 50, get_favorite
             "name": ["like", f"%{search_term}%" if search_term else "%"],
             "title": ["like", f"%{search_term}%" if search_term else "%"],
         },
-        filters=  {"_liked_by": ["like", f"%{frappe.session.user}%"]} if get_favorites else {},
+        filters={"_liked_by": ["like", f"%{frappe.session.user}%"]} if get_favorites else {},
         fields=[
             "name",
             "title",
@@ -109,9 +107,7 @@ def get_dashboards(search_term: str | None = None, limit: int = 50, get_favorite
             },
         )
         if dashboard._liked_by:
-            dashboard["is_favourite"] = frappe.session.user in frappe.as_json(
-                dashboard._liked_by
-            )
+            dashboard["is_favourite"] = frappe.session.user in frappe.as_json(dashboard._liked_by)
         del dashboard["items"]
 
     return dashboards


### PR DESCRIPTION
added a `get_favorites` param to `get_dashboards` method to filter favorite dashboards and remove query limit while fetching favorites. 