### PR TITLE
feat: add dashboard folders

### DIFF
--- a/frontend/src2/dashboard/DashboardCard.vue
+++ b/frontend/src2/dashboard/DashboardCard.vue
@@ -1,10 +1,11 @@
 <script setup lang="tsx">
-import { BarChart2, Clock, Eye, MoreVertical, RefreshCw, Bookmark } from 'lucide-vue-next'
+import { BarChart2, Bookmark, Clock, Eye, Folder, MoreVertical, RefreshCw } from 'lucide-vue-next'
 import { DashboardListItem } from './dashboards'
 
 interface Props {
 	dashboard: DashboardListItem
 	dropdownOptions: any[]
+	folderTitle?: string
 	previewLoading?: boolean
 }
 
@@ -30,10 +31,7 @@ const emit = defineEmits<{
 				onerror="this.src = ''"
 				class="object-cover opacity-80"
 			/>
-			<div
-				v-else
-				class="flex h-full w-full items-center justify-center bg-gray-50/70"
-			>
+			<div v-else class="flex h-full w-full items-center justify-center bg-gray-50/70">
 				<Button
 					variant="ghost"
 					@click.prevent.stop="emit('update-preview')"
@@ -53,6 +51,14 @@ const emit = defineEmits<{
 					<p class="truncate text-sm" :title="dashboard.title">
 						{{ dashboard.title }}
 					</p>
+				</div>
+				<div
+					v-if="folderTitle"
+					class="mt-1 flex min-w-0 items-center gap-1 text-xs text-gray-600"
+					:title="folderTitle"
+				>
+					<Folder class="h-3 w-3 shrink-0" stroke-width="1.5" />
+					<span class="truncate">{{ folderTitle }}</span>
 				</div>
 				<div class="mt-1.5 flex gap-2">
 					<div class="flex items-center gap-1">

--- a/frontend/src2/dashboard/DashboardList.vue
+++ b/frontend/src2/dashboard/DashboardList.vue
@@ -1,22 +1,78 @@
 <script setup lang="tsx">
 import { Breadcrumbs } from 'frappe-ui'
-import { SearchIcon } from 'lucide-vue-next'
-import { computed, ref, watchEffect } from 'vue'
+import {
+	Check,
+	Folder,
+	FolderOpen,
+	GripVertical,
+	Pencil,
+	Plus,
+	SearchIcon,
+	Star,
+	Trash2,
+	X,
+} from 'lucide-vue-next'
+import { computed, nextTick, ref, watchEffect } from 'vue'
 import { useRouter } from 'vue-router'
-import useDashboardStore, { DashboardListItem } from './dashboards'
-import DashboardCard from './DashboardCard.vue'
+import { confirmDialog } from '../helpers/confirm_dialog'
 import { __ } from '../translation'
+import DashboardCard from './DashboardCard.vue'
+import useDashboardStore, { DashboardFolder, DashboardListItem } from './dashboards'
 
 const store = useDashboardStore()
+const MAX_FOLDER_TITLE_LENGTH = 50
 const searchQuery = ref('')
 watchEffect(() => {
 	store.fetchDashboards(searchQuery.value)
 })
 
-const favorites = computed(() => store.favorites)
+const selectedFolder = ref('')
+watchEffect(() => {
+	if (!store.loading && !selectedFolder.value) {
+		selectedFolder.value = store.favorites.length ? 'favorites' : 'all'
+	}
+})
+
+const filteredDashboards = computed(() => {
+	if (selectedFolder.value === 'favorites') return store.favorites
+	if (selectedFolder.value === 'all') return store.dashboards
+	return store.dashboards.filter((dashboard) => dashboard.folder === selectedFolder.value)
+})
+
+const selectedTitle = computed(() => {
+	if (selectedFolder.value === 'favorites') return __('Favorites')
+	if (selectedFolder.value === 'all') return __('All Dashboards')
+	return (
+		store.folders.find((folder) => folder.name === selectedFolder.value)?.title ||
+		__('Dashboards')
+	)
+})
+
+const getFolderTitle = (dashboard: DashboardListItem) => {
+	if (selectedFolder.value !== 'all' || !dashboard.folder) return
+	return store.folders.find((folder) => folder.name === dashboard.folder)?.title
+}
 
 const router = useRouter()
 const dropdownOptions = (dashboard: DashboardListItem) => {
+	const moveSubmenu = [
+		...(dashboard.folder
+			? [
+					{
+						label: __('Remove from folder'),
+						icon: 'folder-minus',
+						onClick: () => store.moveDashboard(dashboard.name),
+					},
+			  ]
+			: []),
+		...store.folders
+			.filter((folder) => folder.name !== dashboard.folder)
+			.map((folder) => ({
+				label: folder.title,
+				icon: 'folder',
+				onClick: () => store.moveDashboard(dashboard.name, folder.name),
+			})),
+	]
 	return [
 		{
 			label: __('Open Workbook'),
@@ -29,11 +85,109 @@ const dropdownOptions = (dashboard: DashboardListItem) => {
 			loading: store.updatingPreviewImage,
 			onClick: () => store.updatePreviewImage(dashboard.name),
 		},
+		...(moveSubmenu.length
+			? [
+					{
+						label: __('Move to'),
+						icon: 'folder',
+						submenu: moveSubmenu,
+					},
+			  ]
+			: []),
 	]
 }
 
 const toggleFavorite = (dashboard: DashboardListItem) => {
 	store.toggleLike(dashboard.name, !dashboard.is_favourite)
+}
+
+const creatingFolder = ref(false)
+const folderTitle = ref('')
+const folderInput = ref<HTMLInputElement>()
+async function startCreatingFolder() {
+	creatingFolder.value = true
+	folderTitle.value = ''
+	await nextTick()
+	folderInput.value?.focus()
+}
+
+async function createFolder() {
+	const title = folderTitle.value.trim()
+	if (!title) return
+	await store.createFolder(title)
+	creatingFolder.value = false
+}
+
+const editingFolder = ref<string>()
+async function startRenaming(folder: DashboardFolder) {
+	editingFolder.value = folder.name
+	folderTitle.value = folder.title
+	await nextTick()
+	document.querySelector<HTMLInputElement>(`[data-folder-input="${folder.name}"]`)?.select()
+}
+
+async function renameFolder(folder: DashboardFolder) {
+	const title = folderTitle.value.trim()
+	if (title && title !== folder.title) await store.renameFolder(folder.name, title)
+	editingFolder.value = undefined
+}
+
+function deleteFolder(folder: DashboardFolder) {
+	confirmDialog({
+		title: __('Delete Folder'),
+		message: __('Dashboards in this folder will remain in All Dashboards. Continue?'),
+		theme: 'red',
+		onSuccess: async () => {
+			await store.deleteFolder(folder.name)
+			if (selectedFolder.value === folder.name) selectedFolder.value = 'all'
+		},
+	})
+}
+
+const draggedDashboard = ref<string>()
+const draggedFolder = ref<string>()
+const dragOverFolder = ref<string>()
+
+function startDashboardDrag(event: DragEvent, dashboard: DashboardListItem) {
+	draggedDashboard.value = dashboard.name
+	event.dataTransfer?.setData('text/plain', dashboard.name)
+	if (event.dataTransfer) event.dataTransfer.effectAllowed = 'move'
+}
+
+function startFolderDrag(event: DragEvent, folder: DashboardFolder) {
+	draggedFolder.value = folder.name
+	event.dataTransfer?.setData('text/plain', folder.name)
+	if (event.dataTransfer) event.dataTransfer.effectAllowed = 'move'
+}
+
+function allowFolderDrop(event: DragEvent, folderName: string) {
+	event.preventDefault()
+	dragOverFolder.value = folderName
+}
+
+async function dropOnFolder(folderName?: string) {
+	if (draggedDashboard.value) {
+		await store.moveDashboard(draggedDashboard.value, folderName)
+	}
+	draggedDashboard.value = undefined
+	dragOverFolder.value = undefined
+}
+
+async function dropFolderBefore(targetFolder: DashboardFolder) {
+	if (!draggedFolder.value || draggedFolder.value === targetFolder.name) return
+	const folderNames = store.folders.map((folder) => folder.name)
+	const from = folderNames.indexOf(draggedFolder.value)
+	const to = folderNames.indexOf(targetFolder.name)
+	folderNames.splice(to, 0, folderNames.splice(from, 1)[0])
+	await store.updateFolderOrder(folderNames)
+	draggedFolder.value = undefined
+	dragOverFolder.value = undefined
+}
+
+function finishDrag() {
+	draggedDashboard.value = undefined
+	draggedFolder.value = undefined
+	dragOverFolder.value = undefined
 }
 
 watchEffect(() => {
@@ -44,44 +198,165 @@ watchEffect(() => {
 <template>
 	<header class="flex h-12 items-center justify-between border-b py-2.5 pl-5 pr-2">
 		<Breadcrumbs :items="[{ label: 'Dashboards', route: '/dashboards' }]" />
-		<div class="flex items-center gap-2"></div>
 	</header>
 
-	<div class="mb-4 flex h-full flex-col gap-3 overflow-auto px-5 py-3">
-		<div class="flex gap-2 overflow-visible py-1">
-			<FormControl :placeholder="__('Search')" v-model="searchQuery" :debounce="300">
-				<template #prefix>
-					<SearchIcon class="h-4 w-4 text-gray-500" />
-				</template>
-			</FormControl>
-		</div>
-		<!-- favourite dashboards -->
-		<div class="h-full w-full">
-			<div v-if="favorites.length > 0" class="mb-8">
-				<h2 class="mb-4 text-lg font-semibold text-gray-700">{{ __('Favorites') }}</h2>
-				<div class="grid grid-cols-1 gap-10 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-					<DashboardCard
-						v-for="dashboard in favorites"
-						:key="'fav-' + dashboard.name"
-						:dashboard="dashboard"
-						:dropdown-options="dropdownOptions(dashboard)"
-						:preview-loading="store.updatingPreviewImage[dashboard.name]"
-						@toggle-favorite="toggleFavorite(dashboard)"
-						@update-preview="store.updatePreviewImage(dashboard.name)"
+	<div class="flex min-h-0 flex-1">
+		<aside class="flex w-56 shrink-0 flex-col border-r bg-gray-50/60 p-3">
+			<div class="mb-2 flex items-center justify-between px-2">
+				<span class="text-xs font-medium uppercase text-gray-500">{{ __('Folders') }}</span>
+				<Button
+					variant="ghost"
+					class="!h-7 !w-7 !p-1"
+					:title="__('New Folder')"
+					@click="startCreatingFolder"
+				>
+					<Plus class="h-4 w-4" />
+				</Button>
+			</div>
+
+			<div class="space-y-0.5">
+				<button
+					class="flex w-full items-center gap-2 rounded px-2 py-1.5 text-sm hover:bg-gray-100"
+					:class="{ 'bg-gray-200 font-medium': selectedFolder === 'favorites' }"
+					@click="selectedFolder = 'favorites'"
+				>
+					<Star class="h-4 w-4 text-gray-500" stroke-width="1.5" />
+					<span class="flex-1 truncate text-left">{{ __('Favorites') }}</span>
+					<span class="w-5 text-right text-xs text-gray-500">
+						{{ store.favorites.length }}
+					</span>
+				</button>
+				<button
+					class="flex w-full items-center gap-2 rounded px-2 py-1.5 text-sm hover:bg-gray-100"
+					:class="{ 'bg-gray-200 font-medium': selectedFolder === 'all' }"
+					@click="selectedFolder = 'all'"
+				>
+					<FolderOpen class="h-4 w-4 text-gray-500" stroke-width="1.5" />
+					<span class="flex-1 truncate text-left">{{ __('All Dashboards') }}</span>
+					<span class="w-5 text-right text-xs text-gray-500">
+						{{ store.dashboards.length }}
+					</span>
+				</button>
+			</div>
+
+			<div class="my-2 border-t" />
+
+			<div v-if="creatingFolder" class="mb-1 flex items-center gap-1 px-1">
+				<input
+					ref="folderInput"
+					v-model="folderTitle"
+					:maxlength="MAX_FOLDER_TITLE_LENGTH"
+					class="h-7 min-w-0 flex-1 rounded border bg-white px-2 text-sm outline-none focus:border-gray-500"
+					:placeholder="__('Folder name')"
+					@keydown.enter="createFolder"
+					@keydown.esc="creatingFolder = false"
+				/>
+				<button class="rounded p-1 hover:bg-gray-200" @click="createFolder">
+					<Check class="h-3.5 w-3.5" />
+				</button>
+				<button class="rounded p-1 hover:bg-gray-200" @click="creatingFolder = false">
+					<X class="h-3.5 w-3.5" />
+				</button>
+			</div>
+
+			<div class="min-h-0 flex-1 space-y-0.5 overflow-auto">
+				<div
+					v-for="folder in store.folders"
+					:key="folder.name"
+					class="group flex items-center gap-1 rounded px-2 py-0.5 hover:bg-gray-100"
+					:class="{
+						'bg-gray-200': selectedFolder === folder.name,
+						'bg-blue-50': dragOverFolder === folder.name,
+					}"
+					draggable="true"
+					@dragstart="startFolderDrag($event, folder)"
+					@dragend="finishDrag"
+					@dragover="allowFolderDrop($event, folder.name)"
+					@dragleave="dragOverFolder = undefined"
+					@drop.prevent="
+						draggedFolder ? dropFolderBefore(folder) : dropOnFolder(folder.name)
+					"
+				>
+					<GripVertical class="h-3.5 w-3.5 shrink-0 cursor-grab text-gray-400" />
+					<Folder class="h-4 w-4 shrink-0 text-gray-500" stroke-width="1.5" />
+					<input
+						v-if="editingFolder === folder.name"
+						v-model="folderTitle"
+						:maxlength="MAX_FOLDER_TITLE_LENGTH"
+						:data-folder-input="folder.name"
+						class="h-7 min-w-0 flex-1 rounded border bg-white px-1.5 text-sm outline-none"
+						@keydown.enter="renameFolder(folder)"
+						@keydown.esc="editingFolder = undefined"
+						@blur="renameFolder(folder)"
 					/>
+					<button
+						v-else
+						class="min-w-0 flex-1 truncate py-1 text-left text-sm"
+						@click="selectedFolder = folder.name"
+					>
+						{{ folder.title }}
+					</button>
+					<span class="w-5 text-right text-xs text-gray-500 group-hover:hidden">
+						{{
+							store.dashboards.filter((dashboard) => dashboard.folder === folder.name)
+								.length
+						}}
+					</span>
+					<div class="hidden items-center group-hover:flex">
+						<button
+							class="rounded p-1 hover:bg-gray-200"
+							:title="__('Rename')"
+							@click="startRenaming(folder)"
+						>
+							<Pencil class="h-3.5 w-3.5" />
+						</button>
+						<button
+							class="rounded p-1 hover:bg-gray-200"
+							:title="__('Delete')"
+							@click="deleteFolder(folder)"
+						>
+							<Trash2 class="h-3.5 w-3.5 text-red-600" />
+						</button>
+					</div>
 				</div>
 			</div>
-			<!-- all dashboards -->
-			<div v-if="store.dashboards.length">
-				<h2 v-if="favorites.length > 0" class="mb-4 text-lg font-semibold text-gray-700">
-					All Dashboards
-				</h2>
-				<div class="grid grid-cols-1 gap-10 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+		</aside>
+
+		<main class="min-w-0 flex-1 overflow-auto px-5 py-3">
+			<div class="mb-5 flex items-center justify-between gap-4">
+				<div>
+					<h2 class="text-lg font-semibold text-gray-700">{{ selectedTitle }}</h2>
+					<p class="mt-1 text-sm text-gray-500">
+						{{ __('{0} dashboards', String(filteredDashboards.length)) }}
+					</p>
+				</div>
+				<FormControl
+					class="w-64"
+					:placeholder="__('Search')"
+					v-model="searchQuery"
+					:debounce="300"
+				>
+					<template #prefix>
+						<SearchIcon class="h-4 w-4 text-gray-500" />
+					</template>
+				</FormControl>
+			</div>
+
+			<div
+				v-if="filteredDashboards.length"
+				class="grid grid-cols-1 gap-10 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"
+			>
+				<div
+					v-for="dashboard in filteredDashboards"
+					:key="dashboard.name"
+					draggable="true"
+					@dragstart="startDashboardDrag($event, dashboard)"
+					@dragend="finishDrag"
+				>
 					<DashboardCard
-						v-for="dashboard in store.dashboards"
-						:key="dashboard.name"
 						:dashboard="dashboard"
 						:dropdown-options="dropdownOptions(dashboard)"
+						:folder-title="getFolderTitle(dashboard)"
 						:preview-loading="store.updatingPreviewImage[dashboard.name]"
 						@toggle-favorite="toggleFavorite(dashboard)"
 						@update-preview="store.updatePreviewImage(dashboard.name)"
@@ -89,13 +364,12 @@ watchEffect(() => {
 				</div>
 			</div>
 
-			<!-- Empty State -->
-			<div v-else class="flex h-full w-full flex-col items-center justify-center text-base">
+			<div v-else class="flex h-64 w-full flex-col items-center justify-center text-base">
 				<div class="text-xl font-medium">{{ __('No Dashboards') }}</div>
 				<div class="mt-1 text-base text-gray-600">
-					{{ __('Create a dashboard in your workbook to view it here.') }}
+					{{ __('Drag dashboards into this folder or create one in a workbook.') }}
 				</div>
 			</div>
-		</div>
+		</main>
 	</div>
 </template>

--- a/frontend/src2/dashboard/dashboards.ts
+++ b/frontend/src2/dashboard/dashboards.ts
@@ -16,10 +16,18 @@ export type DashboardListItem = {
 	preview_image: string
 	views: number
 	is_favourite: boolean
+	folder?: string | null
+}
+
+export type DashboardFolder = {
+	name: string
+	title: string
+	sort_order: number
 }
 
 const dashboards = ref<DashboardListItem[]>([])
 const favorites = ref<DashboardListItem[]>([])
+const folders = ref<DashboardFolder[]>([])
 
 const loading = ref(false)
 const mapTimeAgo = (dashboard: any) => ({
@@ -27,16 +35,18 @@ const mapTimeAgo = (dashboard: any) => ({
 	created_from_now: useTimeAgo(dashboard.creation),
 	modified_from_now: useTimeAgo(dashboard.modified),
 })
-async function fetchDashboards(search_term?: string, limit: number = 50) {
+async function fetchDashboards(search_term?: string, limit: number = 0) {
 	loading.value = true
 
-	const [regular, fav] = await Promise.all([
+	const [regular, fav, dashboardFolders] = await Promise.all([
 		call('insights.api.dashboards.get_dashboards', { search_term, limit }),
 		call('insights.api.dashboards.get_dashboards', { get_favorites: true }),
+		call('insights.api.dashboards.get_dashboard_folders'),
 	])
 
 	dashboards.value = regular.map(mapTimeAgo)
 	favorites.value = fav.map(mapTimeAgo)
+	folders.value = dashboardFolders
 	loading.value = false
 }
 
@@ -66,6 +76,40 @@ async function toggleLike(dashboard_name: string, add: boolean) {
 	}).then(() => fetchDashboards())
 }
 
+async function createFolder(title: string) {
+	await call('insights.api.dashboards.create_dashboard_folder', { title }).catch(showErrorToast)
+	return fetchDashboards()
+}
+
+async function renameFolder(folder_name: string, title: string) {
+	await call('insights.api.dashboards.rename_dashboard_folder', { folder_name, title }).catch(
+		showErrorToast,
+	)
+	return fetchDashboards()
+}
+
+async function deleteFolder(folder_name: string) {
+	await call('insights.api.dashboards.delete_dashboard_folder', { folder_name }).catch(
+		showErrorToast,
+	)
+	return fetchDashboards()
+}
+
+async function moveDashboard(dashboard_name: string, folder_name?: string | null) {
+	await call('insights.api.dashboards.move_dashboard_to_folder', {
+		dashboard_name,
+		folder_name: folder_name || null,
+	}).catch(showErrorToast)
+	return fetchDashboards()
+}
+
+async function updateFolderOrder(folder_names: string[]) {
+	await call('insights.api.dashboards.update_dashboard_folder_order', { folder_names }).catch(
+		showErrorToast,
+	)
+	return fetchDashboards()
+}
+
 export default function useDashboardStore() {
 	if (!dashboards.value.length) {
 		fetchDashboards()
@@ -74,6 +118,7 @@ export default function useDashboardStore() {
 	return reactive({
 		dashboards,
 		favorites,
+		folders,
 		loading,
 		fetchDashboards,
 
@@ -81,5 +126,10 @@ export default function useDashboardStore() {
 		updatingPreviewImage,
 
 		toggleLike,
+		createFolder,
+		renameFolder,
+		deleteFolder,
+		moveDashboard,
+		updateFolderOrder,
 	})
 }

--- a/frontend/src2/types/workbook.types.ts
+++ b/frontend/src2/types/workbook.types.ts
@@ -108,6 +108,7 @@ export type InsightsDashboardv3 = {
 	owner: string
 	title: string
 	workbook: string
+	folder?: string | null
 	items: WorkbookDashboardItem[]
 	preview_image?: string
 	share_link?: string

--- a/insights/api/dashboards.py
+++ b/insights/api/dashboards.py
@@ -1,4 +1,5 @@
 import frappe
+from frappe import _
 
 from insights.api.permissions import is_private
 from insights.decorators import insights_whitelist, validate_type
@@ -85,6 +86,7 @@ def get_dashboards(search_term: str | None = None, limit: int = 50, get_favorite
             "name",
             "title",
             "workbook",
+            "folder",
             "creation",
             "modified",
             "preview_image",
@@ -111,6 +113,73 @@ def get_dashboards(search_term: str | None = None, limit: int = 50, get_favorite
         del dashboard["items"]
 
     return dashboards
+
+
+@insights_whitelist()
+def get_dashboard_folders():
+    return frappe.get_all(
+        "Insights Folder",
+        filters={"type": "dashboard"},
+        fields=["name", "title", "sort_order"],
+        order_by="sort_order asc, creation asc",
+    )
+
+
+@insights_whitelist()
+def create_dashboard_folder(title: str):
+    folder = frappe.new_doc("Insights Folder")
+    folder.title = title
+    folder.type = "dashboard"
+    folder.sort_order = frappe.db.count("Insights Folder", filters={"type": "dashboard"})
+    folder.insert()
+    return folder.as_dict()
+
+
+def get_dashboard_folder(folder_name: str):
+    folder = frappe.get_doc("Insights Folder", folder_name)
+    if folder.type != "dashboard":
+        frappe.throw(_("Invalid dashboard folder"))
+    return folder
+
+
+@insights_whitelist()
+def rename_dashboard_folder(folder_name: str, title: str):
+    folder = get_dashboard_folder(folder_name)
+    folder.check_permission("write")
+    folder.title = title
+    folder.save()
+    return folder.as_dict()
+
+
+@insights_whitelist()
+def delete_dashboard_folder(folder_name: str):
+    folder = get_dashboard_folder(folder_name)
+    folder.check_permission("delete")
+    frappe.db.set_value(
+        "Insights Dashboard v3",
+        {"folder": folder_name},
+        "folder",
+        None,
+        update_modified=False,
+    )
+    folder.delete()
+
+
+@insights_whitelist()
+def move_dashboard_to_folder(dashboard_name: str, folder_name: str | None = None):
+    dashboard = frappe.get_doc("Insights Dashboard v3", dashboard_name)
+    dashboard.check_permission("write")
+    if folder_name:
+        get_dashboard_folder(folder_name).check_permission("read")
+    dashboard.db_set("folder", folder_name, update_modified=False)
+
+
+@insights_whitelist()
+def update_dashboard_folder_order(folder_names: list[str]):
+    for sort_order, folder_name in enumerate(folder_names):
+        folder = get_dashboard_folder(folder_name)
+        folder.check_permission("write")
+        folder.db_set("sort_order", sort_order, update_modified=False)
 
 
 @insights_whitelist()

--- a/insights/insights/doctype/insights_dashboard_v3/insights_dashboard_v3.json
+++ b/insights/insights/doctype/insights_dashboard_v3/insights_dashboard_v3.json
@@ -9,6 +9,7 @@
   "share_link",
   "column_break_owsx",
   "workbook",
+  "folder",
   "is_public",
   "vertical_compact_layout",
   "section_break_lgpd",
@@ -50,6 +51,14 @@
    "options": "Insights Workbook",
    "reqd": 1,
    "search_index": 1
+  },
+  {
+   "fieldname": "folder",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Folder",
+   "options": "Insights Folder"
   },
   {
    "fieldname": "share_link",

--- a/insights/insights/doctype/insights_dashboard_v3/insights_dashboard_v3.py
+++ b/insights/insights/doctype/insights_dashboard_v3/insights_dashboard_v3.py
@@ -6,6 +6,7 @@ from contextlib import contextmanager
 
 import frappe
 import requests
+from frappe import _
 from frappe.model.document import Document
 from frappe.query_builder import Interval
 from frappe.query_builder.functions import Now
@@ -82,7 +83,7 @@ class InsightsDashboardv3(Document):
 
         folder = frappe.get_doc("Insights Folder", self.folder)
         if folder.type != "dashboard":
-            frappe.throw("Dashboard folder must be a dashboard folder")
+            frappe.throw(_("Dashboard folder must be a dashboard folder"))
 
     def set_linked_charts(self):
         self.set(

--- a/insights/insights/doctype/insights_dashboard_v3/insights_dashboard_v3.py
+++ b/insights/insights/doctype/insights_dashboard_v3/insights_dashboard_v3.py
@@ -27,6 +27,7 @@ class InsightsDashboardv3(Document):
             InsightsDashboardChartv3,
         )
 
+        folder: DF.Link | None
         is_public: DF.Check
         items: DF.JSON | None
         linked_charts: DF.TableMultiSelect[InsightsDashboardChartv3]
@@ -71,8 +72,17 @@ class InsightsDashboardv3(Document):
         return d
 
     def before_save(self):
+        self.validate_folder()
         self.set_linked_charts()
         self.enqueue_update_dashboard_preview()
+
+    def validate_folder(self):
+        if not self.folder:
+            return
+
+        folder = frappe.get_doc("Insights Folder", self.folder)
+        if folder.type != "dashboard":
+            frappe.throw("Dashboard folder must be a dashboard folder")
 
     def set_linked_charts(self):
         self.set(

--- a/insights/insights/doctype/insights_folder/insights_folder.json
+++ b/insights/insights/doctype/insights_folder/insights_folder.json
@@ -26,7 +26,6 @@
    "in_standard_filter": 1,
    "label": "Workbook",
    "options": "Insights Workbook",
-   "reqd": 1,
    "search_index": 1
   },
   {
@@ -35,7 +34,7 @@
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Type",
-   "options": "query\nchart",
+   "options": "query\nchart\ndashboard",
    "reqd": 1
   },
   {

--- a/insights/insights/doctype/insights_folder/insights_folder.py
+++ b/insights/insights/doctype/insights_folder/insights_folder.py
@@ -31,4 +31,4 @@ class InsightsFolder(Document):
         if self.type == "dashboard":
             self.workbook = None
         elif not self.workbook:
-            frappe.throw("Workbook is required for query and chart folders")
+            frappe.throw(_("Workbook is required for query and chart folders"))

--- a/insights/insights/doctype/insights_folder/insights_folder.py
+++ b/insights/insights/doctype/insights_folder/insights_folder.py
@@ -1,22 +1,34 @@
 # Copyright (c) 2025, Frappe Technologies Pvt. Ltd. and contributors
 # For license information, please see license.txt
 
+import frappe
+from frappe import _
 from frappe.model.document import Document
+
+MAX_FOLDER_TITLE_LENGTH = 50
 
 
 class InsightsFolder(Document):
-	# begin: auto-generated types
-	# This code is auto-generated. Do not modify anything in this block.
+    # begin: auto-generated types
+    # This code is auto-generated. Do not modify anything in this block.
 
-	from typing import TYPE_CHECKING
+    from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
-		from frappe.types import DF
+    if TYPE_CHECKING:
+        from frappe.types import DF
 
-		is_expanded: DF.Check
-		sort_order: DF.Int
-		title: DF.Data
-		type: DF.Literal["query", "chart"]
-		workbook: DF.Link
-	# end: auto-generated types
-	pass
+        is_expanded: DF.Check
+        sort_order: DF.Int
+        title: DF.Data
+        type: DF.Literal["query", "chart", "dashboard"]
+        workbook: DF.Link | None
+    # end: auto-generated types
+
+    def validate(self):
+        if len(self.title or "") > MAX_FOLDER_TITLE_LENGTH:
+            frappe.throw(_("Folder name cannot exceed {0} characters").format(MAX_FOLDER_TITLE_LENGTH))
+
+        if self.type == "dashboard":
+            self.workbook = None
+        elif not self.workbook:
+            frappe.throw("Workbook is required for query and chart folders")


### PR DESCRIPTION
## Summary
- add dashboard folder persistence and APIs
- add folder rail to the dashboards page with create, rename, delete, reorder, and drag/drop move support
- show folder names on dashboard cards in All Dashboards and keep Favorites user-specific

## Verification
- pre-commit run --files frontend/src2/dashboard/DashboardCard.vue frontend/src2/dashboard/DashboardList.vue frontend/src2/dashboard/dashboards.ts frontend/src2/types/workbook.types.ts insights/api/dashboards.py insights/insights/doctype/insights_dashboard_v3/insights_dashboard_v3.json insights/insights/doctype/insights_dashboard_v3/insights_dashboard_v3.py insights/insights/doctype/insights_folder/insights_folder.json insights/insights/doctype/insights_folder/insights_folder.py
- yarn build
- bench --site prm.localhost migrate
- verified dashboard folder flows in local browser


https://github.com/user-attachments/assets/b12603bd-5864-40aa-9580-cb0bdb552589

