### PR TITLE
When trying to download data for installation in China, an error will…

### DIFF
--- a/insights/setup/demo.py
+++ b/insights/setup/demo.py
@@ -86,6 +86,11 @@ class DemoDataFactory:
         if frappe.flags.in_test or os.environ.get("CI"):
             return
 
+        if os.path.exists(self.db_file_path) and os.path.getsize(self.db_file_path) > 0:
+            # If the file already exists and is not empty, skip the download process and proceed directly to the parsing stage.
+            frappe.logger().info(f"Insights: Found existing demo data at {self.db_file_path}, skipping download.")
+            return
+
         import requests
 
         try:


### PR DESCRIPTION
… occur.

https://github.com/frappe/insights/issues/884

The principle is that if this file is not downloaded, an error will occur preventing the correct installation wizard from being executed. This is a very serious issue.

"The current implementation of download_demo_data lacks a local file check. It attempts to download from Google Drive every time, even if the data file is already present in private/files. This causes the Setup Wizard to crash in offline or restricted network environments (like behind a firewall). We should check os.path.exists(self.db_file_path) before calling requests.get."






