### PR TITLE
fix: replace setup wizard with demo data setup 

### DIFF
--- a/frontend/src2/App.vue
+++ b/frontend/src2/App.vue
@@ -5,6 +5,7 @@
 		</div>
 
 		<div class="flex h-full flex-1 flex-col overflow-auto">
+			<DemoDataBanner />
 			<Suspense>
 				<RouterView />
 			</Suspense>
@@ -28,6 +29,7 @@ import { computed, ref, watchEffect } from 'vue'
 import { useRoute } from 'vue-router'
 import { Toaster } from 'vue-sonner'
 import AppSidebar from './components/AppSidebar.vue'
+import DemoDataBanner from './components/DemoDataBanner.vue'
 import { dialogs } from './helpers/confirm_dialog'
 import { attachRealtimeListener, waitUntil } from './helpers/index.ts'
 import { createToast } from './helpers/toasts.ts'

--- a/frontend/src2/App.vue
+++ b/frontend/src2/App.vue
@@ -5,7 +5,6 @@
 		</div>
 
 		<div class="flex h-full flex-1 flex-col overflow-auto">
-			<DemoDataBanner />
 			<Suspense>
 				<RouterView />
 			</Suspense>
@@ -29,7 +28,6 @@ import { computed, ref, watchEffect } from 'vue'
 import { useRoute } from 'vue-router'
 import { Toaster } from 'vue-sonner'
 import AppSidebar from './components/AppSidebar.vue'
-import DemoDataBanner from './components/DemoDataBanner.vue'
 import { dialogs } from './helpers/confirm_dialog'
 import { attachRealtimeListener, waitUntil } from './helpers/index.ts'
 import { createToast } from './helpers/toasts.ts'

--- a/frontend/src2/components/AppSidebar.vue
+++ b/frontend/src2/components/AppSidebar.vue
@@ -20,6 +20,7 @@
 			</div>
 		</div>
 		<div>
+				<DemoDataBanner v-if="!isSidebarCollapsed" class="m-2 p-2" />
 			<TrialBanner v-if="is_fc_site" :is-sidebar-collapsed="isSidebarCollapsed" />
 			<SidebarLink
 				:label="isSidebarCollapsed ? __('Expand') : __('Collapse')"
@@ -57,6 +58,7 @@ import { computed, ref } from 'vue'
 import useSettings from '../settings/settings'
 import Settings from '../settings/Settings.vue'
 import SidebarLink from './SidebarLink.vue'
+import DemoDataBanner from './DemoDataBanner.vue'
 import UserDropdown from './UserDropdown.vue'
 import { TrialBanner } from 'frappe-ui/frappe'
 import { __ } from '../translation'

--- a/frontend/src2/components/DemoDataBanner.vue
+++ b/frontend/src2/components/DemoDataBanner.vue
@@ -24,7 +24,7 @@ async function checkDemoData() {
 watch(
 	() => session.initialized,
 	(val) => val && checkDemoData(),
-	{ immediate: true }
+	{ immediate: true },
 )
 
 async function setupDemoData() {
@@ -56,6 +56,7 @@ function dismiss() {
 
 <template>
 	<div
+		v-if="show && session.user.is_admin"
 		class="flex flex-col gap-3 rounded-lg bg-white px-3 py-2.5 text-sm shadow-sm"
 	>
 		<div class="flex items-start justify-between">

--- a/frontend/src2/components/DemoDataBanner.vue
+++ b/frontend/src2/components/DemoDataBanner.vue
@@ -56,22 +56,27 @@ function dismiss() {
 <template>
 	<div
 		v-if="show && session.user.is_admin"
-		class="flex items-center justify-between gap-3 border-b px-4 py-2.5 text-sm"
+		class="flex flex-col gap-3 rounded-lg bg-white px-3 py-2.5 text-sm shadow-sm"
 	>
-		<span class="text-gray-800">
-			Get started quickly with sample data and a pre-built workbook.
-		</span>
-		<div class="flex items-center gap-2">
-			<Button
-				variant="solid"
-				size="sm"
-				label="Setup Demo Data"
-				:loading="loading"
-				@click="setupDemoData"
-			/>
-			<button v-if="!loading" class="rounded p-0.5 text-gray-600" @click="dismiss">
-				<X class="h-4 w-4" />
+		<div class="flex items-start justify-between">
+			<div class="flex flex-col gap-1">
+				<div class="font-medium text-gray-900">Try demo data</div>
+				<div class="text-xs text-gray-600">
+					Explore with sample data and a pre-built workbook
+				</div>
+			</div>
+			<button
+				v-if="!loading"
+				class="mt-0.5 shrink-0 rounded p-0.5 text-gray-500 hover:text-gray-700"
+				@click="dismiss"
+			>
+				<X class="h-3.5 w-3.5" />
 			</button>
 		</div>
+		<Button label="Setup Demo Data" variant="subtle" :loading="loading" @click="setupDemoData">
+			<template #prefix>
+				<Sparkles class="h-3.5 w-3.5" />
+			</template>
+		</Button>
 	</div>
 </template>

--- a/frontend/src2/components/DemoDataBanner.vue
+++ b/frontend/src2/components/DemoDataBanner.vue
@@ -1,0 +1,77 @@
+<script setup lang="ts">
+import { useStorage } from '@vueuse/core'
+import { call } from 'frappe-ui'
+import { X } from 'lucide-vue-next'
+import { ref, watch } from 'vue'
+import session from '../session'
+import { createToast } from '../helpers/toasts'
+
+const dismissed = useStorage('insights:demo-banner-dismissed', false)
+const loading = ref(false)
+const show = ref(false)
+
+async function checkDemoData() {
+	if (dismissed.value || !session.user.is_admin) return
+	try {
+		const hasDemoData = await call('insights.setup.setup_wizard.check_demo_data_exists')
+		show.value = !hasDemoData
+	} catch {
+		show.value = false
+	}
+}
+
+watch(
+	() => session.initialized,
+	(val) => val && checkDemoData(),
+	{ immediate: true }
+)
+
+async function setupDemoData() {
+	loading.value = true
+	try {
+		await call('insights.setup.setup_wizard.setup_demo_data')
+		show.value = false
+		createToast({
+			title: 'Demo Data Ready',
+			message: 'Sample data with workbook has been set up successfully',
+			variant: 'success',
+		})
+	} catch {
+		createToast({
+			title: 'Setup Failed',
+			message: 'Failed to setup demo data',
+			variant: 'error',
+		})
+	} finally {
+		loading.value = false
+	}
+}
+
+function dismiss() {
+	dismissed.value = true
+	show.value = false
+}
+</script>
+
+<template>
+	<div
+		v-if="show && session.user.is_admin"
+		class="flex items-center justify-between gap-3 border-b px-4 py-2.5 text-sm"
+	>
+		<span class="text-gray-800">
+			Get started quickly with sample data and a pre-built workbook.
+		</span>
+		<div class="flex items-center gap-2">
+			<Button
+				variant="solid"
+				size="sm"
+				label="Setup Demo Data"
+				:loading="loading"
+				@click="setupDemoData"
+			/>
+			<button v-if="!loading" class="rounded p-0.5 text-gray-600" @click="dismiss">
+				<X class="h-4 w-4" />
+			</button>
+		</div>
+	</div>
+</template>

--- a/frontend/src2/components/DemoDataBanner.vue
+++ b/frontend/src2/components/DemoDataBanner.vue
@@ -23,7 +23,7 @@ async function checkDemoData() {
 watch(
 	() => session.initialized,
 	(val) => val && checkDemoData(),
-	{ immediate: true },
+	{ immediate: true }
 )
 
 async function setupDemoData() {
@@ -61,7 +61,7 @@ function dismiss() {
 		<div class="flex items-start justify-between">
 			<div class="flex flex-col gap-1">
 				<div class="font-medium text-gray-900">Try demo data</div>
-				<div class="text-xs text-gray-600">
+				<div class="text-p-xs text-gray-600">
 					Explore with sample data and a pre-built workbook
 				</div>
 			</div>
@@ -74,9 +74,6 @@ function dismiss() {
 			</button>
 		</div>
 		<Button label="Setup Demo Data" variant="subtle" :loading="loading" @click="setupDemoData">
-			<template #prefix>
-				<Sparkles class="h-3.5 w-3.5" />
-			</template>
 		</Button>
 	</div>
 </template>

--- a/frontend/src2/components/DemoDataBanner.vue
+++ b/frontend/src2/components/DemoDataBanner.vue
@@ -23,7 +23,7 @@ async function checkDemoData() {
 watch(
 	() => session.initialized,
 	(val) => val && checkDemoData(),
-	{ immediate: true }
+	{ immediate: true },
 )
 
 async function setupDemoData() {

--- a/frontend/src2/components/DemoDataBanner.vue
+++ b/frontend/src2/components/DemoDataBanner.vue
@@ -1,37 +1,26 @@
 <script setup lang="ts">
 import { useStorage } from '@vueuse/core'
 import { call } from 'frappe-ui'
-import { Sparkle, Sparkles, X } from 'lucide-vue-next'
-import { ref, watch } from 'vue'
-import session from '../session'
+import { Sparkles, X } from 'lucide-vue-next'
+import { computed, ref } from 'vue'
 import { createToast } from '../helpers/toasts'
-import { S } from 'vue-router/dist/router-CWoNjPRp.mjs'
+import session from '../session'
 
 const dismissed = useStorage('insights:demo-banner-dismissed', false)
 const loading = ref(false)
-const show = ref(false)
-
-async function checkDemoData() {
-	if (dismissed.value || !session.user.is_admin) return
-	try {
-		const hasDemoData = await call('insights.setup.setup_wizard.check_demo_data_exists')
-		show.value = !hasDemoData
-	} catch {
-		show.value = false
-	}
-}
-
-watch(
-	() => session.initialized,
-	(val) => val && checkDemoData(),
-	{ immediate: true },
+const show = computed(
+	() =>
+		session.initialized &&
+		!dismissed.value &&
+		session.user.is_admin &&
+		!session.user.has_demo_data,
 )
 
 async function setupDemoData() {
 	loading.value = true
 	try {
 		await call('insights.setup.setup_wizard.setup_demo_data')
-		show.value = false
+		session.user.has_demo_data = true
 		createToast({
 			title: 'Demo Data Ready',
 			message: 'Sample data with workbook has been set up successfully',
@@ -50,15 +39,11 @@ async function setupDemoData() {
 
 function dismiss() {
 	dismissed.value = true
-	show.value = false
 }
 </script>
 
 <template>
-	<div
-		v-if="show && session.user.is_admin"
-		class="flex flex-col gap-3 rounded-lg bg-white px-3 py-2.5 text-sm shadow-sm"
-	>
+	<div v-if="show" class="flex flex-col gap-3 rounded-lg bg-white px-3 py-2.5 text-sm shadow-sm">
 		<div class="flex items-start justify-between">
 			<div class="flex flex-col gap-1">
 				<div class="font-medium text-p-base text-gray-900">Try demo data</div>

--- a/frontend/src2/components/DemoDataBanner.vue
+++ b/frontend/src2/components/DemoDataBanner.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
 import { useStorage } from '@vueuse/core'
 import { call } from 'frappe-ui'
-import { X } from 'lucide-vue-next'
+import { Sparkle, Sparkles, X } from 'lucide-vue-next'
 import { ref, watch } from 'vue'
 import session from '../session'
 import { createToast } from '../helpers/toasts'
+import { S } from 'vue-router/dist/router-CWoNjPRp.mjs'
 
 const dismissed = useStorage('insights:demo-banner-dismissed', false)
 const loading = ref(false)
@@ -55,12 +56,11 @@ function dismiss() {
 
 <template>
 	<div
-		v-if="show && session.user.is_admin"
 		class="flex flex-col gap-3 rounded-lg bg-white px-3 py-2.5 text-sm shadow-sm"
 	>
 		<div class="flex items-start justify-between">
 			<div class="flex flex-col gap-1">
-				<div class="font-medium text-gray-900">Try demo data</div>
+				<div class="font-medium text-p-base text-gray-900">Try demo data</div>
 				<div class="text-p-xs text-gray-600">
 					Explore with sample data and a pre-built workbook
 				</div>
@@ -74,6 +74,9 @@ function dismiss() {
 			</button>
 		</div>
 		<Button label="Setup Demo Data" variant="subtle" :loading="loading" @click="setupDemoData">
+			<template #prefix>
+				<Sparkles class="h-3.5 w-3.5" />
+			</template>
 		</Button>
 	</div>
 </template>

--- a/frontend/src2/session.ts
+++ b/frontend/src2/session.ts
@@ -14,6 +14,7 @@ type SessionUser = {
 	is_v2_instance: boolean
 	default_version: 'v3' | 'v2' | ''
 	has_desk_access?: boolean
+	has_demo_data: boolean
 }
 
 const emptyUser: SessionUser = {
@@ -28,6 +29,7 @@ const emptyUser: SessionUser = {
 	locale: 'en-US',
 	is_v2_instance: false,
 	default_version: '',
+	has_demo_data: false,
 }
 
 const session = reactive({
@@ -64,6 +66,7 @@ async function fetchSessionInfo() {
 		is_user: Boolean(userInfo.is_user),
 		is_v2_instance: Boolean(userInfo.is_v2_instance),
 		has_desk_access: Boolean(userInfo.has_desk_access),
+		has_demo_data: Boolean(userInfo.has_demo_data),
 	})
 }
 

--- a/frontend/src2/settings/GeneralSettings.vue
+++ b/frontend/src2/settings/GeneralSettings.vue
@@ -1,11 +1,52 @@
 <script setup lang="ts">
-import Checkbox from '../components/Checkbox.vue'
+import { call } from 'frappe-ui'
+import { ref, watch } from 'vue'
+import { createToast } from '../helpers/toasts'
 import DatePickerControl from '../query/components/DatePickerControl.vue'
+import session from '../session'
 import SettingItem from './SettingItem.vue'
 import useSettings from './settings'
 
 const settings = useSettings()
 settings.load()
+
+const hasDemoData = ref(true)
+const demoLoading = ref(false)
+
+async function checkDemoData() {
+	try {
+		hasDemoData.value = await call('insights.setup.setup_wizard.check_demo_data_exists')
+	} catch {
+		hasDemoData.value = true
+	}
+}
+
+watch(
+	() => session.initialized,
+	(val) => val && checkDemoData(),
+	{ immediate: true }
+)
+
+async function setupDemoData() {
+	demoLoading.value = true
+	try {
+		await call('insights.setup.setup_wizard.setup_demo_data')
+		hasDemoData.value = true
+		createToast({
+			title: 'Demo Data Ready',
+			message: 'Sample data and workbook have been set up successfully',
+			variant: 'success',
+		})
+	} catch {
+		createToast({
+			title: 'Setup Failed',
+			message: 'Failed to setup demo data',
+			variant: 'error',
+		})
+	} finally {
+		demoLoading.value = false
+	}
+}
 </script>
 
 <template>
@@ -50,6 +91,20 @@ settings.load()
 					'Friday',
 					'Saturday',
 				]"
+			/>
+		</SettingItem>
+
+		<SettingItem
+			v-if="session.user.is_admin && !hasDemoData"
+			label="Demo Data"
+			description="Set up sample data and a pre-built workbook to explore Insights features."
+		>
+			<Button
+				variant="solid"
+				size="sm"
+				label="Setup Demo Data"
+				:loading="demoLoading"
+				@click="setupDemoData"
 			/>
 		</SettingItem>
 

--- a/frontend/src2/settings/GeneralSettings.vue
+++ b/frontend/src2/settings/GeneralSettings.vue
@@ -100,7 +100,7 @@ async function setupDemoData() {
 			description="Set up sample data and a pre-built workbook to explore Insights features."
 		>
 			<Button
-				variant="solid"
+				variant="subtle"
 				size="sm"
 				label="Setup Demo Data"
 				:loading="demoLoading"

--- a/frontend/src2/settings/GeneralSettings.vue
+++ b/frontend/src2/settings/GeneralSettings.vue
@@ -24,7 +24,7 @@ async function checkDemoData() {
 watch(
 	() => session.initialized,
 	(val) => val && checkDemoData(),
-	{ immediate: true }
+	{ immediate: true },
 )
 
 async function setupDemoData() {

--- a/frontend/src2/settings/GeneralSettings.vue
+++ b/frontend/src2/settings/GeneralSettings.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { call } from 'frappe-ui'
-import { ref, watch } from 'vue'
+import { ref } from 'vue'
 import { createToast } from '../helpers/toasts'
 import DatePickerControl from '../query/components/DatePickerControl.vue'
 import session from '../session'
@@ -10,28 +10,13 @@ import useSettings from './settings'
 const settings = useSettings()
 settings.load()
 
-const hasDemoData = ref(true)
 const demoLoading = ref(false)
-
-async function checkDemoData() {
-	try {
-		hasDemoData.value = await call('insights.setup.setup_wizard.check_demo_data_exists')
-	} catch {
-		hasDemoData.value = true
-	}
-}
-
-watch(
-	() => session.initialized,
-	(val) => val && checkDemoData(),
-	{ immediate: true },
-)
 
 async function setupDemoData() {
 	demoLoading.value = true
 	try {
 		await call('insights.setup.setup_wizard.setup_demo_data')
-		hasDemoData.value = true
+		session.user.has_demo_data = true
 		createToast({
 			title: 'Demo Data Ready',
 			message: 'Sample data and workbook have been set up successfully',
@@ -95,7 +80,7 @@ async function setupDemoData() {
 		</SettingItem>
 
 		<SettingItem
-			v-if="session.user.is_admin && !hasDemoData"
+			v-if="session.user.is_admin && !session.user.has_demo_data"
 			label="Demo Data"
 			description="Set up sample data and a pre-built workbook to explore Insights features."
 		>

--- a/insights/api/__init__.py
+++ b/insights/api/__init__.py
@@ -51,11 +51,19 @@ def get_user_info():
         "User", frappe.session.user, ["first_name", "last_name", "user_type"], as_dict=1
     )
 
+    _is_admin = is_admin or frappe.session.user == "Administrator"
+
+    has_demo_data = False
+    if _is_admin:
+        from insights.setup.setup_wizard import check_demo_data_exists
+
+        has_demo_data = check_demo_data_exists()
+
     return {
         "email": frappe.session.user,
         "first_name": user.get("first_name"),
         "last_name": user.get("last_name"),
-        "is_admin": is_admin or frappe.session.user == "Administrator",
+        "is_admin": _is_admin,
         "is_user": is_user or frappe.session.user == "Administrator",
         # TODO: move to `get_session_info` since not user specific
         "country": frappe.db.get_single_value("System Settings", "country"),
@@ -63,6 +71,7 @@ def get_user_info():
         "is_v2_instance": frappe.db.count("Insights Query") > 0,
         "default_version": get_user_default("insights_default_version", frappe.session.user),
         "has_desk_access": user.get("user_type") == "System User",
+        "has_demo_data": has_demo_data,
     }
 
 

--- a/insights/hooks.py
+++ b/insights/hooks.py
@@ -75,11 +75,6 @@ add_to_apps_screen = [
 # 	"filters": "insights.utils.jinja_filters"
 # }
 
-# Setup
-# ------------
-setup_wizard_requires = "assets/insights/js/setup_wizard.js"
-setup_wizard_stages = "insights.setup.setup_wizard.get_setup_stages"
-
 # Installation
 # ------------
 

--- a/insights/setup/demo.py
+++ b/insights/setup/demo.py
@@ -73,10 +73,10 @@ class DemoDataFactory:
 
     def demo_data_exists(self):
         tables = get_data_source_tables(self.data_source.name)
-        tables_exists = len(tables) == 8
+        tables_exists = len(tables) >= 8
 
         links_count = frappe.db.count("Insights Table Link v3", {"data_source": self.data_source.name})
-        links_exists = links_count == 8
+        links_exists = links_count >= 8
 
         sample_workbook_exists = frappe.db.exists("Insights Workbook", {"title": "Order Analysis"})
 

--- a/insights/setup/setup_wizard.py
+++ b/insights/setup/setup_wizard.py
@@ -15,7 +15,7 @@ def check_demo_data_exists() -> bool:
         db_connections,
     )
 
-    if not frappe.db.exists("Insights Data Source v3", "demo_data"):
+    if not frappe.db.exists("Insights Data Source v3", "demo_data", cache=True):
         return False
 
     with db_connections():

--- a/insights/setup/setup_wizard.py
+++ b/insights/setup/setup_wizard.py
@@ -1,38 +1,31 @@
 # Copyright (c) 2022, Frappe Technologies Pvt. Ltd. and Contributors
 # License: GNU General Public License v3. See license.txt
 
-
 import os
 
 import frappe
-from frappe import _
 
 from insights.decorators import insights_whitelist
 from insights.setup.demo import DemoDataFactory
 
 
-def get_setup_stages(args=None):
-    return [
-        {
-            "status": _("Setting up demo data"),
-            "fail_msg": _("Failed to setup demo data"),
-            "tasks": [
-                {
-                    "fn": setup_demo_data,
-                    "args": args,
-                    "fail_msg": _("Failed to setup demo data"),
-                }
-            ],
-        },
-        {
-            "status": _("Wrapping up"),
-            "fail_msg": _("Failed to login"),
-            "tasks": [{"fn": wrap_up, "args": args, "fail_msg": _("Failed to login")}],
-        },
-    ]
+@insights_whitelist(role="Insights Admin")
+def check_demo_data_exists() -> bool:
+    from insights.insights.doctype.insights_data_source_v3.insights_data_source_v3 import (
+        db_connections,
+    )
+
+    if not frappe.db.exists("Insights Data Source v3", "demo_data"):
+        return False
+
+    with db_connections():
+        factory = DemoDataFactory()
+        factory.initialize()
+        return factory.demo_data_exists()
 
 
-def setup_demo_data(args):
+@insights_whitelist(role="Insights Admin")
+def setup_demo_data():
     if frappe.flags.in_test or os.environ.get("CI"):
         return
 
@@ -42,33 +35,4 @@ def setup_demo_data(args):
         frappe.db.commit()
     except Exception:
         frappe.log_error("Insights: Demo Data Setup Failed")
-
-
-def wrap_up(args):
-    frappe.local.message_log = []
-    set_user_as_insights_admin(args)
-    login_as_first_user(args)
-
-
-def set_user_as_insights_admin(args):
-    # if developer mode is enabled, first user step is skipped, hence no user is created
-    if not args.get("email") or not frappe.db.exists("User", args.get("email")):
-        return
-    user = frappe.get_doc("User", args.get("email"))
-    user.add_roles("Insights Admin", "Insights User")
-
-
-def login_as_first_user(args):
-    if args.get("email") and hasattr(frappe.local, "login_manager"):
-        frappe.local.login_manager.login_as(args.get("email"))
-
-
-@insights_whitelist(role="Insights Admin")
-def enable_setup_wizard_complete():
-    frappe.db.set_value(
-        "Installed Application",
-        {"app_name": "insights"},
-        "is_setup_complete",
-        1,
-    )
-    frappe.clear_cache()
+        frappe.throw("Failed to setup demo data")

--- a/insights/www/insights.py
+++ b/insights/www/insights.py
@@ -13,10 +13,6 @@ no_cache = 1
 
 
 def get_context(context):
-    setup_complete = check_setup_complete()
-    if not setup_complete:
-        frappe.local.flags.redirect_location = "/app/setup-wizard"
-        raise frappe.Redirect
     is_v2_site = frappe.db.count("Insights Query", cache=True) > 0
     if not is_v2_site:
         continue_to_v3(context)
@@ -88,8 +84,3 @@ def redirect_to_v2():
     raise frappe.Redirect
 
 
-def check_setup_complete():
-    try:
-        return frappe.is_setup_complete()
-    except AttributeError:
-        return frappe.db.get_single_value("System Settings", "setup_complete")

--- a/insights/www/insights.py
+++ b/insights/www/insights.py
@@ -82,5 +82,3 @@ def redirect_to_v2():
         path = "/insights_v2"
     frappe.local.flags.redirect_location = path
     raise frappe.Redirect
-
-


### PR DESCRIPTION
Removes setup wizard stages from Insights and adds functionality to setup demo data if it has not been setup

<img width="156" height="474" alt="image" src="https://github.com/user-attachments/assets/b7d05e82-3242-4c4b-afdd-6a0db68b8f48" />
<img width="824" height="518" alt="image" src="https://github.com/user-attachments/assets/b90c7486-c843-4df1-bb2b-5303ddb7e941" />


