### PR TITLE
fix: metadata conversion and url detection

### DIFF
--- a/frontend/src2/components/DataTable.vue
+++ b/frontend/src2/components/DataTable.vue
@@ -67,7 +67,16 @@ const columnsMeta = computed(() => {
 })
 
 const isNumberColumn = (col: string) => columnsMeta.value.get(col)?.isNumber
-const isUrl = (value: any): boolean => typeof value === 'string' && value.startsWith('http')
+const isUrl = (value: any): boolean => {
+	if (typeof value !== 'string') return false
+
+	try {
+		const url = new URL(value.trim())
+		return url.protocol === 'http:' || url.protocol === 'https:'
+	} catch {
+		return false
+	}
+}
 
 const $header = ref<HTMLElement>()
 function getColumnWidth(column: string) {

--- a/frontend/src2/components/DataTable.vue
+++ b/frontend/src2/components/DataTable.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { Button, Dialog, FormControl, LoadingIndicator, Rating } from 'frappe-ui'
+import { Button, Dialog, FormControl, LoadingIndicator } from 'frappe-ui'
 import { ChevronLeft, ChevronRight, Download, Plus, Search, Table2Icon } from 'lucide-vue-next'
 import { computed, nextTick, reactive, ref } from 'vue'
 import { createHeaders, formatNumber, getShortNumber } from '../helpers'
@@ -47,6 +47,7 @@ const headers = computed(() => {
 	if (!props.columns?.length) return []
 	return createHeaders(props.columns)
 })
+
 const columnsMeta = computed(() => {
 	if (!props.columns || !props.rows) return new Map()
 
@@ -58,17 +59,6 @@ const columnsMeta = computed(() => {
 		)
 		const metadata = {
 			isNumber: FIELDTYPES.NUMBER.includes(col.type) || hasColorScaleFormatting,
-			isStarRating: false,
-		}
-
-		const values = props.rows!.map((row) => row[name])
-
-		// Check if it's a star rating column
-		if (
-			metadata.isNumber &&
-			(col.name.toLowerCase().includes('rating') || col.name.toLowerCase().includes('stars'))
-		) {
-			metadata.isStarRating = values.every((val) => val >= 0 && val <= 1)
 		}
 
 		meta.set(name, metadata)
@@ -77,7 +67,6 @@ const columnsMeta = computed(() => {
 })
 
 const isNumberColumn = (col: string) => columnsMeta.value.get(col)?.isNumber
-const isStarRating = (col: string) => columnsMeta.value.get(col)?.isStarRating
 const isUrl = (value: any): boolean => typeof value === 'string' && value.startsWith('http')
 
 const $header = ref<HTMLElement>()
@@ -688,10 +677,7 @@ function toggleNewColumn() {
 							height="30px"
 							@dblclick="isNumberColumn(col.name) && props.onDrilldown?.(col, row)"
 						>
-							<template v-if="isStarRating(col.name)">
-								<Rating :modelValue="row[col.name] * 5" :readonly="true" />
-							</template>
-							<template v-else-if="isNumberColumn(col.name)">
+							<template v-if="isNumberColumn(col.name)">
 								{{ _formatNumber(row[col.name]) }}
 							</template>
 							<template v-else-if="isUrl(row[col.name])">


### PR DESCRIPTION
fixes #902 

fixes:
1. **metadata conversion to rating** - relying on simple `includes()` is flaky. The proper implementation should pipe the `Rating` fieldtype to frontend. Now it is not doing that. If you have a simple `Rating` field it will be represented as a decimal. Relying on UI for this is bad. Removing the feature (for now). 

`rating` mapping with `includes()` issue:

| | |
|---|---|
| <img width="285" height="85" alt="image" src="https://github.com/user-attachments/assets/6efe6281-8e57-46ce-84c0-63be9c4cd92b" /> | <img width="222" height="98" alt="image" src="https://github.com/user-attachments/assets/3d6355c0-cc8f-4e0d-a814-16734328886b" /> |

`rating` mapping is not piped to frontend properly (gets passed as `float`/`int`)

| | | |
|---|---|---|
| <img width="290" height="227" alt="image" src="https://github.com/user-attachments/assets/981d440e-392e-4ce4-a0a4-4a98d4113845" /> | <img width="256" height="107" alt="image" src="https://github.com/user-attachments/assets/e8ac87ec-b0ac-4368-a4d3-0e4154fe0718" /> | <img width="119" height="39" alt="image" src="https://github.com/user-attachments/assets/cb990d57-a227-4856-9971-f3b8ef2139c9" /> |


2. **URL detection logic**

| | |
|---|---|
| <img width="357" height="109" alt="image" src="https://github.com/user-attachments/assets/62bd8c13-8a88-4105-96e6-4aee339411b8" /> | <img width="310" height="124" alt="image" src="https://github.com/user-attachments/assets/7a7a54e2-3d9a-4668-a952-2667a601b2e6" /> |

fixed the URL detection issue with proper validation checks.



## After fix

1. `rating` and `stars` fix

| | |
|---|---|
| <img width="290" height="69" alt="image" src="https://github.com/user-attachments/assets/97e26481-d3a2-41b7-aa65-7d2b16d5b1b7" /> | <img width="2001" height="135" alt="image" src="https://github.com/user-attachments/assets/3d6c686e-6e95-4128-a0c4-c843d77dd600" /> |


2. URL fix

| |
|---|
| <img width="149" height="67" alt="image" src="https://github.com/user-attachments/assets/200019d3-7ab3-4bb1-a60b-abee6db8423d" /> |

proper urls work

| |
|---|
| <img width="246" height="97" alt="image" src="https://github.com/user-attachments/assets/b7a8b31d-56a8-4a39-8217-99d89bf9bf73" /> |