### PR TITLE
fix: letters dropping in ContentEditable component

### DIFF
--- a/frontend/src2/components/ContentEditable.vue
+++ b/frontend/src2/components/ContentEditable.vue
@@ -16,6 +16,7 @@
 
 <script setup>
 import { onMounted, ref, watch } from 'vue'
+import { useDebounceFn } from '@vueuse/core'
 
 function replaceAll(str, search, replacement) {
 	return str.split(search).join(replacement)
@@ -66,13 +67,24 @@ function valuePropPresent() {
 	return props.value != undefined
 }
 
-function update(event) {
-	if (event == 'blur') emit('blur', currentContent())
+function emitContent(value) {
 	if (valuePropPresent()) {
-		emit('change', currentContent())
+		emit('change', value)
 	} else {
-		emit('update:modelValue', currentContent())
+		emit('update:modelValue', value)
 	}
+}
+
+const debouncedEmit = useDebounceFn(emitContent, 100)
+
+function update(event) {
+	if (event == 'blur') {
+		debouncedEmit.cancel()
+		emit('blur', currentContent())
+		emitContent(currentContent())
+		return
+	}
+	debouncedEmit(currentContent())
 }
 
 function onPaste(event) {
@@ -96,20 +108,24 @@ onMounted(() => {
 	updateContent(valuePropPresent() ? props.value : props.modelValue ?? '')
 })
 
+function isFocused() {
+	return document.activeElement === element.value
+}
+
 watch(
 	() => props.modelValue ?? props.value,
 	(newval, oldval) => {
-		if (newval != currentContent()) {
+		if (!isFocused() && newval != currentContent()) {
 			updateContent(newval ?? '')
 		}
-	}
+	},
 )
 
 watch(
 	() => props.noHtml,
 	(newval, oldval) => {
 		updateContent(props.modelValue ?? '')
-	}
+	},
 )
 
 watch(
@@ -117,7 +133,7 @@ watch(
 	(newval, oldval) => {
 		updateContent(props.modelValue ?? '')
 	},
-	{ flush: 'post' }
+	{ flush: 'post' },
 )
 </script>
 

--- a/frontend/src2/components/ContentEditable.vue
+++ b/frontend/src2/components/ContentEditable.vue
@@ -16,7 +16,6 @@
 
 <script setup>
 import { onMounted, ref, watch } from 'vue'
-import { useDebounceFn } from '@vueuse/core'
 
 function replaceAll(str, search, replacement) {
 	return str.split(search).join(replacement)
@@ -75,16 +74,11 @@ function emitContent(value) {
 	}
 }
 
-const debouncedEmit = useDebounceFn(emitContent, 100)
-
 function update(event) {
 	if (event == 'blur') {
-		debouncedEmit.cancel()
 		emit('blur', currentContent())
-		emitContent(currentContent())
-		return
 	}
-	debouncedEmit(currentContent())
+	emitContent(currentContent())
 }
 
 function onPaste(event) {
@@ -114,7 +108,7 @@ function isFocused() {
 
 watch(
 	() => props.modelValue ?? props.value,
-	(newval, oldval) => {
+	(newval) => {
 		if (!isFocused() && newval != currentContent()) {
 			updateContent(newval ?? '')
 		}
@@ -123,14 +117,14 @@ watch(
 
 watch(
 	() => props.noHtml,
-	(newval, oldval) => {
+	() => {
 		updateContent(props.modelValue ?? '')
 	},
 )
 
 watch(
 	() => props.tag,
-	(newval, oldval) => {
+	() => {
 		updateContent(props.modelValue ?? '')
 	},
 	{ flush: 'post' },

--- a/frontend/src2/dashboard/DashboardBuilder.vue
+++ b/frontend/src2/dashboard/DashboardBuilder.vue
@@ -65,7 +65,9 @@ const verticalCompact = useStorage('dashboard_vertical_compact', true)
 			<div class="flex items-center justify-between p-4 pb-3">
 				<ContentEditable
 					class="cursor-text rounded-sm text-lg font-semibold !text-gray-800 focus:ring-2 focus:ring-gray-700 focus:ring-offset-4"
-					v-model="dashboard.doc.title"
+					:modelValue="dashboard.doc.title"
+					@returned="dashboard.doc.title = $event"
+					@blur="dashboard.doc.title = $event"
 					placeholder="Untitled Dashboard"
 				></ContentEditable>
 				<div class="flex gap-2">

--- a/frontend/src2/query/components/NativeQueryEditor.vue
+++ b/frontend/src2/query/components/NativeQueryEditor.vue
@@ -114,8 +114,10 @@ const completions = computed(() => {
 					<DataSourceSelector v-model="data_source" placeholder="Select a data source" />
 					<ContentEditable
 						class="flex h-7 cursor-text items-center justify-center rounded bg-white px-2 text-base text-gray-800 focus-visible:ring-1 focus-visible:ring-gray-600"
-						v-model="query.doc.title"
 						placeholder="Untitled Dashboard"
+						:modelValue="query.doc.title"
+						@returned="query.doc.title = $event"
+						@blur="query.doc.title = $event"
 					></ContentEditable>
 				</div>
 				<div class="flex-1 overflow-hidden">

--- a/frontend/src2/query/components/ScriptQueryEditor.vue
+++ b/frontend/src2/query/components/ScriptQueryEditor.vue
@@ -53,7 +53,9 @@ function handleSaveVariables(variables: any[]) {
 			<div class="flex flex-shrink-0 items-center gap-1 border-b p-1">
 				<ContentEditable
 					class="flex h-7 cursor-text items-center justify-center rounded bg-white px-2 text-base text-gray-800 focus-visible:ring-1 focus-visible:ring-gray-600"
-					v-model="query.doc.title"
+					:modelValue="query.doc.title"
+					@returned="query.doc.title = $event"
+					@blur="query.doc.title = $event"
 					placeholder="Untitled Dashboard"
 				></ContentEditable>
 			</div>

--- a/frontend/src2/query/components/source_selector/DataSourceSelector.vue
+++ b/frontend/src2/query/components/source_selector/DataSourceSelector.vue
@@ -25,6 +25,7 @@ const dataSourceOptions = computed(() => {
 
 <template>
 	<Autocomplete
+		class="!w-fit"
 		:options="dataSourceOptions"
 		:modelValue="currentSourceName"
 		@update:modelValue="currentSourceName = $event?.value || ''"


### PR DESCRIPTION
                                                                                                                                                                                 
- Fix `ContentEditable` to prevent overwriting user input mid-edit. Remove debouncing and rely on the isFocused() guard in the watcher — the prop only updates the DOM when not focused.
- Also update `DashboardBuilder`, `NativeQueryEditor`, and `ScriptQueryEditor` to use explicit `@blur`/`@returned` instead of `v-model` so titles only save on blur/enter.