### PR TITLE
refactor: migrate stored tables to per-data-source schema

### DIFF
--- a/insights/insights/doctype/insights_data_source_v3/data_warehouse.py
+++ b/insights/insights/doctype/insights_data_source_v3/data_warehouse.py
@@ -183,11 +183,15 @@ class WarehouseTableWriter:
 
         total_rows = 0
         try:
-            with insights.warehouse.get_write_connection(self.database) as db:
+            with insights.warehouse.get_write_connection() as db:
                 self._log(f"Committing {len(self._parquet_files)} parquet files to '{self.table_name}'")
 
                 with suppress(CatalogException):
                     db.create_database(self.database)
+
+                db.raw_sql(f"USE '{self.database}'")
+
+                self._log(f"Switched to '{self.database}' database")
 
                 parquet_glob = str(self._temp_dir / "*.parquet")
                 merged = db.read_parquet(parquet_glob)

--- a/insights/insights/doctype/insights_data_source_v3/data_warehouse.py
+++ b/insights/insights/doctype/insights_data_source_v3/data_warehouse.py
@@ -94,18 +94,20 @@ class Warehouse:
         return WarehouseTable(data_source, table_name)
 
     def get_table_writer(
-        self, table_name: str, schema: ibis.Schema, mode: str = "replace", log_fn=None
+        self, table_name: str, schema: ibis.Schema, database: str = "main", mode: str = "replace", log_fn=None
     ) -> "WarehouseTableWriter":
         """Create a table writer for batch inserts with automatic cleanup.
 
         Usage:
-            with warehouse.get_table_writer("table", schema) as writer:
+            with warehouse.get_table_writer("table", schema, database="my_schema") as writer:
                 writer.insert(df1)
                 writer.insert(df2)
             # On successful exit, data is committed to warehouse
             # On exception, temp files are cleaned up automatically
         """
-        return WarehouseTableWriter(table_name, table_schema=schema, mode=mode, log_fn=log_fn)
+        return WarehouseTableWriter(
+            table_name, table_schema=schema, database=database, mode=mode, log_fn=log_fn
+        )
 
 
 class WarehouseTableWriter:
@@ -184,6 +186,9 @@ class WarehouseTableWriter:
             with insights.warehouse.get_write_connection(self.database) as db:
                 self._log(f"Committing {len(self._parquet_files)} parquet files to '{self.table_name}'")
 
+                with suppress(CatalogException):
+                    db.create_database(self.database)
+
                 parquet_glob = str(self._temp_dir / "*.parquet")
                 merged = db.read_parquet(parquet_glob)
 
@@ -235,15 +240,11 @@ class WarehouseTable:
 
         self.data_source = data_source
         self.table_name = table_name
-        self.warehouse_table_name = self.format_table_name(data_source, table_name)
+        self.schema = get_warehouse_schema_name(data_source)
+        self.warehouse_table_name = frappe.scrub(table_name)
         self.table_doc_name = get_table_name(data_source, table_name)
 
         self.validate()
-
-    @staticmethod
-    def format_table_name(data_source: str, table_name: str) -> str:
-        """Format a warehouse table name from data source and table name."""
-        return f"{frappe.scrub(data_source)}.{frappe.scrub(table_name)}"
 
     def validate(self):
         if not self.data_source:
@@ -253,7 +254,7 @@ class WarehouseTable:
 
     def get_ibis_table(self, import_if_not_exists: bool = True) -> Expr:
         try:
-            return insights.warehouse.db.table(self.warehouse_table_name)
+            return insights.warehouse.db.table(self.warehouse_table_name, database=self.schema)
         except TableNotFound:
             if import_if_not_exists:
                 self.enqueue_import()
@@ -261,6 +262,7 @@ class WarehouseTable:
                 return insights.warehouse.db.create_table(
                     self.warehouse_table_name,
                     schema=remote_table.schema(),
+                    database=self.schema,
                     temp=True,
                     overwrite=True,
                 )
@@ -437,7 +439,10 @@ class WarehouseTableImporter:
         try:
             batch_size = self.calculate_batch_size()
             with insights.warehouse.get_table_writer(
-                self.warehouse_table_name, self.remote_table_schema, log_fn=self._log
+                self.warehouse_table_name,
+                self.remote_table_schema,
+                database=self.table.schema,
+                log_fn=self._log,
             ) as writer:
                 total_rows = self.process_batches(batch_size, writer)
                 self.log.rows_imported = total_rows
@@ -544,3 +549,8 @@ def execute_warehouse_table_import(data_source: str, table_name: str):
     table = WarehouseTable(data_source, table_name)
     importer = WarehouseTableImporter(table)
     importer.start_import()
+
+
+def get_warehouse_schema_name(data_source: str) -> str:
+    """Return the DuckDB schema name for a given data source name."""
+    return frappe.scrub(data_source).replace(".", "_")

--- a/insights/insights/doctype/insights_data_source_v3/insights_data_source_v3.py
+++ b/insights/insights/doctype/insights_data_source_v3/insights_data_source_v3.py
@@ -89,10 +89,8 @@ class InsightsDataSourceDocument:
                 {
                     "database_type": "DuckDB",
                     "database_name": None,  # this should never be used
-                    "schema": self.name.replace(".", "_"),
                 }
             )
-            insights.warehouse.create_database(self.schema)
 
         if self.is_site_db:
             self.db_set("is_frappe_db", 1)

--- a/insights/patches.txt
+++ b/insights/patches.txt
@@ -51,3 +51,4 @@ insights.insights.doctype.insights_table_v3.patches.force_sync_tables #5
 insights.patches.enable_data_store
 insights.insights.doctype.insights_data_source_v3.patches.set_type
 execute:frappe.db.set_single_value("Insights Settings", "apply_user_permissions", 1)
+insights.patches.migrate_warehouse_tables_to_schemas

--- a/insights/patches/migrate_warehouse_tables_to_schemas.py
+++ b/insights/patches/migrate_warehouse_tables_to_schemas.py
@@ -1,0 +1,46 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+# Migrates legacy flat warehouse tables stored as "scrub_data_source.scrub_table" in the
+# main DuckDB schema to proper per-data-source schemas: schema.table_name
+
+import os
+from contextlib import suppress
+
+import frappe
+
+
+def execute():
+    from insights.insights.doctype.insights_data_source_v3.data_warehouse import (
+        Warehouse,
+        get_warehouse_schema_name,
+    )
+
+    w = Warehouse()
+
+    if not os.path.exists(w.get_db_path()):
+        return
+
+    stored_tables = frappe.get_all(
+        "Insights Table v3",
+        filters={"stored": 1},
+        fields=["data_source", "table"],
+    )
+
+    if not stored_tables:
+        return
+
+    with w.get_write_connection() as db:
+        for row in stored_tables:
+            schema = get_warehouse_schema_name(row.data_source)
+            table = frappe.scrub(row.table)
+            legacy_name = f"{frappe.scrub(row.data_source)}.{table}"
+
+            with suppress(Exception):
+                db.create_database(schema)
+
+            with suppress(Exception):
+                expr = db.table(legacy_name)
+                db.create_table(table, expr, database=schema, overwrite=True)
+                db.drop_table(legacy_name, force=True)
+                frappe.logger().info(f"Insights warehouse: migrated '{legacy_name}' → '{schema}'.'{table}'")

--- a/insights/patches/migrate_warehouse_tables_to_schemas.py
+++ b/insights/patches/migrate_warehouse_tables_to_schemas.py
@@ -11,6 +11,9 @@ import frappe
 
 
 def execute():
+    from duckdb import CatalogException
+    from ibis.common.exceptions import TableNotFound
+
     from insights.insights.doctype.insights_data_source_v3.data_warehouse import (
         Warehouse,
         get_warehouse_schema_name,
@@ -30,17 +33,28 @@ def execute():
     if not stored_tables:
         return
 
+    logger = frappe.logger()
+
     with w.get_write_connection() as db:
         for row in stored_tables:
             schema = get_warehouse_schema_name(row.data_source)
             table = frappe.scrub(row.table)
             legacy_name = f"{frappe.scrub(row.data_source)}.{table}"
 
-            with suppress(Exception):
+            # CatalogException is raised when the schema already exists — that is fine.
+            with suppress(CatalogException):
                 db.create_database(schema)
 
-            with suppress(Exception):
+            # TableNotFound means the legacy table was never written; skip silently.
+            try:
                 expr = db.table(legacy_name)
                 db.create_table(table, expr, database=schema, overwrite=True)
                 db.drop_table(legacy_name, force=True)
-                frappe.logger().info(f"Insights warehouse: migrated '{legacy_name}' → '{schema}'.'{table}'")
+                logger.info(f"Insights warehouse: migrated '{legacy_name}' → '{schema}'.'{table}'")
+            except TableNotFound:
+                logger.warning(f"Insights warehouse: legacy table '{legacy_name}' not found, skipping.")
+            except Exception:
+                logger.exception(
+                    f"Insights warehouse: failed to migrate '{legacy_name}' → '{schema}'.'{table}'. "
+                    "Manual remediation may be required."
+                )


### PR DESCRIPTION
Previously, tables imported into DuckDB were stored as flat dotted names (`site_db.tabsales_order`) in the `main` schema, now we store them in their respective `schema` per-data-source