### PR TITLE
feat: format first day of fiscal year in table headers

### DIFF
--- a/frontend/src2/helpers/index.ts
+++ b/frontend/src2/helpers/index.ts
@@ -440,13 +440,16 @@ export function createHeaders(columns: QueryResultColumn[]) {
 		const areDates = areValidDates(headerRow.map((header) => header.label))
 		if (!areDates) continue
 
+		const areFirstOfFiscalYear = areFirstDayOfFiscalYear(headerRow.map((header) => header.label))
 		const areFirstOfYear = areFirstDayOfYear(headerRow.map((header) => header.label))
 		const areFirstOfMonth = areFirstDayOfMonth(headerRow.map((header) => header.label))
 
 		for (let header of headerRow) {
 			if (!isValidDate(header.label)) continue
 
-			if (areFirstOfYear) {
+			if (areFirstOfFiscalYear) {
+				header.label = getFormattedDate(header.label, 'fiscal_year')
+			} else if (areFirstOfYear) {
 				header.label = getFormattedDate(header.label, 'year')
 			} else if (areFirstOfMonth) {
 				header.label = getFormattedDate(header.label, 'month')
@@ -457,6 +460,24 @@ export function createHeaders(columns: QueryResultColumn[]) {
 	}
 
 	return groupedHeaders
+}
+
+function areFirstDayOfFiscalYear(data: string[]) {
+	const fiscalYearStart = session.user?.fiscal_year_start
+	if (!fiscalYearStart) return false
+
+	const start = new Date(fiscalYearStart)
+	const fiscalStartMonth = start.getMonth()
+	const fiscalStartDay = start.getDate()
+
+	// when the fiscal year aligns with the calendar year, defer to year formatting
+	if (fiscalStartMonth === 0 && fiscalStartDay === 1) return false
+
+	const firstDayOfFiscalYear = (date: string) => {
+		const d = new Date(date)
+		return d.getMonth() === fiscalStartMonth && d.getDate() === fiscalStartDay
+	}
+	return data.map(firstDayOfFiscalYear).filter(Boolean).length / data.length >= 0.5
 }
 
 function areFirstDayOfMonth(data: string[]) {


### PR DESCRIPTION
Formats column headers falling on the first day of the fiscal year as fiscal-year labels (e.g. `FY 2016-17`).