### PR TITLE
fix prevent deadlocks when saving multiple queries

### DIFF
--- a/insights/insights/doctype/insights_query_v3/insights_query_v3.py
+++ b/insights/insights/doctype/insights_query_v3/insights_query_v3.py
@@ -105,6 +105,7 @@ class InsightsQueryv3(Document):
             query_name=self.name,
             operations=self.operations,
             enqueue_after_commit=True,
+            now=bool(frappe.flags.in_test),
         )
 
     def cleanup_empty_folder(self, folder_name):

--- a/insights/insights/doctype/insights_query_v3/insights_query_v3.py
+++ b/insights/insights/doctype/insights_query_v3/insights_query_v3.py
@@ -100,7 +100,12 @@ class InsightsQueryv3(Document):
             )
 
     def on_update(self):
-        sync_query_references(self.name, self.operations)
+        frappe.enqueue(
+            sync_query_references,
+            query_name=self.name,
+            operations=self.operations,
+            enqueue_after_commit=True,
+        )
 
     def cleanup_empty_folder(self, folder_name):
         """Delete folder if it has no queries or charts"""

--- a/insights/insights/query_utils.py
+++ b/insights/insights/query_utils.py
@@ -107,10 +107,8 @@ def sync_query_references(query_name: str, operations) -> None:
     from frappe.model.document import bulk_insert
 
     ops = frappe.parse_json(operations) or []
-    frappe.db.delete("Insights Query Reference", {"query": query_name})
 
     docs = []
-
     all_table_deps = extract_table_deps_from_operations(ops) + extract_table_deps_from_sql_operations(ops)
     for tbl in all_table_deps:
         ref = frappe.new_doc("Insights Query Reference")
@@ -129,6 +127,7 @@ def sync_query_references(query_name: str, operations) -> None:
         ref.ref_query = dep_query
         docs.append(ref)
 
+    frappe.db.delete("Insights Query Reference", {"query": query_name})
     if docs:
         bulk_insert("Insights Query Reference", docs)
 


### PR DESCRIPTION
## Deadlock Root Cause

The deadlock is in `sync_query_references` ([[insights/insights/query_utils.py:101](https://claude.ai/epitaxy/insights/insights/query_utils.py)](insights/insights/query_utils.py)), which runs inside `on_update` every time any query is saved.

**The problematic pattern:**

```python
frappe.db.delete("Insights Query Reference", {"query": query_name})  # 1. DELETE
# ...build docs...
bulk_insert("Insights Query Reference", docs)                          # 2. INSERT
```

This delete-then-insert sequence happens **within the same open transaction** (Frappe wraps every request in a transaction). When two `set_value` requests for different queries land concurrently, you get a classic InnoDB gap-lock deadlock:

### Lock sequence

| Time | Transaction 1 (Query A) | Transaction 2 (Query B) |
|------|--------------------------|--------------------------|
| t1 | `DELETE WHERE query='A'` → acquires next-key locks on gaps around `query='A'` rows in the secondary index | |
| t2 | | `DELETE WHERE query='B'` → acquires next-key locks on gaps around `query='B'` rows |
| t3 | `bulk_insert(...)` → tries to INSERT rows; needs to insert into a primary-key gap position that T2's gap lock covers | |
| t4 | | `bulk_insert(...)` → tries to INSERT into a position covered by T1's gap lock |
| t5 | **DEADLOCK** | **DEADLOCK** |

InnoDB's next-key locks on the secondary index (`query` column) extend into adjacent key ranges, so even inserts for `query='A'` can conflict with gap locks acquired by `DELETE WHERE query='B'`.

### Why this specific trigger

The `set_value` API ([[frappe/client.py:215](https://github.com/frappe/frappe/blob/main/frappe/client.py)](https://github.com/frappe/frappe/blob/main/frappe/client.py)) is lightweight — it's called frequently (e.g., toggling `use_live_connection`, updating `title`). Any two concurrent `set_value` calls on **any** two `Insights Query v3` documents will race through `on_update` → `sync_query_references` and hit this window.

### Contributing factors

1. **`on_update` runs synchronously** — no debouncing or deferred execution.
2. **The table is shared** — all queries write to the same `Insights Query Reference` table.
3. **No retry logic** — `frappe.exceptions.QueryDeadlockError` is raised and propagates to the user as a 500.
4. **`bulk_insert` uses chunked multi-row INSERTs** — larger lock surface than individual inserts.