### PR TITLE
feat: add `upsert` strategy for incremental sync

### DIFF
--- a/insights/insights/doctype/insights_data_source_v3/data_warehouse.py
+++ b/insights/insights/doctype/insights_data_source_v3/data_warehouse.py
@@ -85,7 +85,14 @@ class Warehouse:
         return WarehouseTable(data_source, table_name)
 
     def get_table_writer(
-        self, table_name: str, schema: ibis.Schema, database: str = "main", mode: str = "replace", log_fn=None
+        self,
+        table_name: str,
+        schema: ibis.Schema,
+        database: str = "main",
+        mode: str = "replace",
+        primary_key_column: str = "",
+        cursor_column: str = "",
+        log_fn=None,
     ) -> "WarehouseTableWriter":
         """Create a table writer for batch inserts with automatic cleanup.
 
@@ -97,7 +104,13 @@ class Warehouse:
             # On exception, temp files are cleaned up automatically
         """
         return WarehouseTableWriter(
-            table_name, table_schema=schema, database=database, mode=mode, log_fn=log_fn
+            table_name,
+            table_schema=schema,
+            database=database,
+            mode=mode,
+            primary_key_column=primary_key_column,
+            cursor_column=cursor_column,
+            log_fn=log_fn,
         )
 
 
@@ -119,12 +132,16 @@ class WarehouseTableWriter:
         table_schema: ibis.Schema,
         database: str = "main",
         mode: str = "replace",
+        primary_key_column: str = "",
+        cursor_column: str = "",
         log_fn=None,
     ):
         self.database = database
         self.table_name = table_name
         self.table_schema = table_schema
         self.mode = mode  # 'replace' or 'append'
+        self.primary_key_column = primary_key_column
+        self.cursor_column = cursor_column
         self._log = log_fn or (lambda *args, **kwargs: None)
 
         self._temp_dir: Path | None = None
@@ -187,8 +204,11 @@ class WarehouseTableWriter:
                 parquet_glob = str(self._temp_dir / "*.parquet")
                 merged = db.read_parquet(parquet_glob)
 
-                if self.mode == "append" and self._table_exists(db):
-                    db.insert(self.table_name, merged)
+                if self._table_exists(db):
+                    if self.mode == "append":
+                        db.insert(self.table_name, merged)
+                    elif self.mode == "upsert":
+                        self._upsert(db, merged)
                 else:
                     db.create_table(self.table_name, merged, schema=self.table_schema, overwrite=True)
 
@@ -208,6 +228,41 @@ class WarehouseTableWriter:
             return db.list_tables(like=f"^{self.table_name}$")
         except Exception:
             return False
+
+    def _upsert(self, db: DuckDBBackend, incoming: Table) -> None:
+        if not self.primary_key_column or not self.cursor_column:
+            raise RuntimeError("Upsert mode requires both cursor and primary key columns")
+
+        source_query = ibis.to_sql(incoming, dialect="duckdb", pretty=False)
+        merge_stmt = self._build_merge_statement(source_query)
+        self._log(f"MERGE Query:\n{merge_stmt}")
+        db.raw_sql(merge_stmt)
+
+    def _build_merge_statement(self, source_query: str) -> str:
+        source_alias = "source"
+        target_alias = "target"
+
+        def quote_ident(name: str) -> str:
+            return '"' + name.replace('"', '""') + '"'
+
+        def qualified_column(name: str, table: str) -> str:
+            return f"{table}.{quote_ident(name)}"
+
+        assignments = ", ".join(
+            f"{quote_ident(name)} = {qualified_column(name, source_alias)}"
+            for name in self.table_schema.names
+        )
+        insert_columns = ", ".join(quote_ident(name) for name in self.table_schema.names)
+        insert_values = ", ".join(qualified_column(name, source_alias) for name in self.table_schema.names)
+
+        return (
+            f"MERGE INTO {quote_ident(self.table_name)} AS {target_alias} "
+            f"USING ({source_query}) AS {source_alias} "
+            f"ON {qualified_column(self.primary_key_column, target_alias)} = "
+            f"{qualified_column(self.primary_key_column, source_alias)} "
+            f"WHEN MATCHED THEN UPDATE SET {assignments} "
+            f"WHEN NOT MATCHED THEN INSERT ({insert_columns}) VALUES ({insert_values})"
+        )
 
     def rollback(self) -> None:
         """Rollback and cleanup all temporary files."""
@@ -292,8 +347,10 @@ class WarehouseTableImporter:
         self.table = table
         self.remote_table: Table = None
         self.remote_table_schema = None
-        self.primary_key = ""
+        self.cursor_column = ""
+        self.dedupe_key_column = ""
         self.warehouse_table_name = ""
+        self.sync_strategy = "Append Only"
         self.writer_mode = "replace"  # overridden to "append" for incremental syncs
 
         self.log = None
@@ -385,7 +442,9 @@ class WarehouseTableImporter:
                 "row_limit",
                 "before_import_script",
                 "sync_mode",
+                "sync_strategy",
                 "sync_cursor_column",
+                "sync_primary_key_column",
                 "sync_from",
                 "last_sync_bookmark",
             ],
@@ -401,7 +460,9 @@ class WarehouseTableImporter:
             frappe.db.get_single_value("Insights Settings", "max_memory_usage") or 512
         )
         self.settings.sync_mode = table_doc.sync_mode or "Full"
+        self.settings.sync_strategy = table_doc.sync_strategy or "Append Only"
         self.settings.sync_cursor_column = table_doc.sync_cursor_column or ""
+        self.settings.sync_primary_key_column = table_doc.sync_primary_key_column or ""
         self.settings.sync_from = table_doc.sync_from  # Datetime or None
         self.settings.last_sync_bookmark = table_doc.last_sync_bookmark or ""
         self.log.db_set(
@@ -413,7 +474,9 @@ class WarehouseTableImporter:
         )
         self._log(
             f"Settings: sync_mode={self.settings.sync_mode}"
+            f", strategy={self.settings.sync_strategy}"
             f", cursor={self.settings.sync_cursor_column or 'N/A'}"
+            f", key={self.settings.sync_primary_key_column or 'N/A'}"
             f", sync_from={self.settings.sync_from or 'N/A'}"
             f", bookmark={self.settings.last_sync_bookmark or 'N/A'}"
             f", row_limit={self.settings.row_limit}"
@@ -453,27 +516,30 @@ class WarehouseTableImporter:
 
     def _prepare_full_table(self) -> None:
         if hasattr(self.remote_table, "creation"):
-            self.primary_key = "creation"
+            self.cursor_column = "creation"
         elif hasattr(self.remote_table, "timestamp"):
-            self.primary_key = "timestamp"
+            self.cursor_column = "timestamp"
         else:
-            self.primary_key = ""
+            self.cursor_column = ""
+
+        self.dedupe_key_column = ""
 
         self._apply_before_import_script()
         self.remote_table = self.apply_limit(self.remote_table)
         self.writer_mode = "replace"
 
     def _prepare_incremental_table(self) -> None:
-        pk = self.settings.sync_cursor_column
-        self.primary_key = pk
+        self.cursor_column = self.settings.sync_cursor_column
+        self.dedupe_key_column = self.settings.sync_primary_key_column
+        self.sync_strategy = self.settings.sync_strategy or "Append Only"
 
         self._apply_before_import_script()
 
         bookmark = self._resolve_incremental_bookmark()
-        self._log(f"Incremental sync: {pk} > {bookmark}")
-        self.remote_table = self.remote_table.filter(_[pk] > bookmark)
+        self._log(f"Incremental sync: {self.cursor_column} > {bookmark}")
+        self.remote_table = self.remote_table.filter(_[self.cursor_column] > bookmark)
 
-        self.writer_mode = "append"
+        self.writer_mode = "upsert" if self.sync_strategy == "Update or Insert" else "append"
 
     def _resolve_incremental_bookmark(self):
         """Return the cursor value to filter from for incremental sync, following this precedence:
@@ -503,10 +569,10 @@ class WarehouseTableImporter:
         )
 
     def apply_limit(self, table: Expr) -> Expr:
-        if not self.primary_key:
+        if not self.cursor_column:
             return table.limit(self.settings.row_limit)
 
-        pk = self.primary_key
+        pk = self.cursor_column
         cutoff_row = (
             table.order_by(ibis.desc(pk, nulls_first=False))
             # OFFSET to the Nth row
@@ -535,6 +601,8 @@ class WarehouseTableImporter:
                 self.remote_table_schema,
                 database=self.table.schema,
                 mode=self.writer_mode,
+                primary_key_column=self.dedupe_key_column,
+                cursor_column=self.cursor_column,
                 log_fn=self._log,
             ) as writer:
                 total_rows = self.process_batches(batch_size, writer)
@@ -564,9 +632,9 @@ class WarehouseTableImporter:
 
     def process_batches(self, batch_size: int, writer: WarehouseTableWriter) -> int:
         remote_table = self.remote_table
-        if self.primary_key:
+        if self.cursor_column:
             remote_table = remote_table.order_by(
-                ibis.asc(self.primary_key, nulls_first=True),
+                ibis.asc(self.cursor_column, nulls_first=True),
             )
 
         batch_number = 0
@@ -579,17 +647,17 @@ class WarehouseTableImporter:
 
             batch = writer.insert(batch)
 
-            batch_count = batch.count().execute()
-            total_rows += int(batch_count)
+            batch_count = int(batch.count().execute())
+            total_rows += batch_count
 
             self._log(f"Rows: {batch_count} Total Rows: {total_rows}")
 
-            if batch_count < batch_size or not self.primary_key:
+            if batch_count < batch_size or not self.cursor_column:
                 break
 
-            max_pk = batch[self.primary_key].max().execute()
-            self._log(f"Bookmark: {max_pk}")
-            remote_table = remote_table.filter(_[self.primary_key] > max_pk)
+            last_cursor = batch[self.cursor_column].max().execute()
+            self._log(f"Bookmark: {last_cursor}")
+            remote_table = remote_table.filter(_[self.cursor_column] > last_cursor)
             batch_number += 1
 
         self._log(f"Total Batches: {batch_number + 1} Total Rows: {total_rows}")
@@ -615,11 +683,11 @@ class WarehouseTableImporter:
         t.stored = 1
         t.last_synced_on = frappe.utils.now()
 
-        if self.settings.sync_mode == "Incremental" and self.primary_key:
+        if self.settings.sync_mode == "Incremental" and self.cursor_column:
             new_bookmark = self._read_warehouse_bookmark()
             if new_bookmark is not None:
                 t.last_sync_bookmark = str(new_bookmark)
-                self._log(f"Bookmark updated: {self.primary_key} = {new_bookmark}")
+            self._log(f"Bookmark updated: {self.cursor_column} = {new_bookmark}")
 
         t.save(ignore_permissions=True)
 
@@ -633,7 +701,7 @@ class WarehouseTableImporter:
             wh_table = insights.warehouse.db.table(
                 self.table.warehouse_table_name, database=self.table.schema
             )
-            return wh_table[self.primary_key].max().execute()
+            return wh_table[self.cursor_column].max().execute()
         except Exception:
             self._log("Warning: could not read bookmark from warehouse table.")
             return None

--- a/insights/insights/doctype/insights_table_v3/insights_table_v3.json
+++ b/insights/insights/doctype/insights_table_v3/insights_table_v3.json
@@ -14,9 +14,13 @@
   "stored",
   "sync_section",
   "sync_mode",
-  "sync_cursor_column",
   "sync_from",
+  "column_break_poei",
+  "sync_strategy",
+  "sync_cursor_column",
+  "sync_primary_key_column",
   "last_sync_bookmark",
+  "section_break_mdzv",
   "before_import_script"
  ],
  "fields": [
@@ -68,8 +72,7 @@
   },
   {
    "fieldname": "sync_section",
-   "fieldtype": "Section Break",
-   "label": "Incremental Sync"
+   "fieldtype": "Section Break"
   },
   {
    "default": "Full",
@@ -79,12 +82,29 @@
    "options": "Full\nIncremental"
   },
   {
+   "default": "Append Only",
    "depends_on": "eval:doc.sync_mode == 'Incremental'",
-   "description": "Column used to track sync progress. Use <b>modified</b> if rows can be updated (syncs new and changed rows). Use <b>creation</b> if rows are append-only (syncs only new rows, faster).",
+   "description": "Choose how incremental sync writes rows: <b>Append Only</b> adds new rows, while <b>Update or Insert</b> updates matching keys and inserts new rows.",
+   "fieldname": "sync_strategy",
+   "fieldtype": "Select",
+   "label": "Sync Strategy",
+   "options": "Append Only\nUpdate or Insert"
+  },
+  {
+   "depends_on": "eval:doc.sync_mode == 'Incremental'",
+   "description": "Temporal column used to detect rows that changed since the last sync. Use <b>modified</b> for mutable tables and <b>creation</b> for append-only tables.",
    "fieldname": "sync_cursor_column",
    "fieldtype": "Data",
    "label": "Cursor Column",
    "mandatory_depends_on": "eval:doc.sync_mode == 'Incremental'"
+  },
+  {
+   "depends_on": "eval:doc.sync_mode == 'Incremental' && doc.sync_strategy == 'Update or Insert'",
+   "description": "Stable key used to identify the latest version of each logical row during incremental upserts.",
+   "fieldname": "sync_primary_key_column",
+   "fieldtype": "Data",
+   "label": "Primary Key Column",
+   "mandatory_depends_on": "eval:doc.sync_mode == 'Incremental' && doc.sync_strategy == 'Update or Insert'"
   },
   {
    "depends_on": "eval:doc.sync_mode == 'Incremental'",
@@ -106,11 +126,19 @@
    "fieldtype": "Code",
    "label": "Before Import Script",
    "options": "Python"
+  },
+  {
+   "fieldname": "column_break_poei",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "section_break_mdzv",
+   "fieldtype": "Section Break"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-04-18 00:00:00.000000",
+ "modified": "2026-05-17 11:46:50.112615",
  "modified_by": "Administrator",
  "module": "Insights",
  "name": "Insights Table v3",

--- a/insights/insights/doctype/insights_table_v3/insights_table_v3.py
+++ b/insights/insights/doctype/insights_table_v3/insights_table_v3.py
@@ -35,6 +35,8 @@ class InsightsTablev3(Document):
         sync_cursor_column: DF.Data | None
         sync_from: DF.Datetime | None
         sync_mode: DF.Literal["Full", "Incremental"]
+        sync_primary_key_column: DF.Data | None
+        sync_strategy: DF.Literal["Append Only", "Update or Insert"]
         table: DF.Data
     # end: auto-generated types
 
@@ -61,26 +63,19 @@ class InsightsTablev3(Document):
             # Can't connect right now — skip validation rather than blocking save.
             return
 
-        if not self.sync_cursor_column:
-            frappe.throw(
-                "Incremental sync requires a Cursor Column. "
-                "Set it to the datetime column that marks when rows were created (e.g., <b>creation</b>)."
-            )
+        self.sync_strategy = self.sync_strategy or "Append Only"
 
         if not self.sync_cursor_column:
-            for candidate in ("creation", "timestamp"):
-                if candidate in remote.columns:
+            for candidate in ("modified", "creation", "timestamp"):
+                if candidate in remote.columns and remote[candidate].type().is_temporal():
                     self.sync_cursor_column = candidate
-                    return
+                    break
+
+        if not self.sync_cursor_column:
             frappe.throw(
                 "Incremental sync requires a Cursor Column. "
-                "Set it to the datetime column that marks when rows were created (e.g., <b>creation</b>)."
+                "Set it to the datetime column that tracks when rows changed (for example <b>modified</b> or <b>creation</b>)."
             )
-            return
-
-        # Auto-detected candidates are known-good; only validate user-specified columns.
-        if self.sync_cursor_column in ("creation", "timestamp"):
-            return
 
         if self.sync_cursor_column not in remote.columns:
             frappe.throw(
@@ -93,6 +88,18 @@ class InsightsTablev3(Document):
                 f"Cursor Column <b>{self.sync_cursor_column}</b> must be a datetime/date column, "
                 f"but its type is <b>{col_type}</b>."
             )
+
+        if self.sync_strategy == "Update or Insert":
+            if not self.sync_primary_key_column:
+                frappe.throw(
+                    "Incremental upsert sync requires a Primary Key Column. "
+                    "Set it to the stable column that uniquely identifies each logical row."
+                )
+
+            if self.sync_primary_key_column not in remote.columns:
+                frappe.throw(
+                    f"Primary Key Column <b>{self.sync_primary_key_column}</b> does not exist in <b>{self.table}</b>."
+                )
 
     @staticmethod
     def bulk_create(data_source: str, tables: list[str]):

--- a/insights/tests/test_warehouse.py
+++ b/insights/tests/test_warehouse.py
@@ -1,0 +1,168 @@
+import tempfile
+from contextlib import contextmanager, suppress
+from pathlib import Path
+from unittest.mock import patch
+
+import ibis
+import pandas as pd
+
+import insights
+from insights.insights.doctype.insights_data_source_v3.connectors.duckdb import open_local_duckdb
+from insights.insights.doctype.insights_data_source_v3.data_warehouse import WarehouseTableWriter
+from insights.tests.base import InsightsIntegrationTestCase
+
+
+class TestWarehouse(InsightsIntegrationTestCase):
+    def make_schema(self):
+        return ibis.schema({"id": "int64", "value": "string", "modified": "timestamp"})
+
+    def make_frame(self, rows):
+        frame = pd.DataFrame(rows)
+        frame["modified"] = pd.to_datetime(frame["modified"])
+        return frame
+
+    @contextmanager
+    def warehouse_db(self):
+        with tempfile.TemporaryDirectory(prefix="insights_warehouse_test_") as tmpdir:
+            db = open_local_duckdb(
+                str(Path(tmpdir) / "warehouse.duckdb"),
+                read_only=False,
+                allowed_dir=str(Path(tempfile.gettempdir())),
+            )
+            try:
+                yield db
+            finally:
+                with suppress(Exception):
+                    db.disconnect()
+
+    def patched_write_connection(self, db):
+        @contextmanager
+        def get_write_connection(database=None, timeout=30):
+            if database:
+                db.raw_sql(f"USE '{database}'")
+            yield db
+
+        return get_write_connection
+
+    def read_rows(self, db, table_name):
+        rows = db.table(table_name).order_by("id").execute()
+        rows["modified"] = rows["modified"].dt.strftime("%Y-%m-%d %H:%M:%S")
+        return rows.to_dict("records")
+
+    def test_writer_creates_table_on_first_commit(self):
+        with self.warehouse_db() as db:
+            with patch.object(
+                insights.warehouse,
+                "get_write_connection",
+                self.patched_write_connection(db),
+            ):
+                with WarehouseTableWriter(
+                    "warehouse_writer_create",
+                    table_schema=self.make_schema(),
+                    database="main",
+                    mode="replace",
+                ) as writer:
+                    writer.insert(
+                        self.make_frame(
+                            [
+                                {"id": 1, "value": "alpha", "modified": "2024-01-01 00:00:00"},
+                                {"id": 2, "value": "beta", "modified": "2024-01-02 00:00:00"},
+                            ]
+                        )
+                    )
+                    rows_written = writer.commit()
+            self.assertEqual(rows_written, 2)
+            self.assertEqual(
+                self.read_rows(db, "warehouse_writer_create"),
+                [
+                    {"id": 1, "value": "alpha", "modified": "2024-01-01 00:00:00"},
+                    {"id": 2, "value": "beta", "modified": "2024-01-02 00:00:00"},
+                ],
+            )
+
+    def test_writer_append_mode_keeps_existing_rows(self):
+        with self.warehouse_db() as db:
+            with patch.object(
+                insights.warehouse,
+                "get_write_connection",
+                self.patched_write_connection(db),
+            ):
+                with WarehouseTableWriter(
+                    "warehouse_writer_append",
+                    table_schema=self.make_schema(),
+                    database="main",
+                    mode="replace",
+                ) as writer:
+                    writer.insert(
+                        self.make_frame([{"id": 1, "value": "alpha", "modified": "2024-01-01 00:00:00"}])
+                    )
+                    writer.commit()
+
+                with WarehouseTableWriter(
+                    "warehouse_writer_append",
+                    table_schema=self.make_schema(),
+                    database="main",
+                    mode="append",
+                ) as writer:
+                    writer.insert(
+                        self.make_frame(
+                            [
+                                {"id": 2, "value": "beta", "modified": "2024-01-02 00:00:00"},
+                                {"id": 3, "value": "gamma", "modified": "2024-01-03 00:00:00"},
+                            ]
+                        )
+                    )
+                    rows_written = writer.commit()
+            self.assertEqual(rows_written, 2)
+            self.assertEqual(
+                self.read_rows(db, "warehouse_writer_append"),
+                [
+                    {"id": 1, "value": "alpha", "modified": "2024-01-01 00:00:00"},
+                    {"id": 2, "value": "beta", "modified": "2024-01-02 00:00:00"},
+                    {"id": 3, "value": "gamma", "modified": "2024-01-03 00:00:00"},
+                ],
+            )
+
+    def test_writer_upsert_mode_updates_matching_primary_keys(self):
+        with self.warehouse_db() as db:
+            with patch.object(
+                insights.warehouse,
+                "get_write_connection",
+                self.patched_write_connection(db),
+            ):
+                with WarehouseTableWriter(
+                    "warehouse_writer_upsert",
+                    table_schema=self.make_schema(),
+                    database="main",
+                    mode="replace",
+                ) as writer:
+                    writer.insert(
+                        self.make_frame([{"id": 1, "value": "alpha", "modified": "2024-01-01 00:00:00"}])
+                    )
+                    writer.commit()
+
+                with WarehouseTableWriter(
+                    "warehouse_writer_upsert",
+                    table_schema=self.make_schema(),
+                    database="main",
+                    mode="upsert",
+                    primary_key_column="id",
+                    cursor_column="modified",
+                ) as writer:
+                    writer.insert(
+                        self.make_frame(
+                            [
+                                {"id": 1, "value": "updated", "modified": "2024-01-02 00:00:00"},
+                                {"id": 2, "value": "beta", "modified": "2024-01-02 00:00:00"},
+                            ]
+                        )
+                    )
+                    rows_written = writer.commit()
+            self.assertEqual(rows_written, 2)
+            self.assertEqual(
+                self.read_rows(db, "warehouse_writer_upsert"),
+                [
+                    {"id": 1, "value": "updated", "modified": "2024-01-02 00:00:00"},
+                    {"id": 2, "value": "beta", "modified": "2024-01-02 00:00:00"},
+                ],
+            )


### PR DESCRIPTION
This PR fixes incremental sync for mutable tables.

Previously, using a cursor like `modified` could create duplicate rows in the warehouse because incremental sync only appended new batches. Now, users must choose the sync strategy up front:

- `Append Only`: always add new rows
- `Update or Insert`: merge rows by a configured primary key

For `Update or Insert`, users must also set a `Primary Key Column`. The cursor column is still used only to detect what changed since the last sync.

Important limitation: we currently assume cursor values are unique enough for batching. If two rows have the same cursor value, conflict handling is not implemented yet.