### PR TITLE
make x and y axis labels show

### DIFF
--- a/frontend/src2/charts/components/YAxisConfig.vue
+++ b/frontend/src2/charts/components/YAxisConfig.vue
@@ -10,6 +10,7 @@ import { AxisChartConfig } from '../../types/chart.types'
 import { ColumnOption, MeasureOption } from '../../types/query.types'
 import CollapsibleSection from './CollapsibleSection.vue'
 import MeasurePicker from './MeasurePicker.vue'
+import { UNIT_OPTIONS } from '../units'
 
 const props = defineProps<{ columnOptions: ColumnOption[] }>()
 const y_axis = defineModel<AxisChartConfig['y_axis']>({
@@ -105,6 +106,13 @@ const updateColor = debounce((color: string, idx: number) => {
 				v-if="y_axis.show_axis_label"
 				v-model="y_axis.axis_label"
 				label="Axis Label"
+			/>
+			<FormControl
+				v-if="y_axis.show_axis_label"
+				v-model="y_axis.units"
+				label="Units"
+				type="select"
+				:options="UNIT_OPTIONS.map((o) => ({ label: o.label, value: o.value }))"
 			/>
 
 			<InlineFormControlLabel label="Y-Min" class="w-1/2">

--- a/frontend/src2/charts/helpers.ts
+++ b/frontend/src2/charts/helpers.ts
@@ -4,6 +4,7 @@ import { FIELDTYPES } from '../helpers/constants'
 import { getFormattedDate } from '../query/helpers'
 import {
 	AxisChartConfig,
+	AxisUnit,
 	BarChartConfig,
 	BubbleChartConfig,
 	ChartConfig,
@@ -18,6 +19,7 @@ import {
 } from '../types/chart.types'
 import { QueryResult, QueryResultColumn, QueryResultRow } from '../types/query.types'
 import { getColors, getGradientColors } from './colors'
+import { formatValueWithUnit, hasUnit } from './units'
 
 interface GeoJSONFeature {
 	type: string
@@ -65,12 +67,14 @@ export function getLineChartOptions(config: LineChartConfig, result: QueryResult
 		: null
 
 	const yAxisLabel = config.y_axis.show_axis_label ? config.y_axis.axis_label : undefined
+	const yUnit = config.y_axis.show_axis_label ? config.y_axis.units : undefined
 	const leftYAxis = getYAxis({
 		min: config.y_axis.min,
 		max: config.y_axis.max,
 		label: yAxisLabel,
+		unit: yUnit,
 	})
-	const rightYAxis = getYAxis()
+	const rightYAxis = getYAxis({ unit: yUnit })
 	const hasRightAxis = config.y_axis.series.some((s) => s.align === 'Right')
 	const yAxis = !hasRightAxis ? [leftYAxis] : [leftYAxis, rightYAxis]
 
@@ -125,7 +129,8 @@ export function getLineChartOptions(config: LineChartConfig, result: QueryResult
 				show: hide_from_chart ? false : show_data_labels,
 				position: labelPosition,
 				formatter: (params: any) => {
-					return getShortNumber(params.value?.[1], 1)
+					const v = params.value?.[1]
+					return hasUnit(yUnit) ? formatValueWithUnit(v, yUnit, 1) : getShortNumber(v, 1)
 				},
 			},
 			labelLayout: { hideOverlap: true },
@@ -158,6 +163,7 @@ export function getLineChartOptions(config: LineChartConfig, result: QueryResult
 		tooltip: getTooltip({
 			xAxisIsDate,
 			granularity,
+			yUnit,
 		}),
 		legend: { ...getLegend(show_legend, show_scrollbar), data: legendData },
 	}
@@ -202,14 +208,16 @@ export function getBarChartOptions(config: BarChartConfig, result: QueryResult, 
 		: null
 
 	const yAxisLabel = config.y_axis.show_axis_label ? config.y_axis.axis_label : undefined
+	const yUnit = config.y_axis.show_axis_label ? config.y_axis.units : undefined
 	const leftYAxis = getYAxis({
 		normalized: config.y_axis.normalize,
 		min: config.y_axis.min,
 		max: config.y_axis.max,
 		label: yAxisLabel,
 		horizontal: swapAxes,
+		unit: yUnit,
 	})
-	const rightYAxis = getYAxis({ normalized: config.y_axis.normalize })
+	const rightYAxis = getYAxis({ normalized: config.y_axis.normalize, unit: yUnit })
 	const hasRightAxis = config.y_axis.series.some((s) => s.align === 'Right')
 	const yAxis = !hasRightAxis ? [leftYAxis] : [leftYAxis, rightYAxis]
 
@@ -279,7 +287,8 @@ export function getBarChartOptions(config: BarChartConfig, result: QueryResult, 
 				position: labelPosition,
 				formatter: (params: any) => {
 					const _val = swapAxes ? params.value?.[0] : params.value?.[1]
-					return getShortNumber(_val, 1)
+					if (config.y_axis.normalize) return getShortNumber(_val, 1)
+					return hasUnit(yUnit) ? formatValueWithUnit(_val, yUnit, 1) : getShortNumber(_val, 1)
 				},
 				fontSize: 11,
 			},
@@ -313,6 +322,7 @@ export function getBarChartOptions(config: BarChartConfig, result: QueryResult, 
 			xAxisIsDate,
 			granularity,
 			xySwapped: swapAxes,
+			yUnit: config.y_axis.normalize ? undefined : yUnit,
 		}),
 		legend: { ...getLegend(show_legend, show_scrollbar, swapAxes), data: legendData },
 	}
@@ -379,6 +389,7 @@ type YAxisCustomizeOptions = {
 	max?: number
 	label?: string
 	horizontal?: boolean
+	unit?: AxisUnit
 }
 function getYAxis(options: YAxisCustomizeOptions = {}) {
 	const nameConfig = options.label
@@ -389,6 +400,11 @@ function getYAxis(options: YAxisCustomizeOptions = {}) {
 				nameTextStyle: { fontSize: 12, fontWeight: 'bold' as const },
 		  }
 		: { name: '' }
+
+	const useUnit = !options.normalized && hasUnit(options.unit)
+	const formatter = useUnit
+		? (value: number) => formatValueWithUnit(value, options.unit, 1)
+		: (value: number) => getShortNumber(value, 1)
 
 	return {
 		show: true,
@@ -404,7 +420,7 @@ function getYAxis(options: YAxisCustomizeOptions = {}) {
 			show: true,
 			hideOverlap: true,
 			margin: 8,
-			formatter: (value: number) => getShortNumber(value, 1),
+			formatter,
 		},
 		min: options.normalized ? 0 : options.min || undefined,
 		max: options.normalized ? 100 : options.max || undefined,
@@ -1184,6 +1200,12 @@ function getGrid(options: any = {}) {
 }
 
 function getTooltip(options: any = {}) {
+	const formatY = (value: number) => {
+		if (isNaN(value)) return value
+		return hasUnit(options.yUnit)
+			? formatValueWithUnit(value, options.yUnit, 2)
+			: formatNumber(value)
+	}
 	return {
 		trigger: 'axis',
 		confine: true,
@@ -1198,7 +1220,7 @@ function getTooltip(options: any = {}) {
 			if (!Array.isArray(params)) {
 				const p = params as any
 				const value = options.xySwapped ? p.value[0] : p.value[1]
-				const formatted = isNaN(value) ? value : formatNumber(value)
+				const formatted = formatY(value)
 				return `
 					<div class="flex items-center justify-between gap-5">
 						<div>${p.name}</div>
@@ -1214,7 +1236,7 @@ function getTooltip(options: any = {}) {
 						options.xAxisIsDate && options.granularity
 							? getFormattedDate(xValue, options.granularity)
 							: xValue
-					const formattedY = isNaN(yValue) ? yValue : formatNumber(yValue)
+					const formattedY = formatY(yValue)
 					return `
 							<div class="flex flex-col">
 								${idx == 0 ? `<div>${formattedX}</div>` : ''}

--- a/frontend/src2/charts/helpers.ts
+++ b/frontend/src2/charts/helpers.ts
@@ -64,7 +64,12 @@ export function getLineChartOptions(config: LineChartConfig, result: QueryResult
 		? getGranularity(config.x_axis.dimension.dimension_name, config)
 		: null
 
-	const leftYAxis = getYAxis({ min: config.y_axis.min, max: config.y_axis.max })
+	const yAxisLabel = config.y_axis.show_axis_label ? config.y_axis.axis_label : undefined
+	const leftYAxis = getYAxis({
+		min: config.y_axis.min,
+		max: config.y_axis.max,
+		label: yAxisLabel,
+	})
 	const rightYAxis = getYAxis()
 	const hasRightAxis = config.y_axis.series.some((s) => s.align === 'Right')
 	const yAxis = !hasRightAxis ? [leftYAxis] : [leftYAxis, rightYAxis]
@@ -145,7 +150,7 @@ export function getLineChartOptions(config: LineChartConfig, result: QueryResult
 		animation: true,
 		animationDuration: 700,
 		dataZoom: getDataZoom(show_scrollbar),
-		grid: getGrid({ show_legend, show_scrollbar }),
+		grid: getGrid({ show_legend, show_scrollbar, y_axis_label: yAxisLabel }),
 		color: colors,
 		xAxis,
 		yAxis,
@@ -196,10 +201,13 @@ export function getBarChartOptions(config: BarChartConfig, result: QueryResult, 
 		? getGranularity(config.x_axis.dimension.dimension_name, config)
 		: null
 
+	const yAxisLabel = config.y_axis.show_axis_label ? config.y_axis.axis_label : undefined
 	const leftYAxis = getYAxis({
 		normalized: config.y_axis.normalize,
 		min: config.y_axis.min,
 		max: config.y_axis.max,
+		label: yAxisLabel,
+		horizontal: swapAxes,
 	})
 	const rightYAxis = getYAxis({ normalized: config.y_axis.normalize })
 	const hasRightAxis = config.y_axis.series.some((s) => s.align === 'Right')
@@ -296,7 +304,7 @@ export function getBarChartOptions(config: BarChartConfig, result: QueryResult, 
 		animation: true,
 		animationDuration: 700,
 		color: colors,
-		grid: getGrid({ show_legend, show_scrollbar, swapAxes }),
+		grid: getGrid({ show_legend, show_scrollbar, swapAxes, y_axis_label: yAxisLabel }),
 		xAxis: swapAxes ? yAxis : xAxis,
 		yAxis: swapAxes ? xAxis : yAxis,
 		dataZoom: getDataZoom(show_scrollbar, swapAxes),
@@ -369,8 +377,19 @@ type YAxisCustomizeOptions = {
 	normalized?: boolean
 	min?: number
 	max?: number
+	label?: string
+	horizontal?: boolean
 }
 function getYAxis(options: YAxisCustomizeOptions = {}) {
+	const nameConfig = options.label
+		? {
+				name: options.label,
+				nameLocation: 'middle',
+				nameGap: options.horizontal ? 30 : 50,
+				nameTextStyle: { fontSize: 12, fontWeight: 'bold' as const },
+		  }
+		: { name: '' }
+
 	return {
 		show: true,
 		type: 'value',
@@ -389,6 +408,7 @@ function getYAxis(options: YAxisCustomizeOptions = {}) {
 		},
 		min: options.normalized ? 0 : options.min || undefined,
 		max: options.normalized ? 100 : options.max || undefined,
+		...nameConfig,
 	}
 }
 
@@ -1144,11 +1164,21 @@ function getGrid(options: any = {}) {
 		bottom += 30
 	}
 
+	let left = 30
+	if (options.y_axis_label) {
+		// containLabel reserves space for tick labels, not the axis `name` — pad it ourselves
+		if (options.swapAxes) {
+			bottom += 25
+		} else {
+			left += 25
+		}
+	}
+
 	return {
 		top: 18,
-		left: 30,
+		left,
 		right: 30,
-		bottom: bottom,
+		bottom,
 		containLabel: true,
 	}
 }

--- a/frontend/src2/charts/units.ts
+++ b/frontend/src2/charts/units.ts
@@ -1,0 +1,101 @@
+import { AxisUnit } from '../types/chart.types'
+
+type Scale = { unit: AxisUnit; factor: number; suffix: string }
+
+const TIME_SCALES_IN_SECONDS: Scale[] = [
+	{ unit: 'ns', factor: 1e-9, suffix: 'ns' },
+	{ unit: 'us', factor: 1e-6, suffix: 'µs' },
+	{ unit: 'ms', factor: 1e-3, suffix: 'ms' },
+	{ unit: 's', factor: 1, suffix: 's' },
+	{ unit: 'min', factor: 60, suffix: 'min' },
+	{ unit: 'h', factor: 3600, suffix: 'h' },
+	{ unit: 'd', factor: 86400, suffix: 'd' },
+	{ unit: 'w', factor: 604800, suffix: 'w' },
+	{ unit: 'mo', factor: 2629800, suffix: 'mo' },
+	{ unit: 'y', factor: 31557600, suffix: 'y' },
+]
+
+const DATA_SCALES_IN_BYTES: Scale[] = [
+	{ unit: 'bytes', factor: 1, suffix: 'B' },
+	{ unit: 'KB', factor: 1024, suffix: 'KB' },
+	{ unit: 'MB', factor: 1024 ** 2, suffix: 'MB' },
+	{ unit: 'GB', factor: 1024 ** 3, suffix: 'GB' },
+	{ unit: 'TB', factor: 1024 ** 4, suffix: 'TB' },
+]
+
+const TIME_UNITS = new Set(TIME_SCALES_IN_SECONDS.map((s) => s.unit))
+const DATA_UNITS = new Set(DATA_SCALES_IN_BYTES.map((s) => s.unit))
+
+export type UnitGroupOption = { group: string; label: string; value: AxisUnit }
+
+export const UNIT_OPTIONS: UnitGroupOption[] = [
+	{ group: 'None', label: 'None', value: 'none' },
+	{ group: 'Time', label: 'Nanoseconds (ns)', value: 'ns' },
+	{ group: 'Time', label: 'Microseconds (µs)', value: 'us' },
+	{ group: 'Time', label: 'Milliseconds (ms)', value: 'ms' },
+	{ group: 'Time', label: 'Seconds (s)', value: 's' },
+	{ group: 'Time', label: 'Minutes (min)', value: 'min' },
+	{ group: 'Time', label: 'Hours (h)', value: 'h' },
+	{ group: 'Time', label: 'Days (d)', value: 'd' },
+	{ group: 'Time', label: 'Weeks (w)', value: 'w' },
+	{ group: 'Time', label: 'Months (mo)', value: 'mo' },
+	{ group: 'Time', label: 'Years (y)', value: 'y' },
+	{ group: 'Data', label: 'Bytes', value: 'bytes' },
+	{ group: 'Data', label: 'Kilobytes (KB)', value: 'KB' },
+	{ group: 'Data', label: 'Megabytes (MB)', value: 'MB' },
+	{ group: 'Data', label: 'Gigabytes (GB)', value: 'GB' },
+	{ group: 'Data', label: 'Terabytes (TB)', value: 'TB' },
+]
+
+function getScales(unit: AxisUnit): Scale[] | null {
+	if (TIME_UNITS.has(unit)) return TIME_SCALES_IN_SECONDS
+	if (DATA_UNITS.has(unit)) return DATA_SCALES_IN_BYTES
+	return null
+}
+
+function pickScale(baseValue: number, scales: Scale[]): Scale {
+	const abs = Math.abs(baseValue)
+	if (abs === 0 || !isFinite(abs)) return scales[0]
+	let chosen = scales[0]
+	for (const s of scales) {
+		if (abs >= s.factor) chosen = s
+		else break
+	}
+	return chosen
+}
+
+export function hasUnit(unit?: AxisUnit | null): boolean {
+	return !!unit && unit !== 'none' && getScales(unit) !== null
+}
+
+export function formatValueWithUnit(
+	value: number,
+	sourceUnit: AxisUnit | undefined,
+	precision = 1,
+): string {
+	if (value === null || value === undefined || isNaN(value as any)) return String(value)
+	if (!hasUnit(sourceUnit)) return formatPlain(value, precision)
+
+	const scales = getScales(sourceUnit as AxisUnit)!
+	const source = scales.find((s) => s.unit === sourceUnit)!
+	const baseValue = value * source.factor
+	const target = pickScale(baseValue, scales)
+	const scaled = baseValue / target.factor
+
+	return `${stripTrailingZeros(scaled.toFixed(precision))} ${target.suffix}`
+}
+
+function formatPlain(value: number, precision: number): string {
+	if (Math.abs(value) >= 1000) {
+		return new Intl.NumberFormat('en-US', {
+			notation: 'compact',
+			maximumFractionDigits: precision,
+		}).format(value)
+	}
+	return stripTrailingZeros(value.toFixed(precision))
+}
+
+function stripTrailingZeros(s: string): string {
+	if (!s.includes('.')) return s
+	return s.replace(/\.?0+$/, '')
+}

--- a/frontend/src2/types/chart.types.ts
+++ b/frontend/src2/types/chart.types.ts
@@ -31,7 +31,26 @@ export type YAxis = {
 	show_axis_label?: boolean
 	show_data_labels?: boolean
 	show_scrollbar?: boolean
+	units?: AxisUnit
 }
+
+export type AxisUnit =
+	| 'none'
+	| 'ns'
+	| 'us'
+	| 'ms'
+	| 's'
+	| 'min'
+	| 'h'
+	| 'd'
+	| 'w'
+	| 'mo'
+	| 'y'
+	| 'bytes'
+	| 'KB'
+	| 'MB'
+	| 'GB'
+	| 'TB'
 export type Series = {
 	name?: string
 	measure: Measure


### PR DESCRIPTION
Fix for https://github.com/frappe/insights/issues/593. X and Y axis labels now show in V3 charts when the label is enable and text is entered. 