### PR TITLE
fix: join column auto-match, column resolution, and smarter chart defaults

### DIFF
--- a/frontend/src2/charts/components/MeasurePicker.vue
+++ b/frontend/src2/charts/components/MeasurePicker.vue
@@ -22,6 +22,12 @@ const props = defineProps<{
 	columnOptions: ColumnOption[]
 }>()
 
+// True when at least one available column is a pre-aggregated measure (i.e. it
+// came from a summarize/pivot_wider step in the source query). In this case we
+// skip the "pick a function" step by pre-selecting `sum`, since the data is
+// already aggregated and users just want to pick the column directly.
+const sourceHasMeasures = computed(() => props.columnOptions.some((c) => c.is_measure))
+
 const measure = defineModel<Measure>({
 	required: true,
 	default: () => {
@@ -58,9 +64,28 @@ const expressionMeasure = computed<ExpressionMeasure | undefined>({
 
 const searchQuery = ref('')
 
+// Tracks whether the user manually clicked "back" (ChevronLeft) to change the
+// aggregation. When true, we don't auto-fill the aggregation so the user can
+// choose a different function.
+const userResetAggregation = ref(false)
+
 watchEffect(() => {
 	if (!columnMeasure.value && !expressionMeasure.value) {
 		resetMeasure()
+	}
+})
+
+// When the source columns include pre-aggregated measures, pre-select `sum` as
+// the aggregation so the picker opens straight to the column list — skipping
+// the "pick a function" step that would otherwise produce confusing
+// "sum of sum_of_revenue" labels.
+// We skip this if the user explicitly clicked back to pick a different function.
+watchEffect(() => {
+	if (!sourceHasMeasures.value) return
+	if (userResetAggregation.value) return
+	const cm = columnMeasure.value
+	if (cm && !cm.aggregation) {
+		cm.aggregation = 'sum'
 	}
 })
 
@@ -74,7 +99,16 @@ watchEffect(() => {
 		cm.measure_name.includes(cm.column_name)
 
 	if (cm.aggregation && cm.column_name && hasDefaultLabel) {
-		cm.measure_name = `${cm.aggregation}_of_${cm.column_name}`
+		// If the column is already a pre-aggregated measure (flagged via is_measure on
+		// the column option, or its name starts with an aggregation prefix), keep the
+		// column name as-is rather than wrapping it as e.g. "sum_of_total_requests".
+		const aggregationPrefixes = aggregations.map((a) => `${a}_`)
+		const columnIsAlreadyMeasure =
+			props.columnOptions.find((o) => o.value === cm.column_name)?.is_measure ||
+			aggregationPrefixes.some((prefix) => cm.column_name.startsWith(prefix))
+		cm.measure_name = columnIsAlreadyMeasure
+			? cm.column_name
+			: `${cm.aggregation}_of_${cm.column_name}`
 	}
 })
 
@@ -130,6 +164,14 @@ function resetMeasure() {
 	}
 }
 
+// Called when the user explicitly clicks ChevronLeft to go back and pick a
+// different aggregation function. We set a flag so the watchEffect above doesn't
+// immediately re-fill `sum` and trap the user on the column list.
+function resetAggregation() {
+	userResetAggregation.value = true
+	resetMeasure()
+}
+
 const label = ref('')
 </script>
 
@@ -171,7 +213,7 @@ const label = ref('')
 								v-else-if="columnMeasure.aggregation"
 								class="mb-1 flex items-center"
 							>
-								<Button class="!h-6 !w-6" @click.prevent.stop="resetMeasure">
+								<Button class="!h-6 !w-6" @click.prevent.stop="resetAggregation">
 									<template #icon>
 										<ChevronLeft
 											class="h-4 w-4 text-gray-700"
@@ -190,7 +232,11 @@ const label = ref('')
 										:key="option.value"
 										class="flex h-7 flex-shrink-0 cursor-pointer items-center justify-between rounded px-2.5 text-base hover:bg-gray-100"
 										@click.prevent.stop="
-											columnMeasure.aggregation = option.value
+											() => {
+												if (!columnMeasure) return
+												columnMeasure.aggregation = option.value
+												userResetAggregation = false
+											}
 										"
 									>
 										<span>{{ option.label }}</span>

--- a/frontend/src2/query/components/JoinSelectorDialog.vue
+++ b/frontend/src2/query/components/JoinSelectorDialog.vue
@@ -1,19 +1,21 @@
 <script setup lang="ts">
+import { Combobox, MultiSelect } from 'frappe-ui'
 import { Braces } from 'lucide-vue-next'
 import { computed, inject, reactive, watch } from 'vue'
 import useTableStore from '../../data_source/tables'
 import { wheneverChanges } from '../../helpers'
 import { joinTypes } from '../../helpers/constants'
+import { __ } from '../../translation'
 import { JoinArgs } from '../../types/query.types'
 import { workbookKey } from '../../workbook/workbook'
 import { column, expression, query_table, table } from '../helpers'
+import { Query } from '../query'
 import InlineExpression from './InlineExpression.vue'
-import { __ } from '../../translation'
 import {
 	handleOldProps,
+	useQueryColumnOptions,
 	useTableColumnOptions,
 	useTableOptions,
-	useQueryColumnOptions,
 } from './join_utils'
 
 const props = defineProps<{ join?: JoinArgs }>()
@@ -48,14 +50,23 @@ const selectedTable = computed({
 			return join.table.query_name
 		}
 	},
-	set(option: any) {
-		if (option.data_source && option.table_name) {
+	set(value: string) {
+		const option = [...queryTableOptions.value, ...tableOptions.options].find(
+			(o) => o.value === value,
+		)
+		if (!option) return
+		if (
+			'data_source' in option &&
+			'table_name' in option &&
+			option.data_source &&
+			option.table_name
+		) {
 			join.table = table({
 				data_source: option.data_source,
 				table_name: option.table_name,
 			})
 		}
-		if (option.query_name) {
+		if ('query_name' in option && option.query_name) {
 			join.table = query_table({
 				workbook: option.workbook,
 				query_name: option.query_name,
@@ -158,11 +169,11 @@ const groupedTableOptions = computed(() => {
 	return [
 		{
 			group: 'Queries',
-			items: queryTableOptions.value,
+			options: queryTableOptions.value,
 		},
 		{
 			group: 'Tables',
-			items: tableOptions.options,
+			options: tableOptions.options,
 		},
 	]
 })
@@ -245,14 +256,15 @@ function reset() {
 
 				<!-- Fields -->
 				<div class="flex w-full flex-col gap-3 overflow-auto p-0.5 text-base">
-					<div>
-						<Autocomplete
-							:label="__('Right Table')"
+					<div class="flex flex-col gap-1.5">
+						<label class="block text-xs text-ink-gray-5">{{ __('Right Table') }}</label>
+						<Combobox
 							:placeholder="__('Table')"
+							:open-on-focus="true"
 							v-model="selectedTable"
 							:loading="tableOptions.loading"
 							:options="groupedTableOptions"
-							@update:query="tableOptions.searchText = $event"
+							@input="tableOptions.searchText = $event"
 						/>
 					</div>
 					<div>
@@ -264,21 +276,24 @@ function reset() {
 								"
 							>
 								<div class="flex-1">
-									<Autocomplete
-										:label="__('Left Column')"
+									<label class="mb-1 block text-xs text-gray-600">{{
+										__('Left Column')
+									}}</label>
+									<Combobox
 										:placeholder="__('Column')"
 										:options="query.result.columnOptions"
 										:modelValue="join.join_condition.left_column.column_name"
 										@update:modelValue="
-											join.join_condition.left_column.column_name =
-												$event?.value
+											join.join_condition.left_column.column_name = $event
 										"
 									/>
 								</div>
 								<div class="flex h-7 flex-shrink-0 items-center font-mono">=</div>
 								<div class="flex-1">
-									<Autocomplete
-										:label="__('Right Column')"
+									<label class="mb-1 block text-xs text-gray-600">{{
+										__('Right Column')
+									}}</label>
+									<Combobox
 										:placeholder="__('Column')"
 										:loading="
 											rightTableColumnOptions.loading ||
@@ -290,8 +305,7 @@ function reset() {
 										]"
 										:modelValue="join.join_condition.right_column.column_name"
 										@update:modelValue="
-											join.join_condition.right_column.column_name =
-												$event?.value
+											join.join_condition.right_column.column_name = $event
 										"
 									/>
 								</div>
@@ -348,8 +362,7 @@ function reset() {
 						<label class="mb-1 block text-xs text-gray-600">{{
 							__('Select Columns to Add')
 						}}</label>
-						<Autocomplete
-							:multiple="true"
+						<MultiSelect
 							:placeholder="__('Columns')"
 							:loading="
 								rightTableColumnOptions.loading || queryTableColumnOptions.loading
@@ -360,7 +373,7 @@ function reset() {
 							]"
 							:modelValue="join.select_columns?.map((c) => c.column_name)"
 							@update:modelValue="
-								join.select_columns = $event?.map((o: any) => column(o.value)) || []
+								join.select_columns = $event?.map((o: any) => column(o)) || []
 							"
 						/>
 					</div>

--- a/frontend/src2/query/query.ts
+++ b/frontend/src2/query/query.ts
@@ -46,6 +46,7 @@ import {
 	Summarize,
 	SummarizeArgs,
 	UnionArgs,
+	aggregations,
 } from '../types/query.types'
 import { InsightsQueryv3, QueryVariable } from '../types/workbook.types'
 import useWorkbook from '../workbook/workbook'
@@ -98,6 +99,28 @@ export function makeQuery(name: string) {
 			return query.doc.operations.slice(0, activeOperationIdx.value + 1)
 		}
 		return query.doc.operations.slice()
+	})
+
+	const measureColumns = computed(() => {
+		const measureNames = new Set<string>()
+		let seenSummarize = false
+		for (const op of currentOperations.value) {
+			if (op.type === 'summarize') {
+				op.measures.forEach((m) => measureNames.add(m.measure_name))
+				seenSummarize = true
+			} else if (op.type === 'pivot_wider') {
+				op.values.forEach((m) => measureNames.add(m.measure_name))
+				seenSummarize = true
+			} else if (seenSummarize && op.type === 'rename') {
+				// Track renames that happen after a summarize/pivot_wider so that
+				// a measure renamed to e.g. "total_revenue" is still detected.
+				if (measureNames.has(op.column.column_name)) {
+					measureNames.delete(op.column.column_name)
+					measureNames.add(op.new_name)
+				}
+			}
+		}
+		return Array.from(measureNames)
 	})
 
 	const dataSource = computed(() => getDataSource(currentOperations.value))
@@ -159,24 +182,33 @@ export function makeQuery(name: string) {
 				adhoc_filters: adhocFilters.value,
 				force,
 			})
-			.then((response: any) => {
-				if (!response) return
+		.then((response: any) => {
+			if (!response) return
 
-				result.value.executedSQL = response.sql
-				result.value.columns = response.columns
-				result.value.rows = response.rows
-				result.value.totalRowCount = 0
-				result.value.formattedRows = getFormattedRows(result.value, query.doc.operations)
-				result.value.columnOptions = result.value.columns.map((column) => ({
+			result.value.executedSQL = response.sql
+			result.value.columns = response.columns
+			result.value.rows = response.rows
+			result.value.totalRowCount = 0
+			result.value.formattedRows = getFormattedRows(result.value, query.doc.operations)
+
+			const aggregationPrefixes = aggregations.map((a) => `${a}_`)
+			const isMeasureColumn = (name: string) =>
+				measureColumns.value.includes(name) ||
+				aggregationPrefixes.some((prefix) => name.startsWith(prefix))
+
+			result.value.columnOptions = result.value.columns.map((column) => {
+				return {
 					label: column.name,
 					value: column.name,
 					description: column.type,
 					query: query.doc.name,
 					data_type: column.type,
-				}))
-				result.value.timeTaken = response.time_taken
-				result.value.lastExecutedAt = new Date()
+					is_measure: isMeasureColumn(column.name),
+				}
 			})
+			result.value.timeTaken = response.time_taken
+			result.value.lastExecutedAt = new Date()
+		})
 			.catch(() => {
 				result.value = { ...EMPTY_RESULT }
 			})

--- a/frontend/src2/types/query.types.ts
+++ b/frontend/src2/types/query.types.ts
@@ -207,6 +207,7 @@ export type GroupedDropdownOption = {
 export type ColumnOption = DropdownOption & {
 	query: string
 	data_type: ColumnDataType
+	is_measure?: boolean
 }
 
 export type GroupedColumnOption = {

--- a/insights/insights/doctype/insights_data_source_v3/connectors/frappe_db.py
+++ b/insights/insights/doctype/insights_data_source_v3/connectors/frappe_db.py
@@ -133,9 +133,9 @@ def get_frappedb_table_links(data_source):
             all_links.append(
                 _dict(
                     {
-                        "left_table": link.options,
+                        "left_table": "tab" + link.options,
                         "left_column": "name",
-                        "right_table": link.parent,
+                        "right_table": "tab" + link.parent,
                         "right_column": link.fieldname,
                     }
                 )
@@ -144,9 +144,9 @@ def get_frappedb_table_links(data_source):
             all_links.append(
                 _dict(
                     {
-                        "left_table": link.parent,
+                        "left_table": "tab" + link.parent,
                         "left_column": "name",
-                        "right_table": link.options,
+                        "right_table": "tab" + link.options,
                         "right_column": "parent",
                     }
                 )

--- a/insights/insights/doctype/insights_data_source_v3/ibis_utils.py
+++ b/insights/insights/doctype/insights_data_source_v3/ibis_utils.py
@@ -143,10 +143,50 @@ class IbisQueryBuilder:
         return _table
 
     def get_column(self, column_name, throw=True):
+        # 1. Exact match
         if column_name in self.query.columns:
             return self.query[column_name]
+
+        # 2. Sanitized name match (handles capitalisation / special-char differences)
         if sanitize_name(column_name) in self.query.columns:
             return self.query[sanitize_name(column_name)]
+
+        # 3. Suffix match: handles the case where a stored column name was produced
+        #    in live-connection mode (e.g. "tabhd_ticket_priority_name") but the
+        #    query now runs against the warehouse, where rename_duplicate_columns
+        #    prepends the data-source schema prefix and produces a longer name
+        #    (e.g. "support_frappe_io_tabhd_ticket_priority_name").
+        #    We only match when exactly one column ends with "_{column_name}" so
+        #    that ambiguous / short suffixes are never silently resolved to the
+        #    wrong column.
+        suffix = f"_{column_name}"
+        suffix_matches = [col for col in self.query.columns if col.endswith(suffix)]
+        if len(suffix_matches) == 1:
+            return self.query[suffix_matches[0]]
+
+        # 4. Schema-prefix-strip match: handles the case where a stored column name
+        #    was produced in old warehouse mode (e.g. "frappe_cloud_tabinvoice_item_parent")
+        #    but the query now runs without the data-source schema prefix, producing
+        #    the shorter name "tabinvoice_item_parent" (new warehouse behaviour after
+        #    PR #953 + revert of get_ibis_table_name).
+        #    We scan all DatabaseTable nodes in the current ibis expression tree to
+        #    collect the schema names that are actually present in this query, then
+        #    try stripping each as a leading prefix before checking for a column match.
+        all_dt = self.query.op().find_topmost(DatabaseTable)
+        schemas = {
+            dt.namespace.database
+            for dt in all_dt
+            if dt.namespace and dt.namespace.database and dt.namespace.database != "main"
+        }
+        for schema in schemas:
+            prefix = f"{schema}_"
+            if column_name.startswith(prefix):
+                remainder = column_name[len(prefix) :]
+                if remainder in self.query.columns:
+                    return self.query[remainder]
+                if sanitize_name(remainder) in self.query.columns:
+                    return self.query[sanitize_name(remainder)]
+
         if throw:
             frappe.throw(f"Column {column_name} does not exist in the table")
 
@@ -848,24 +888,7 @@ def get_ibis_table_name(table: IbisQuery):
     dt = table.op().find_topmost(DatabaseTable)
     if not dt:
         return "right_table"
-    name = dt[0].name
-    # For warehouse tables, reconstruct the qualified name by prepending the
-    # DuckDB schema (data source name). Before PR #953, warehouse tables were
-    # stored with a dot-delimited name like "frappe_cloud.tabinvoice_item" in
-    # the main schema, so get_ibis_table_name returned "frappe_cloud.tabinvoice_item"
-    # and rename_duplicate_columns produced prefixes like "frappe_cloud_tabinvoice_item_".
-    # After #953, tables live in per-data-source schemas, so DatabaseTable.name is
-    # just "tabinvoice_item". We include namespace.database here so that the same
-    # prefixed column names are produced, preserving existing stored queries.
-    namespace = dt[0].namespace
-    if (
-        namespace
-        and namespace.database
-        and namespace.database != "main"
-        and dt[0].source is insights.warehouse.db
-    ):
-        name = f"{namespace.database}.{name}"
-    return name
+    return dt[0].name
 
 
 def sanitize_name(name):

--- a/insights/patches.txt
+++ b/insights/patches.txt
@@ -52,3 +52,4 @@ insights.patches.enable_data_store
 insights.insights.doctype.insights_data_source_v3.patches.set_type
 execute:frappe.db.set_single_value("Insights Settings", "apply_user_permissions", 1)
 insights.patches.migrate_warehouse_tables_to_schemas
+insights.patches.fix_table_link_names

--- a/insights/patches/fix_table_link_names.py
+++ b/insights/patches/fix_table_link_names.py
@@ -1,0 +1,30 @@
+import frappe
+
+from insights.insights.doctype.insights_data_source_v3.insights_data_source_v3 import after_request
+
+
+def execute():
+    """
+    Table links for Frappe DB data sources were stored using the raw doctype name
+    (e.g. "HD Ticket") instead of the actual MariaDB table name (e.g. "tabHD Ticket").
+    This caused join column auto-selection to fail because `op.table.table_name` uses
+    the `tab`-prefixed name from `Insights Table v3`.
+
+    This patch regenerates all table links with the correct `tab`-prefixed names.
+    """
+    frappe_db_sources = frappe.get_all(
+        "Insights Data Source v3",
+        filters=[["is_frappe_db", "=", 1]],
+        pluck="name",
+    )
+
+    for source in frappe_db_sources:
+        try:
+            doc = frappe.get_doc("Insights Data Source v3", source)
+            doc.update_table_links(force=True)
+            frappe.db.commit()
+        except Exception:
+            frappe.log_error(title=f"Error updating table links for {source}")
+            frappe.db.rollback()
+
+    after_request()


### PR DESCRIPTION
## What's changed

**Replace `Autocomplete` with `Combobox` in the Join dialog**
Swapped out the old `Autocomplete` component for `Combobox` (and `MultiSelect` for the column selection). The grouped options structure was updated to match the new API (`items` → `options`), and the value binding is now a plain string instead of an option object.

**Fix join column auto-match**
Table links for Frappe DB sources were stored with the raw doctype name (e.g. `HD Ticket`) instead of the actual MariaDB table name (`tabHD Ticket`). This caused join column auto-selection to silently fail. Fixed by prepending `tab` when building table links, and added a patch to regenerate existing stored links with the correct names.

**Better column resolution (suffix/prefix fallback)**
`get_column` was only doing exact + sanitized-name lookups. Added suffix matching (for when warehouse mode prepends a schema prefix to column names) and schema-prefix-strip matching (for the reverse case, where stored column names have a prefix the current query doesn't). Also simplified `get_ibis_table_name` to just return `dt[0].name` — the old qualified-name logic was causing the mismatches these fallbacks now handle.

**Smarter chart defaults when the source query is summarized**
Added `is_measure` to `ColumnOption`, populated by scanning the operation list for `summarize`/`pivot_wider` steps (with rename tracking). When at least one measure column is present, `MeasurePicker` auto-selects `sum` and skips the aggregation picker step, so users land straight on the column list. Labels are also kept clean — e.g. `total_requests` instead of `sum_of_total_requests`.