### PR TITLE
fix: dashboard preview generation

### DIFF
--- a/frontend/src2/main.ts
+++ b/frontend/src2/main.ts
@@ -1,15 +1,16 @@
 import { frappeRequest, setConfig } from 'frappe-ui'
+import { spritePlugin } from 'frappe-ui/icons'
 import { GridItem, GridLayout } from 'grid-layout-plus'
 import { createPinia } from 'pinia'
-import { createApp } from 'vue'
+import { createApp, watchEffect } from 'vue'
 import App from './App.vue'
 import { registerControllers, registerGlobalComponents } from './globals.ts'
 import './index.css'
 import router from './router.ts'
 import { translationPlugin } from './translation.ts'
-import { spritePlugin } from 'frappe-ui/icons'
 //@ts-ignore
 import { telemetryPlugin } from 'frappe-ui/frappe'
+import session from './session.ts'
 
 setConfig('resourceFetcher', frappeRequest)
 
@@ -19,9 +20,15 @@ const pinia = createPinia()
 app.use(pinia)
 app.use(router)
 app.use(spritePlugin)
-app.use(telemetryPlugin, { app_name: 'insights' })
 app.component('grid-layout', GridLayout)
 app.component('grid-item', GridItem)
+
+const stop = watchEffect(() => {
+	if (session.isLoggedIn) {
+		app.use(telemetryPlugin, { app_name: 'insights' })
+		stop()
+	}
+})
 
 app.config.errorHandler = (err, vm, info) => {
 	console.groupCollapsed('Unhandled Error in: ', info)


### PR DESCRIPTION
* telemetry plugin calls `frappe.utils.telemetry.pulse.client.is_enabled` which isn't allowed for guest, so it throws to login page
