### PR TITLE
refactor: remove unused imports and clean up code formatting

### DIFF
--- a/insights/insights/doctype/insights_table_v3/patches/force_sync_tables.py
+++ b/insights/insights/doctype/insights_table_v3/patches/force_sync_tables.py
@@ -2,6 +2,7 @@ import frappe
 
 from insights.insights.doctype.insights_data_source_v3.insights_data_source_v3 import after_request
 
+
 def execute():
     """
     `name` of Insights Table v3 is changed from `autoincrement` to `varchar(140)`

--- a/insights/insights/doctype/insights_table_v3/patches/force_sync_tables.py
+++ b/insights/insights/doctype/insights_table_v3/patches/force_sync_tables.py
@@ -1,10 +1,6 @@
 import frappe
 
-from insights.insights.doctype.insights_data_source_v3.insights_data_source_v3 import (
-    after_request,
-    before_request,
-)
-
+from insights.insights.doctype.insights_data_source_v3.insights_data_source_v3 import ( after_request)
 
 def execute():
     """
@@ -13,14 +9,10 @@ def execute():
      The new name will be a reproducible hash of the data_source and table name
     """
 
-    data_sources = frappe.get_all(
-        "Insights Data Source v3", filters={"status": "Active"}, pluck="name"
-    )
+    data_sources = frappe.get_all( "Insights Data Source v3", filters={"status": "Active"}, pluck="name")
 
     doctype_doc = frappe.get_doc("DocType", "Insights Table v3")
     doctype_doc.setup_autoincrement_and_sequence()
-
-    before_request()
 
     for source in data_sources:
         doc = frappe.get_doc("Insights Data Source v3", source)

--- a/insights/insights/doctype/insights_table_v3/patches/force_sync_tables.py
+++ b/insights/insights/doctype/insights_table_v3/patches/force_sync_tables.py
@@ -1,6 +1,6 @@
 import frappe
 
-from insights.insights.doctype.insights_data_source_v3.insights_data_source_v3 import ( after_request)
+from insights.insights.doctype.insights_data_source_v3.insights_data_source_v3 import after_request
 
 def execute():
     """
@@ -9,7 +9,7 @@ def execute():
      The new name will be a reproducible hash of the data_source and table name
     """
 
-    data_sources = frappe.get_all( "Insights Data Source v3", filters={"status": "Active"}, pluck="name")
+    data_sources = frappe.get_all("Insights Data Source v3", filters={"status": "Active"}, pluck="name")
 
     doctype_doc = frappe.get_doc("DocType", "Insights Table v3")
     doctype_doc.setup_autoincrement_and_sequence()


### PR DESCRIPTION
The before_request method has been recently removed from the insights_data_source_v3.py file.