### PR TITLE
fix: Cannot iterate local.insights_adhoc_filters if it's None

### DIFF
--- a/insights/insights/doctype/insights_data_source_v3/ibis_utils.py
+++ b/insights/insights/doctype/insights_data_source_v3/ibis_utils.py
@@ -59,6 +59,7 @@ class IbisQueryBuilder:
 
         if (
             hasattr(frappe.local, "insights_adhoc_filters")
+            and frappe.local.insights_adhoc_filters
             and self.doc.name in frappe.local.insights_adhoc_filters
         ):
             adhoc_filters = frappe.local.insights_adhoc_filters[self.doc.name]
@@ -667,7 +668,7 @@ class IbisQueryBuilder:
     def apply_code(self, code_args):
         code = code_args.code
 
-        adhoc_filters = frappe.as_json(getattr(frappe.local, "insights_adhoc_filters", {}))
+        adhoc_filters = frappe.as_json(getattr(frappe.local, "insights_adhoc_filters") or {})
         digest = make_digest(code + adhoc_filters)
 
         cached_results = get_cached_results(digest)


### PR DESCRIPTION
The set_adhoc_filters context manager sets `frappe.local.insights_adhoc_filters` to None when it's done, meaning that `frappe.local.insights_adhoc_filters` might be defined to None, instead of being missing. This means that `getattr` will return None instead of the default {}.


# Traceback

```
Traceback with variables (most recent call last):
  File "apps/insights/insights/insights/doctype/insights_alert/insights_alert.py", line 172, in send_alerts
    alert_doc.send_alert()
      alerts = [{'name': '2n7cvb3atu'}, {'name': '3arc4dii3g'}, {'name': '5cohdcfsj0'}, {'name': '8qulbd4if3'}, {'name': '335u16pa21'}, {'name': 'a30o6pe3pe'}, {'name': 'dvn2kmca9t'}, {'name': 'boj2q77u4l'}, {'name': 'effoomaojt'}]
      alert = {'name': '8qulbd4if3'}
      alert_doc = <InsightsAlert: 8qulbd4if3>
  File "apps/frappe/frappe/utils/typing_validations.py", line 32, in wrapper
    return func(*args, **kwargs)
      args = (<InsightsAlert: 8qulbd4if3>,)
      kwargs = {}
      apply_condition = <function whitelist.<locals>.innerfn.<locals>.<lambda> at 0x7feeaeb1ca40>
      func = <function InsightsAlert.send_alert at 0x7feeaeb1c9a0>
  File "apps/insights/insights/insights/doctype/insights_alert/insights_alert.py", line 62, in send_alert
    results = self.evaluate_condition()
      self = <InsightsAlert: 8qulbd4if3>
      force = False
  File "apps/insights/insights/insights/doctype/insights_alert/insights_alert.py", line 92, in evaluate_condition
    return doc.evaluate_alert_expression(self.condition)
      self = <InsightsAlert: 8qulbd4if3>
      doc = <InsightsQueryv3: 8ocourj9ia>
  File "apps/insights/insights/insights/doctype/insights_query_v3/insights_query_v3.py", line 272, in evaluate_alert_expression
    builder = IbisQueryBuilder(self)
      self = <InsightsQueryv3: 8ocourj9ia>
      expression = "q['percent_score'] != 0"
  File "apps/insights/insights/insights/doctype/insights_data_source_v3/ibis_utils.py", line 48, in __init__
    self.set_operations()
      self = <insights.insights.doctype.insights_data_source_v3.ibis_utils.IbisQueryBuilder object at 0x7fee771db690>
      doc = <InsightsQueryv3: 8ocourj9ia>
      active_operation_idx = None
  File "apps/insights/insights/insights/doctype/insights_data_source_v3/ibis_utils.py", line 62, in set_operations
    and self.doc.name in frappe.local.insights_adhoc_filters
      self = <insights.insights.doctype.insights_data_source_v3.ibis_utils.IbisQueryBuilder object at 0x7fee771db690>
      operations = ***
builtins.TypeError: argument of type 'NoneType' is not iterable
```