### PR TITLE
perf: apply row limit on data store import query

### DIFF
--- a/insights/insights/doctype/insights_data_source_v3/data_warehouse.py
+++ b/insights/insights/doctype/insights_data_source_v3/data_warehouse.py
@@ -409,7 +409,6 @@ class WarehouseTableImporter:
         self.log.db_set("query", ibis.to_sql(self.remote_table), commit=True)
 
     def apply_limit(self, table: Expr) -> Expr:
-
         if not self.primary_key:
             return table.limit(self.settings.row_limit)
 

--- a/insights/insights/doctype/insights_data_source_v3/data_warehouse.py
+++ b/insights/insights/doctype/insights_data_source_v3/data_warehouse.py
@@ -391,10 +391,8 @@ class WarehouseTableImporter:
 
         if hasattr(self.remote_table, "creation"):
             self.primary_key = "creation"
-            self.remote_table = self.remote_table.order_by(ibis.desc("creation"))
         elif hasattr(self.remote_table, "timestamp"):
             self.primary_key = "timestamp"
-            self.remote_table = self.remote_table.order_by(ibis.desc("timestamp"))
         else:
             self.primary_key = ""
 
@@ -405,10 +403,34 @@ class WarehouseTableImporter:
                 self.settings.before_import_script, {"table": self.remote_table}
             )
 
-        self.remote_table = self.remote_table.limit(self.settings.row_limit)
+        self.remote_table = self.apply_limit(self.remote_table)
         self.remote_table_schema = self.remote_table.schema()
 
         self.log.db_set("query", ibis.to_sql(self.remote_table), commit=True)
+
+    def apply_limit(self, table: Expr) -> Expr:
+
+        if not self.primary_key:
+            return table.limit(self.settings.row_limit)
+
+        pk = self.primary_key
+        cutoff_row = (
+            table.order_by(ibis.desc(pk))
+            # OFFSET to the Nth row
+            # Only selects the pk column so the query is a covering index scan
+            .limit(1, offset=self.settings.row_limit - 1)
+            .select(pk)
+            .execute()
+        )
+
+        if len(cutoff_row) == 0:
+            return table
+
+        cutoff_value = cutoff_row[pk].value[0]
+        self._log(f"Row limit cutoff: {pk} >= {cutoff_value}")
+
+        # replace LIMIT with WHERE clause
+        return table.filter(_[pk] >= cutoff_value)
 
     def start_batch_import(self):
         self.warehouse_table_name = self.table.warehouse_table_name

--- a/insights/insights/doctype/insights_data_source_v3/data_warehouse.py
+++ b/insights/insights/doctype/insights_data_source_v3/data_warehouse.py
@@ -524,7 +524,6 @@ class WarehouseTableImporter:
             elapsed = current_time - self.last_log_time
             self.last_log_time = current_time
 
-        print(f"[{now()}] [{elapsed:.1f}s] {message}")
         self.log.log_output(f"[{now()}] [{elapsed:.1f}s] {message}", commit=commit)
 
 


### PR DESCRIPTION
**Problem:**
 When importing large tables (e.g: 2mil rows from `tabInvoice`), each batch query contained:

  ```sql
  SELECT * FROM (
    SELECT * FROM tabInvoice ORDER BY creation DESC LIMIT 2000000  -> runs for every batch
  ) sub
  WHERE sub.creation > bookmark
  ORDER BY creation LIMIT batch_size
```
  The inner subquery forced DB to do a full table sort on every batch

**Solution:** 
find boundary value: 
                                                                       
   ```sql                                                         
     SELECT creation FROM tabInvoice                                                               
     ORDER BY creation DESC                                            
     LIMIT 1 OFFSET 1999999   
```
 get the Nth row's creation value once and then replace the LIMIT with a WHERE clause:
```sql
  SELECT * FROM tabInvoice
  WHERE creation >= cutoff AND creation > bookmark
  ORDER BY creation LIMIT batch_size 
```
**Benchmark:**
for table with 500k rows and memory limit set to 64MB
| Metric | Before | After |
|---|---|---|
| Total duration | 391s | 33s |
| Avg batch latency | 23s | 1.5s |
| Speedup | — | ~12x |

