### PR TITLE
fix: group by time column

### DIFF
--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -101,8 +101,8 @@ jobs:
         run: |
           bench get-app insights $GITHUB_WORKSPACE --skip-assets
           bench setup requirements --dev
+          bench config set-common-config -c server_script_enabled 1
           bench new-site --db-root-password "$DB_ROOT_PASSWORD" --admin-password "$ADMIN_PASSWORD" "$SITE_NAME"
-          bench --site "$SITE_NAME" set-config server_script_enabled 1 --parse
           bench --site "$SITE_NAME" install-app insights
           bench build
         env:

--- a/frontend/src2/charts/components/ChartBuilderTable.vue
+++ b/frontend/src2/charts/components/ChartBuilderTable.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { Calendar, Check } from 'lucide-vue-next'
 import { h, inject, watchEffect } from 'vue'
-import { FIELDTYPES, granularityOptions } from '../../helpers/constants'
+import { FIELDTYPES, getGranularityOptions } from '../../helpers/constants'
 import QueryDataTable from '../../query/components/QueryDataTable.vue'
 import { column } from '../../query/helpers'
 import { SortDirection } from '../../types/query.types'
@@ -18,14 +18,14 @@ watchEffect(() => {
 
 function onSortChange(column_name: string, sort_order: SortDirection) {
 	const existingOrder = chart.doc.config.order_by.find(
-		(order) => order.column.column_name === column_name
+		(order) => order.column.column_name === column_name,
 	)
 	if (existingOrder) {
 		if (sort_order) {
 			existingOrder.direction = sort_order
 		} else {
 			chart.doc.config.order_by = chart.doc.config.order_by.filter(
-				(order) => order.column.column_name !== column_name
+				(order) => order.column.column_name !== column_name,
 			)
 		}
 	} else {
@@ -37,8 +37,8 @@ function onSortChange(column_name: string, sort_order: SortDirection) {
 	}
 }
 
-function getDateGranularityOptions(column_name: string) {
-	return granularityOptions.map((option) => {
+function getDateGranularityOptions(column_name: string, column_type: string) {
+	return getGranularityOptions(column_type).map((option) => {
 		const _option = { ...option } as any
 		_option.onClick = () => chart.updateGranularity(column_name, option.value)
 		_option.icon =
@@ -69,7 +69,7 @@ function getDateGranularityOptions(column_name: string) {
 			<template #header-suffix="{ column }">
 				<Dropdown
 					v-if="FIELDTYPES.DATE.includes(column.type)"
-					:options="getDateGranularityOptions(column.name)"
+					:options="getDateGranularityOptions(column.name, column.type)"
 				>
 					<Button variant="ghost" class="rounded-none">
 						<template #icon>

--- a/frontend/src2/charts/components/DimensionPicker.vue
+++ b/frontend/src2/charts/components/DimensionPicker.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
 import { ChevronDown, Settings, XIcon } from 'lucide-vue-next'
+import { computed, watchEffect } from 'vue'
 import InlineFormControlLabel from '../../components/InlineFormControlLabel.vue'
 import { isDate } from '../../helpers'
-import { COLUMN_TYPES, granularityOptions } from '../../helpers/constants'
+import { COLUMN_TYPES, getDefaultGranularity, getGranularityOptions } from '../../helpers/constants'
 import { Dimension, DimensionOption } from '../../types/query.types'
 import LazyTextInput from '../../components/LazyTextInput.vue'
 
@@ -27,11 +28,27 @@ if (!dimension.value.dimension_name && dimension.value.column_name) {
 	dimension.value.dimension_name = dimension.value.column_name
 }
 
+const granularityOptions = computed(() => getGranularityOptions(dimension.value.data_type))
+
+watchEffect(() => {
+	const allowedGranularities = new Set(granularityOptions.value.map((option) => option.value))
+
+	if (!allowedGranularities.size) {
+		dimension.value.granularity = undefined
+		return
+	}
+
+	if (!dimension.value.granularity || !allowedGranularities.has(dimension.value.granularity)) {
+		dimension.value.granularity = getDefaultGranularity(dimension.value.data_type)
+	}
+})
+
 function selectDimension(option?: DimensionOption) {
 	if (!option || !option.column_name) {
 		dimension.value = {
 			column_name: '',
 			data_type: 'String',
+			granularity: undefined,
 			dimension_name: '',
 		}
 		return
@@ -84,10 +101,7 @@ function selectDimension(option?: DimensionOption) {
 			<template #body-main>
 				<div class="flex w-[14rem] flex-col gap-2 p-2">
 					<InlineFormControlLabel label="Label">
-						<LazyTextInput
-							placeholder="Label"
-							v-model="dimension.dimension_name"
-						/>
+						<LazyTextInput placeholder="Label" v-model="dimension.dimension_name" />
 					</InlineFormControlLabel>
 
 					<InlineFormControlLabel label="Type">

--- a/frontend/src2/charts/helpers.ts
+++ b/frontend/src2/charts/helpers.ts
@@ -1,6 +1,6 @@
 import { graphic } from 'echarts/core'
 import { ellipsis, formatNumber, getShortNumber, toTitleCase } from '../helpers'
-import { FIELDTYPES } from '../helpers/constants'
+import { FIELDTYPES, isCalendarDateType } from '../helpers/constants'
 import { getFormattedDate } from '../query/helpers'
 import {
 	AxisChartConfig,
@@ -59,7 +59,7 @@ export function getLineChartOptions(config: LineChartConfig, result: QueryResult
 	const show_scrollbar = config.y_axis.show_scrollbar || false
 
 	const xAxis = getXAxis(config.x_axis)
-	const xAxisIsDate = FIELDTYPES.DATE.includes(config.x_axis.dimension.data_type)
+	const xAxisIsDate = isCalendarDateType(config.x_axis.dimension.data_type)
 	const granularity = xAxisIsDate
 		? getGranularity(config.x_axis.dimension.dimension_name, config)
 		: null
@@ -191,7 +191,7 @@ export function getBarChartOptions(config: BarChartConfig, result: QueryResult, 
 	const show_scrollbar = config.y_axis.show_scrollbar || false
 
 	const xAxis = getXAxis(config.x_axis)
-	const xAxisIsDate = FIELDTYPES.DATE.includes(config.x_axis.dimension.data_type)
+	const xAxisIsDate = isCalendarDateType(config.x_axis.dimension.data_type)
 	const granularity = xAxisIsDate
 		? getGranularity(config.x_axis.dimension.dimension_name, config)
 		: null
@@ -335,7 +335,7 @@ function getSerie(config: AxisChartConfig, number_column: string): Series {
 
 function getXAxis(x_axis: XAxis) {
 	const columnType = x_axis.dimension.data_type
-	const xAxisIsDate = columnType && FIELDTYPES.DATE.includes(columnType)
+	const xAxisIsDate = isCalendarDateType(columnType)
 	const rotation = Math.min(Math.max(x_axis.label_rotation || 0, 0), 90)
 
 	return {

--- a/frontend/src2/helpers/constants.ts
+++ b/frontend/src2/helpers/constants.ts
@@ -78,12 +78,16 @@ export type GranularityType = typeof granularityOptions[number]['value']
 
 export const timeGranularityOptions = granularityOptions.slice(0, 3)
 
+export function isCalendarDateType(dataType?: string) {
+	return CalendarDateTypes.includes(dataType || '')
+}
+
 export function getGranularityOptions(dataType?: string) {
 	if (TimeTypes.includes(dataType || '')) {
 		return timeGranularityOptions
 	}
 
-	if (CalendarDateTypes.includes(dataType || '')) {
+	if (isCalendarDateType(dataType)) {
 		return granularityOptions
 	}
 
@@ -95,7 +99,7 @@ export function getDefaultGranularity(dataType?: string): GranularityType | unde
 		return 'hour'
 	}
 
-	if (CalendarDateTypes.includes(dataType || '')) {
+	if (isCalendarDateType(dataType)) {
 		return 'month'
 	}
 

--- a/frontend/src2/helpers/constants.ts
+++ b/frontend/src2/helpers/constants.ts
@@ -4,6 +4,8 @@ import { __ } from '../translation'
 const NumberTypes = ['Integer', 'Decimal']
 const TextTypes = ['Text', 'String', 'JSON', 'Array']
 const DateTypes = ['Date', 'Datetime', 'Time']
+const CalendarDateTypes = ['Date', 'Datetime']
+const TimeTypes = ['Time']
 
 export const FIELDTYPES = {
 	NUMBER: NumberTypes,
@@ -73,3 +75,29 @@ export const granularityOptions = [
 ] as const
 
 export type GranularityType = typeof granularityOptions[number]['value']
+
+export const timeGranularityOptions = granularityOptions.slice(0, 3)
+
+export function getGranularityOptions(dataType?: string) {
+	if (TimeTypes.includes(dataType || '')) {
+		return timeGranularityOptions
+	}
+
+	if (CalendarDateTypes.includes(dataType || '')) {
+		return granularityOptions
+	}
+
+	return []
+}
+
+export function getDefaultGranularity(dataType?: string): GranularityType | undefined {
+	if (TimeTypes.includes(dataType || '')) {
+		return 'hour'
+	}
+
+	if (CalendarDateTypes.includes(dataType || '')) {
+		return 'month'
+	}
+
+	return undefined
+}

--- a/frontend/src2/query/components/PivotSelectorDialog.vue
+++ b/frontend/src2/query/components/PivotSelectorDialog.vue
@@ -49,7 +49,7 @@ watchEffect(() => {
 })
 
 function emptyDimension(): Dimension {
-	return { column_name: '', data_type: 'String', granularity: 'month', dimension_name: '' }
+	return { column_name: '', data_type: 'String', granularity: undefined, dimension_name: '' }
 }
 
 function addRow() {

--- a/frontend/src2/query/components/SummarySelectorDialog.vue
+++ b/frontend/src2/query/components/SummarySelectorDialog.vue
@@ -71,7 +71,7 @@ function addDimension() {
 	dimensions.value.push({
 		column_name: '',
 		data_type: 'String',
-		granularity: 'month',
+		granularity: undefined,
 		dimension_name: '',
 	})
 }

--- a/frontend/src2/query/helpers.ts
+++ b/frontend/src2/query/helpers.ts
@@ -18,7 +18,7 @@ import {
 } from 'lucide-vue-next'
 import { h } from 'vue'
 import { copy } from '../helpers'
-import { FIELDTYPES, GranularityType } from '../helpers/constants'
+import { FIELDTYPES, getDefaultGranularity, GranularityType } from '../helpers/constants'
 import dayjs from '../helpers/dayjs'
 import useSettings from '../settings/settings'
 import {
@@ -154,6 +154,20 @@ export function getFormattedRows(result: QueryResult, operations: Operation[]) {
 export function getFormattedDate(date: string, granularity: string) {
 	if (!date) return ''
 
+	const isTimeOnlyValue = /^\d{1,2}:\d{2}(:\d{2}(\.\d+)?)?$/.test(date)
+	if (isTimeOnlyValue) {
+		const timeFormats: Record<string, string> = {
+			second: 'h:mm:ss A',
+			minute: 'h:mm A',
+			hour: 'h:00 A',
+		}
+
+		if (!timeFormats[granularity]) return date
+
+		const parsed = dayjs(date, ['HH:mm:ss.SSSSSS', 'HH:mm:ss', 'HH:mm'], true)
+		return parsed.isValid() ? parsed.format(timeFormats[granularity]) : date
+	}
+
 	if (granularity === 'fiscal_year') {
 		const d = dayjs(date)
 		const fiscalYearStart = session.user.fiscal_year_start
@@ -206,11 +220,10 @@ export function getDimensions(columns: QueryResultColumn[]): Dimension[] {
 }
 
 export function makeDimension(column: QueryResultColumn): Dimension {
-	const isDate = FIELDTYPES.DATE.includes(column.type)
 	return {
 		column_name: column.name,
 		data_type: column.type as DimensionDataType,
-		granularity: isDate ? 'month' : undefined,
+		granularity: getDefaultGranularity(column.type),
 		dimension_name: column.name,
 	}
 }

--- a/insights/insights/doctype/insights_data_source_v3/ibis_utils.py
+++ b/insights/insights/doctype/insights_data_source_v3/ibis_utils.py
@@ -788,12 +788,29 @@ class IbisQueryBuilder:
     def translate_dimension(self, dimension):
         col = self.get_column(dimension.column_name)
         if self.is_date_type(dimension.data_type) and dimension.granularity:
-            col = self.apply_granularity(col, dimension.granularity)
+            col = self.apply_granularity(col, dimension.granularity, dimension.data_type)
             col = col.cast(self.get_ibis_dtype(dimension.data_type))
         return col.name(dimension.dimension_name or dimension.column_name)
 
     def is_date_type(self, data_type):
         return data_type in ["Date", "Datetime", "Time"]
+
+    def get_supported_granularities(self, data_type):
+        if data_type == "Time":
+            return ["second", "minute", "hour"]
+        if data_type in ["Date", "Datetime"]:
+            return [
+                "second",
+                "minute",
+                "hour",
+                "day",
+                "week",
+                "month",
+                "quarter",
+                "year",
+                "fiscal_year",
+            ]
+        return []
 
     def apply_aggregate(self, column, aggregate_function):
         if aggregate_function == "count_distinct":
@@ -811,7 +828,15 @@ class IbisQueryBuilder:
 
         frappe.throw(f"Aggregate function {aggregate_function} is not supported")
 
-    def apply_granularity(self, column, granularity):
+    def apply_granularity(self, column, granularity, data_type=None):
+        supported_granularities = self.get_supported_granularities(data_type)
+        if supported_granularities and granularity not in supported_granularities:
+            supported = ", ".join(supported_granularities)
+            frappe.throw(
+                f"Granularity {granularity} is not supported for {data_type} columns. Supported granularities: {supported}",
+                title="Unsupported Granularity",
+            )
+
         if granularity == "week":
             return week_start(column).name(column.get_name())
         if granularity == "fiscal_year":

--- a/insights/insights/doctype/insights_data_source_v3/ibis_utils.py
+++ b/insights/insights/doctype/insights_data_source_v3/ibis_utils.py
@@ -787,6 +787,11 @@ class IbisQueryBuilder:
 
     def translate_dimension(self, dimension):
         col = self.get_column(dimension.column_name)
+
+        if dimension.data_type == "Time" and dimension.granularity:
+            col = self.apply_time_granularity(col, dimension.granularity)
+            return col.name(dimension.dimension_name or dimension.column_name)
+
         if self.is_date_type(dimension.data_type) and dimension.granularity:
             col = self.apply_granularity(col, dimension.granularity, dimension.data_type)
             col = col.cast(self.get_ibis_dtype(dimension.data_type))
@@ -794,23 +799,6 @@ class IbisQueryBuilder:
 
     def is_date_type(self, data_type):
         return data_type in ["Date", "Datetime", "Time"]
-
-    def get_supported_granularities(self, data_type):
-        if data_type == "Time":
-            return ["second", "minute", "hour"]
-        if data_type in ["Date", "Datetime"]:
-            return [
-                "second",
-                "minute",
-                "hour",
-                "day",
-                "week",
-                "month",
-                "quarter",
-                "year",
-                "fiscal_year",
-            ]
-        return []
 
     def apply_aggregate(self, column, aggregate_function):
         if aggregate_function == "count_distinct":
@@ -829,8 +817,18 @@ class IbisQueryBuilder:
         frappe.throw(f"Aggregate function {aggregate_function} is not supported")
 
     def apply_granularity(self, column, granularity, data_type=None):
-        supported_granularities = self.get_supported_granularities(data_type)
-        if supported_granularities and granularity not in supported_granularities:
+        supported_granularities = [
+            "second",
+            "minute",
+            "hour",
+            "day",
+            "week",
+            "month",
+            "quarter",
+            "year",
+            "fiscal_year",
+        ]
+        if granularity not in supported_granularities:
             supported = ", ".join(supported_granularities)
             frappe.throw(
                 f"Granularity {granularity} is not supported for {data_type} columns. Supported granularities: {supported}",
@@ -854,6 +852,25 @@ class IbisQueryBuilder:
         if granularity not in truncate_unit:
             frappe.throw(f"Granularity {granularity} is not supported")
         return column.truncate(truncate_unit[granularity]).name(column.get_name())
+
+    def apply_time_granularity(self, column, granularity):
+        supported_granularities = ["second", "minute", "hour"]
+        if granularity not in supported_granularities:
+            supported = ", ".join(supported_granularities)
+            frappe.throw(
+                f"Granularity {granularity} is not supported for Time columns. Supported granularities: {supported}",
+                title="Unsupported Granularity",
+            )
+
+        time_string = column.cast("string")
+        if granularity == "hour":
+            return time_string.substr(0, 2).concat(ibis.literal(":00:00"))
+        if granularity == "minute":
+            return time_string.substr(0, 5).concat(ibis.literal(":00"))
+        if granularity == "second":
+            return time_string.substr(0, 8)
+
+        frappe.throw(f"Granularity {granularity} is not supported for Time columns")
 
     def evaluate_expression(self, expression, additonal_context=None):
         if not expression or not expression.strip():

--- a/insights/tests/test_ibis_utils.py
+++ b/insights/tests/test_ibis_utils.py
@@ -1,0 +1,97 @@
+import frappe
+
+from insights.insights.doctype.insights_data_source_v3.ibis_utils import IbisQueryBuilder
+from insights.tests.base import InsightsIntegrationTestCase
+
+
+class TestIbisQueryBuilderGranularity(InsightsIntegrationTestCase):
+    def make_query_doc(self, operations):
+        return frappe._dict(
+            name="Ibis Time Granularity Test",
+            title="Ibis Time Granularity Test",
+            use_live_connection=0,
+            operations=frappe.as_json(operations),
+        )
+
+    def make_time_source_operations(self):
+        return [
+            {
+                "type": "code",
+                "code": """
+results = [
+    {"posting_time": "09:15:42.123", "label": "alpha"},
+    {"posting_time": "09:15:42.987", "label": "beta"},
+    {"posting_time": "14:33:19.111", "label": "gamma"},
+]
+""",
+            },
+            {
+                "type": "cast",
+                "column": {"type": "column", "column_name": "posting_time"},
+                "data_type": "Time",
+            },
+        ]
+
+    def build_query(self, operations):
+        return IbisQueryBuilder(self.make_query_doc(operations)).build()
+
+    def test_summary_query_groups_time_values_by_supported_granularities(self):
+        cases = [
+            ("hour", {"09:00:00": 2, "14:00:00": 1}),
+            ("minute", {"09:15:00": 2, "14:33:00": 1}),
+            ("second", {"09:15:42": 2, "14:33:19": 1}),
+        ]
+
+        for granularity, expected in cases:
+            with self.subTest(granularity=granularity):
+                query = self.build_query(
+                    [
+                        *self.make_time_source_operations(),
+                        {
+                            "type": "summarize",
+                            "measures": [
+                                {"measure_name": "row_count", "column_name": "label", "aggregation": "count"}
+                            ],
+                            "dimensions": [
+                                {
+                                    "column_name": "posting_time",
+                                    "data_type": "Time",
+                                    "granularity": granularity,
+                                    "dimension_name": "posting_time_bucket",
+                                }
+                            ],
+                        },
+                        {
+                            "type": "order_by",
+                            "column": {"type": "column", "column_name": "posting_time_bucket"},
+                            "direction": "asc",
+                        },
+                    ]
+                )
+
+                result = query.execute()
+                actual = dict(zip(result["posting_time_bucket"], result["row_count"], strict=False))
+
+                self.assertEqual(actual, expected)
+
+    def test_summary_query_rejects_calendar_buckets_for_time_columns(self):
+        operations = [
+            *self.make_time_source_operations(),
+            {
+                "type": "summarize",
+                "measures": [{"measure_name": "row_count", "column_name": "label", "aggregation": "count"}],
+                "dimensions": [
+                    {
+                        "column_name": "posting_time",
+                        "data_type": "Time",
+                        "granularity": "month",
+                        "dimension_name": "posting_time_bucket",
+                    }
+                ],
+            },
+        ]
+
+        with self.assertRaises(frappe.ValidationError) as exc:
+            self.build_query(operations)
+
+        self.assertIn("Supported granularities: second, minute, hour", str(exc.exception))


### PR DESCRIPTION
Fixes grouping by `Time` columns.

`Time` fields were being treated like calendar date fields, which allowed invalid granularities like `month` and caused incorrect grouping. Fixed #1120 

#### Changes

- add dedicated backend handling for `Time` granularities
- restrict `Time` fields to `hour`, `minute`, and `second`
- update frontend granularity defaults/options based on column type
- remove invalid default granularity values for non-date fields
- format grouped time values correctly in output


