### PR TITLE
fix: home_dir error when loading xlsx extension

### DIFF
--- a/insights/api/__init__.py
+++ b/insights/api/__init__.py
@@ -108,6 +108,8 @@ def get_file_data(filename: str):
     file_name = frappe.scrub(file_name)
 
     con = ibis.duckdb.connect()
+    private_folder = frappe.utils.get_files_path(is_private=1)
+    con.raw_sql(f"SET home_directory='{private_folder}'")
     if ext in ["xlsx"]:
         table = con.read_xlsx(file_path)
     else:

--- a/insights/insights/doctype/insights_data_source_v3/connectors/duckdb.py
+++ b/insights/insights/doctype/insights_data_source_v3/connectors/duckdb.py
@@ -20,13 +20,16 @@ def get_duckdb_connection(data_source, read_only=True):
 
 
 def get_local_duckdb_connection(db_name, read_only=True):
-    path = os.path.join(os.path.realpath(get_files_path(is_private=1)), f"{db_name}.duckdb")
+    private_folder = os.path.realpath(get_files_path(is_private=1))
+    path = os.path.join(private_folder, f"{db_name}.duckdb")
 
     if not os.path.exists(path):
         db = ibis.duckdb.connect(path)
         db.disconnect()
 
-    return ibis.duckdb.connect(path, read_only=read_only, enable_external_access=False)
+    db = ibis.duckdb.connect(path, read_only=read_only, enable_external_access=False)
+    db.raw_sql(f"SET home_directory='{private_folder}'")
+    return db
 
 
 def get_http_duckdb_connection(data_source, name, db_name):


### PR DESCRIPTION
DuckDB requires `home_directory` to locate installed extensions (e.g. `excel` for xlsx). In environments where `$HOME` is unset (production servers, Docker containers), this raised:

```
duckdb.IOException: IO Error: Can't find the home directory at ''
Specify a home directory using the SET home_directory='/path/to/dir' option.
```

**To reproduce:**
```python
import os; os.environ.pop("HOME", None)
import ibis
ibis.duckdb.connect().read_xlsx("/path/to/file.xlsx")  # raises IOException
```

Fixes: #954 