### PR TITLE
refactor: query builder toolbar and status

### DIFF
--- a/frontend/src2/charts/components/DrillDown.vue
+++ b/frontend/src2/charts/components/DrillDown.vue
@@ -3,7 +3,8 @@ import { debounce } from 'frappe-ui'
 import { Combine } from 'lucide-vue-next'
 import { inject, provide, ref, nextTick } from 'vue'
 import { wheneverChanges } from '../../helpers'
-import QueryBuilderToolbar from '../../query/components/QueryBuilderToolbar.vue'
+import QueryExecutionStatus from '../../query/components/QueryExecutionStatus.vue'
+import QueryToolbar from '../../query/components/QueryToolbar.vue'
 import QueryDataTable from '../../query/components/QueryDataTable.vue'
 import QueryOperations from '../../query/components/QueryOperations.vue'
 import { count, makeDimension } from '../../query/helpers'
@@ -69,7 +70,9 @@ const groupBy = debounce(_groupBy, 50)
 				class="relative flex h-[32rem] w-full flex-1 gap-4 overflow-hidden bg-white"
 			>
 				<div class="flex h-full flex-1 flex-col gap-2 overflow-hidden p-0.5">
-					<QueryBuilderToolbar></QueryBuilderToolbar>
+					<QueryToolbar>
+						<QueryExecutionStatus />
+					</QueryToolbar>
 					<div class="flex flex-1 overflow-hidden rounded border">
 						<QueryDataTable
 							:enable-sort="true"

--- a/frontend/src2/query/components/NativeQueryEditor.vue
+++ b/frontend/src2/query/components/NativeQueryEditor.vue
@@ -1,21 +1,19 @@
 <script setup lang="ts">
-import { useTimeAgo } from '@vueuse/core'
-import { Copy, CopyPlus, MoreHorizontal, PlayIcon, RefreshCw, Scroll, Wand2 } from 'lucide-vue-next'
+import { Wand2 } from 'lucide-vue-next'
 import { computed, h, inject, ref } from 'vue'
 import Code from '../../components/Code.vue'
-import { formatShortcut, useShortcut } from '../../composables/useShortcut'
+import { useShortcut } from '../../composables/useShortcut'
 import useDataSourceStore from '../../data_source/data_source'
 import { wheneverChanges } from '../../helpers'
 import { createToast } from '../../helpers/toasts'
-import session from '../../session'
 import { __ } from '../../translation'
 import { Query } from '../query'
+import QueryExecutionStatus from './QueryExecutionStatus.vue'
+import QueryToolbar from './QueryToolbar.vue'
 import QueryDataTable from './QueryDataTable.vue'
 import QueryInfo from './QueryInfo.vue'
 import SchemaExplorer from './SchemaExplorer.vue'
 import DataSourceSelector from './source_selector/DataSourceSelector.vue'
-import ViewSQLDialog from './ViewSQLDialog.vue'
-import { Tooltip } from 'frappe-ui'
 
 const query = inject<Query>('query')!
 query.autoExecute = false
@@ -62,44 +60,13 @@ async function format() {
 	}
 }
 
-const showViewSQLDialog = ref(false)
-
-const moreActions = computed(() => {
-	const actions: any[] = []
-
-	if (!query.doc.use_live_connection && session.user.is_admin) {
-		actions.push({
-			label: __('Refresh Stored Tables'),
-			icon: h(RefreshCw, { class: 'h-3 w-3 text-gray-700', strokeWidth: 1.5 }),
-			onClick: query.refreshStoredTables,
-		})
-	}
-
-	actions.push(
-		{
-			label: __('Format SQL'),
-			icon: h(Wand2, { class: 'h-3 w-3 text-gray-700', strokeWidth: 1.5 }),
-			onClick: () => format(),
-		},
-		{
-			label: __('View SQL'),
-			icon: h(Scroll, { class: 'h-3 w-3 text-gray-700', strokeWidth: 1.5 }),
-			onClick: () => (showViewSQLDialog.value = true),
-		},
-		{
-			label: __('Duplicate Query'),
-			icon: h(CopyPlus, { class: 'h-3 w-3 text-gray-700', strokeWidth: 1.5 }),
-			onClick: () => query.duplicate(),
-		},
-		{
-			label: __('Copy Query'),
-			icon: h(Copy, { class: 'h-3 w-3 text-gray-700', strokeWidth: 1.5 }),
-			onClick: () => query.copy(),
-		},
-	)
-
-	return actions
-})
+const extraActions = () => [
+	{
+		label: __('Format SQL'),
+		icon: h(Wand2, { class: 'h-3 w-3 text-gray-700', strokeWidth: 1.5 }),
+		onClick: () => format(),
+	},
+]
 
 const codeEditor = ref<InstanceType<typeof Code> | null>(null)
 function insertTextIntoEditor(text: string) {
@@ -158,25 +125,9 @@ useShortcut('Meta+e', () => {
 	<div class="flex flex-1 overflow-hidden">
 		<div class="relative flex h-full flex-1 flex-col gap-3 overflow-hidden p-4">
 			<!-- Toolbar -->
-			<div class="flex w-full flex-shrink-0 items-center justify-between bg-white">
+			<QueryToolbar :on-execute="() => execute(true)" :extra-actions="extraActions">
 				<DataSourceSelector v-model="data_source" placeholder="Select a data source" />
-				<div class="flex items-center gap-2">
-					<Tooltip :text="__('Execute ({0})', formatShortcut('Meta+E'))">
-						<Button variant="outline" :label="__('Execute')" @click="execute(true)">
-							<template #prefix>
-								<PlayIcon class="h-3.5 w-3.5 text-gray-700" stroke-width="1.5" />
-							</template>
-						</Button>
-					</Tooltip>
-					<Dropdown placement="right" :options="moreActions">
-						<Button variant="outline">
-							<template #icon>
-								<MoreHorizontal class="h-4 w-4 text-gray-700" stroke-width="1.5" />
-							</template>
-						</Button>
-					</Dropdown>
-				</div>
-			</div>
+			</QueryToolbar>
 
 			<!-- SQL Editor -->
 			<div class="relative flex flex-1 flex-col overflow-hidden rounded border">
@@ -191,21 +142,7 @@ useShortcut('Meta+e', () => {
 			</div>
 
 			<!-- Results Table -->
-			<div
-				v-show="query.result.executedSQL"
-				class="tnum flex flex-shrink-0 items-center gap-2 text-sm text-gray-600"
-			>
-				<div class="h-2 w-2 rounded-full bg-green-500"></div>
-				<div class="flex items-center gap-1">
-					<span v-if="query.result.timeTaken == -1">
-						{{ __('Fetched from cache') }}
-					</span>
-					<span v-else>
-						{{ __('Fetched in {0}s', String(query.result.timeTaken)) }}
-					</span>
-					<span> {{ useTimeAgo(query.result.lastExecutedAt).value }} </span>
-				</div>
-			</div>
+			<QueryExecutionStatus />
 			<div class="relative flex h-[45%] w-full flex-col overflow-hidden rounded border">
 				<QueryDataTable :query="query" :enable-alerts="true" />
 			</div>
@@ -219,6 +156,4 @@ useShortcut('Meta+e', () => {
 			<SchemaExplorer :schema="dataSourceSchema" @insert-text="insertTextIntoEditor" />
 		</div>
 	</div>
-
-	<ViewSQLDialog v-if="showViewSQLDialog" v-model="showViewSQLDialog" />
 </template>

--- a/frontend/src2/query/components/QueryBuilder.vue
+++ b/frontend/src2/query/components/QueryBuilder.vue
@@ -3,7 +3,8 @@ import { inject, onBeforeUnmount } from 'vue'
 import { Query } from '../query'
 import QueryBuilderSourceSelector from './QueryBuilderSourceSelector.vue'
 import QueryBuilderTable from './QueryBuilderTable.vue'
-import QueryBuilderToolbar from './QueryBuilderToolbar.vue'
+import QueryExecutionStatus from './QueryExecutionStatus.vue'
+import QueryToolbar from './QueryToolbar.vue'
 import QueryInfo from './QueryInfo.vue'
 import QueryOperations from './QueryOperations.vue'
 import { useMagicKeys } from '@vueuse/core'
@@ -30,7 +31,9 @@ onBeforeUnmount(() => {
 		<div class="relative flex h-full flex-1 flex-col gap-3 overflow-hidden p-4">
 			<QueryBuilderSourceSelector v-if="!query.doc.operations.length" />
 			<template v-else>
-				<QueryBuilderToolbar></QueryBuilderToolbar>
+				<QueryToolbar>
+					<QueryExecutionStatus />
+				</QueryToolbar>
 				<QueryBuilderTable></QueryBuilderTable>
 			</template>
 		</div>

--- a/frontend/src2/query/components/QueryExecutionStatus.vue
+++ b/frontend/src2/query/components/QueryExecutionStatus.vue
@@ -1,0 +1,26 @@
+<script setup lang="ts">
+import { useTimeAgo } from '@vueuse/core'
+import { inject } from 'vue'
+import { __ } from '../../translation'
+import { Query } from '../query'
+
+const query = inject('query') as Query
+</script>
+
+<template>
+	<div
+		v-show="query.result.executedSQL"
+		class="tnum flex flex-shrink-0 items-center gap-2 text-sm text-gray-600"
+	>
+		<div class="h-2 w-2 rounded-full bg-green-500"></div>
+		<div class="flex items-center gap-1">
+			<span v-if="query.result.timeTaken == -1">
+				{{ __('Fetched from cache') }}
+			</span>
+			<span v-else>
+				{{ __('Fetched in {0}s', String(query.result.timeTaken)) }}
+			</span>
+			<span> {{ useTimeAgo(query.result.lastExecutedAt).value }} </span>
+		</div>
+	</div>
+</template>

--- a/frontend/src2/query/components/QueryToolbar.vue
+++ b/frontend/src2/query/components/QueryToolbar.vue
@@ -1,18 +1,27 @@
 <script setup lang="ts">
-import { useTimeAgo } from '@vueuse/core'
 import { Copy, CopyPlus, MoreHorizontal, PlayIcon, RefreshCw, Scroll } from 'lucide-vue-next'
 import { computed, h, inject, ref } from 'vue'
-import { Query } from '../query'
-import { __ } from '../../translation'
-import ViewSQLDialog from './ViewSQLDialog.vue'
+import { Tooltip } from 'frappe-ui'
+import { formatShortcut } from '../../composables/useShortcut'
 import session from '../../session'
+import { __ } from '../../translation'
+import { Query } from '../query'
+import ViewSQLDialog from './ViewSQLDialog.vue'
+
+const props = withDefaults(
+	defineProps<{
+		onExecute?: () => void
+		extraActions?: () => any[]
+	}>(),
+	{ onExecute: undefined, extraActions: undefined },
+)
 
 const query = inject('query') as Query
 
 const showViewSQLDialog = ref(false)
 
 const moreActions = computed(() => {
-	const actions = []
+	const actions: any[] = []
 
 	if (!query.doc.use_live_connection && session.user.is_admin) {
 		actions.push({
@@ -20,6 +29,10 @@ const moreActions = computed(() => {
 			icon: h(RefreshCw, { class: 'h-3 w-3 text-gray-700', strokeWidth: 1.5 }),
 			onClick: query.refreshStoredTables,
 		})
+	}
+
+	if (props.extraActions) {
+		actions.push(...props.extraActions())
 	}
 
 	actions.push(
@@ -42,33 +55,23 @@ const moreActions = computed(() => {
 
 	return actions
 })
+
+function handleExecute() {
+	props.onExecute ? props.onExecute() : query.execute(true)
+}
 </script>
 
 <template>
 	<div class="flex w-full flex-shrink-0 items-center justify-between bg-white">
-		<div>
-			<div
-				v-show="query.result.executedSQL"
-				class="tnum flex items-center gap-2 text-sm text-gray-600"
-			>
-				<div class="h-2 w-2 rounded-full bg-green-500"></div>
-				<div class="flex items-center gap-1">
-					<span v-if="query.result.timeTaken == -1">
-						{{ __('Fetched from cache') }}
-					</span>
-					<span v-else>
-						{{ __('Fetched in {0}s', String(query.result.timeTaken)) }}
-					</span>
-					<span> {{ useTimeAgo(query.result.lastExecutedAt).value }} </span>
-				</div>
-			</div>
-		</div>
+		<slot />
 		<div class="flex items-center gap-2">
-			<Button variant="outline" :label="__('Execute')" @click="() => query.execute(true)">
-				<template #prefix>
-					<PlayIcon class="h-3.5 w-3.5 text-gray-700" stroke-width="1.5" />
-				</template>
-			</Button>
+			<Tooltip :text="__('Execute ({0})', formatShortcut('Meta+E'))">
+				<Button variant="outline" :label="__('Execute')" @click="handleExecute">
+					<template #prefix>
+						<PlayIcon class="h-3.5 w-3.5 text-gray-700" stroke-width="1.5" />
+					</template>
+				</Button>
+			</Tooltip>
 			<Dropdown placement="right" :options="moreActions">
 				<Button variant="outline">
 					<template #icon>


### PR DESCRIPTION
**Consolidate query toolbar**: the builder query and native query editors had duplicate toolbar logic (menu actions, ViewSQLDialog, Execute button). Refactored into two shared components:
  - `QueryToolbar` — unified toolbar replacing `QueryBuilderToolbar`. Accepts an optional `onExecute` prop (defaults to `query.execute(true)`) and an `extraActions` prop for per-caller additions. Uses a slot for left-side content.
  - `QueryExecutionStatus` — extracted the "Fetched in Xs / from cache" status pill that was duplicated across `QueryBuilder`, `NativeQueryEditor`, and `DrillDown`.