### PR TITLE
fix(v3): safety patches for ibis evaluation and ad-hoc filter context

### DIFF
--- a/insights/insights/doctype/insights_data_source_v3/ibis_utils.py
+++ b/insights/insights/doctype/insights_data_source_v3/ibis_utils.py
@@ -383,15 +383,6 @@ class IbisQueryBuilder:
             self.get_column(filter_value.column_name) if getattr(filter_value, "column_name", None) is not None else None
         )
 
-        # If it's a visual filter literal value wrapper, extract the actual value
-        if (
-            right_column is None
-            and isinstance(filter_value, dict)
-            and filter_value.get("type") in ["Value", "value"]
-            and "value" in filter_value
-        ):
-            filter_value = filter_value.get("value")
-
         if filter_operator in ["contains", "not_contains"]:
             filter_value = filter_value.replace("%", "")
 

--- a/insights/insights/doctype/insights_data_source_v3/ibis_utils.py
+++ b/insights/insights/doctype/insights_data_source_v3/ibis_utils.py
@@ -380,8 +380,17 @@ class IbisQueryBuilder:
             frappe.throw(f"Operator {filter_operator} is not supported")
 
         right_column = (
-            self.get_column(filter_value.column_name) if hasattr(filter_value, "column_name") else None
+            self.get_column(filter_value.column_name) if getattr(filter_value, "column_name", None) is not None else None
         )
+
+        # If it's a visual filter literal value wrapper, extract the actual value
+        if (
+            right_column is None
+            and isinstance(filter_value, dict)
+            and filter_value.get("type") in ["Value", "value"]
+            and "value" in filter_value
+        ):
+            filter_value = filter_value.get("value")
 
         if filter_operator in ["contains", "not_contains"]:
             filter_value = filter_value.replace("%", "")
@@ -401,7 +410,7 @@ class IbisQueryBuilder:
 
             filter_value = [start, end]
 
-        right_value = right_column or filter_value
+        right_value = right_column if right_column is not None else filter_value
         return operator_fn(left, right_value)
 
     def get_operator(self, operator):

--- a/insights/insights/doctype/insights_query_v3/insights_query_v3.py
+++ b/insights/insights/doctype/insights_query_v3/insights_query_v3.py
@@ -461,6 +461,9 @@ def import_query(query, workbook):
 
 @contextmanager
 def set_adhoc_filters(filters):
-    frappe.local.insights_adhoc_filters = filters or getattr(frappe.local, "insights_adhoc_filters", {})
+    # If frappe.local.insights_adhoc_filters exists but is None, getattr returns None.
+    # We must ensure it's a dict.
+    current = getattr(frappe.local, "insights_adhoc_filters", None)
+    frappe.local.insights_adhoc_filters = filters or current or {}
     yield
     frappe.local.insights_adhoc_filters = None


### PR DESCRIPTION
This PR fixes two critical issues in the v3 Query Builder:
1. Fixes ad-hoc filter injection by correctly handling visual filter literal value wrappers.
2. Fixes unsafe Ibis expression truth-value checks using 'is not None' instead of direct boolean evaluation.
3. Ensures 'set_adhoc_filters' context manager always yields a dictionary to prevent downstream failures.