### PR TITLE
fix: misc fiscal year fixes

### DIFF
--- a/frontend/src2/query/helpers.ts
+++ b/frontend/src2/query/helpers.ts
@@ -20,6 +20,7 @@ import { h } from 'vue'
 import { copy } from '../helpers'
 import { FIELDTYPES, GranularityType } from '../helpers/constants'
 import dayjs from '../helpers/dayjs'
+import useSettings from '../settings/settings'
 import {
 	Cast,
 	CastArgs,
@@ -151,7 +152,15 @@ export function getFormattedDate(date: string, granularity: GranularityType) {
 
 	if (granularity === 'fiscal_year') {
 		const d = dayjs(date)
-		return `FY ${d.format('YYYY')}-${d.add(1, 'year').format('YY')}`
+		const fiscalYearStart = useSettings().doc.fiscal_year_start || '04-01'
+		const fiscalStartMonth = dayjs(fiscalYearStart).month()
+		const fiscalStartDay = dayjs(fiscalYearStart).date()
+
+		const fiscalStartThisYear = d.month(fiscalStartMonth).date(fiscalStartDay)
+		const startYear = d.isBefore(fiscalStartThisYear) ? d.year() - 1 : d.year()
+		const endYear = startYear + 1
+
+		return `FY ${startYear}-${String(endYear).slice(-2)}`
 	}
 
 	const dayjsFormat: Record<string, string> = {

--- a/frontend/src2/query/query.ts
+++ b/frontend/src2/query/query.ts
@@ -747,7 +747,15 @@ export function makeQuery(name: string) {
 		}
 
 		if (FIELDTYPES.DATE.includes(dim.data_type)) {
+			if (!value) {
+				filters.push({ column: column(dim.column_name), operator: 'is_not_set', value: '' })
+				return filters
+			}
+
 			const start = dayjs(value)
+			// since fiscal year is not supported in dayjs
+			// we will treat it as year for drill down purposes
+			const granularity = dim.granularity === 'fiscal_year' ? 'year' : dim.granularity
 
 			filters.push({
 				column: column(dim.column_name),
@@ -755,8 +763,8 @@ export function makeQuery(name: string) {
 				value: start.format('YYYY-MM-DD HH:mm:ss'),
 			})
 
-			if (dim.granularity) {
-				const end = start.clone().add(1, dim.granularity)
+			if (granularity) {
+				const end = start.clone().add(1, granularity)
 				filters.push({
 					column: column(dim.column_name),
 					operator: '<',


### PR DESCRIPTION
closes #967 
  - Fiscal year formatting now uses the fiscal year start setting to get the correct year.
  - Drilldown on fiscal year grouped data now works: `fiscal_year` is mapped to `year` for date range filters.
  -  Drilldown on null date rows uses `is_not_set` filter instead of running unfiltered. Now shows only relevant rows
  - Fixes error: `Arguments order_approved_at:timestamp(6) and Literal(Invalid Date):string are not comparable` on drill down
