### PR TITLE
feat: implement url-based pagination for data source tables list

### DIFF
--- a/frontend/src2/components/DataTableFooter.vue
+++ b/frontend/src2/components/DataTableFooter.vue
@@ -31,7 +31,10 @@ async function handleFetchCount() {
 	<div class="flex flex-shrink-0 items-center border-t px-2 py-1">
 		<div class="flex flex-1 items-center">
 			<slot name="left">
-				<div v-if="pagination" class="flex items-center gap-1 tnum text-sm text-gray-500">
+				<div
+					v-if="pagination && pagination.to.value > 0"
+					class="flex items-center gap-1 tnum text-sm text-gray-500"
+				>
 					Showing {{ pagination.from.value }}–{{ pagination.to.value }} of
 					<template v-if="totalRowCount">
 						{{ totalRowCount.toLocaleString() }}

--- a/frontend/src2/components/DataTableFooter.vue
+++ b/frontend/src2/components/DataTableFooter.vue
@@ -31,10 +31,7 @@ async function handleFetchCount() {
 	<div class="flex flex-shrink-0 items-center border-t px-2 py-1">
 		<div class="flex flex-1 items-center">
 			<slot name="left">
-				<div
-					v-if="pagination && !pagination.isSinglePage.value"
-					class="flex items-center gap-1 tnum text-sm text-gray-500"
-				>
+				<div v-if="pagination" class="flex items-center gap-1 tnum text-sm text-gray-500">
 					Showing {{ pagination.from.value }}–{{ pagination.to.value }} of
 					<template v-if="totalRowCount">
 						{{ totalRowCount.toLocaleString() }}
@@ -56,7 +53,7 @@ async function handleFetchCount() {
 			</slot>
 		</div>
 		<div class="flex items-center gap-1">
-			<template v-if="pagination && !pagination.isSinglePage.value">
+			<template v-if="pagination">
 				<Button
 					variant="ghost"
 					:disabled="pagination.isFirstPage.value"

--- a/frontend/src2/composables/useUrlPagination.ts
+++ b/frontend/src2/composables/useUrlPagination.ts
@@ -28,7 +28,7 @@ export function useUrlPagination<T>(
 	const isError = ref(false)
 	const currentPage = computed(() => Number(route.query.page) || 1)
 	const refreshTrigger = ref(0)
-	
+
 	function refresh() {
 		refreshTrigger.value++
 	}
@@ -53,7 +53,7 @@ export function useUrlPagination<T>(
 		}),
 		async ({ search, page }, oldVal, onCleanup) => {
 			let isAborted = false
-			
+
 			onCleanup(() => {
 				isAborted = true
 			})

--- a/frontend/src2/composables/useUrlPagination.ts
+++ b/frontend/src2/composables/useUrlPagination.ts
@@ -1,0 +1,97 @@
+import { ref, watch, computed, Ref, ComputedRef } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { watchDebounced } from '@vueuse/core'
+
+export type UrlPaginationState<T> = {
+	searchQuery: Ref<string>
+	items: Ref<T[]>
+	totalCount: Ref<number | undefined>
+	currentPage: ComputedRef<number>
+	isLoading: Ref<boolean>
+	isError: Ref<boolean>
+	refresh: () => void
+}
+
+export function useUrlPagination<T>(
+	fetchData: (search: string, limit: number, offset: number) => Promise<T[]>,
+	fetchCount: (search: string) => Promise<number>,
+	pageSize = 100,
+	onSuccess?: () => void,
+): UrlPaginationState<T> {
+	const route = useRoute()
+	const router = useRouter()
+
+	const searchQuery = ref((route.query.search as string) || '')
+	const items = ref<T[]>([]) as Ref<T[]>
+	const totalCount = ref<number | undefined>(undefined)
+	const isLoading = ref(false)
+	const isError = ref(false)
+	const currentPage = computed(() => Number(route.query.page) || 1)
+	const refreshTrigger = ref(0)
+	
+	function refresh() {
+		refreshTrigger.value++
+	}
+
+	watchDebounced(
+		searchQuery,
+		(newSearch) => {
+			const currentSearch = (route.query.search as string) || ''
+			if (newSearch === currentSearch) return
+			router.replace({
+				query: { ...route.query, search: newSearch || undefined, page: 1 },
+			})
+		},
+		{ debounce: 300 },
+	)
+
+	watch(
+		() => ({
+			search: route.query.search as string | undefined,
+			page: route.query.page as string | undefined,
+			_trigger: refreshTrigger.value,
+		}),
+		async ({ search, page }, oldVal, onCleanup) => {
+			let isAborted = false
+			
+			onCleanup(() => {
+				isAborted = true
+			})
+
+			const s = search || ''
+			const p = Number(page) || 1
+			if (searchQuery.value !== s) searchQuery.value = s
+
+			const offset = (p - 1) * pageSize
+			isLoading.value = true
+			isError.value = false
+
+			try {
+				const [fetchedItems, count] = await Promise.all([
+					fetchData(s, pageSize, offset),
+					fetchCount(s),
+				])
+
+				if (isAborted) return
+
+				items.value = fetchedItems
+				totalCount.value = count
+
+				if (count > 0 && offset >= count) {
+					router.replace({ query: { ...route.query, page: 1 } })
+					return
+				}
+
+				onSuccess?.()
+			} catch (e) {
+				if (isAborted) return
+				isError.value = true
+			} finally {
+				if (!isAborted) isLoading.value = false
+			}
+		},
+		{ immediate: true },
+	)
+
+	return { searchQuery, items, totalCount, currentPage, isLoading, isError, refresh }
+}

--- a/frontend/src2/data_source/DataSourceTableList.vue
+++ b/frontend/src2/data_source/DataSourceTableList.vue
@@ -1,35 +1,69 @@
 <script setup lang="tsx">
-import { watchDebounced } from '@vueuse/core'
-import { Breadcrumbs, ListView } from 'frappe-ui'
+import { Breadcrumbs, ListView, Button, FormControl } from 'frappe-ui'
 import { MoreHorizontal, RefreshCcw, SearchIcon } from 'lucide-vue-next'
-import { h, ref, watchEffect } from 'vue'
+import { h, ref, computed, watchEffect } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
 import useDataSourceStore from './data_source'
 import useTableStore, { DataSourceTable } from './tables'
+import { usePagination } from '../composables/usePagination'
+import { useUrlPagination } from '../composables/useUrlPagination'
+import DataTableFooter from '../components/DataTableFooter.vue'
 import { __ } from '../translation'
 
 const props = defineProps<{ name: string }>()
 
-const dataSource = useDataSourceStore().getSource(props.name)
+const route = useRoute()
+const router = useRouter()
+const dataSourceStore = useDataSourceStore()
 const tableStore = useTableStore()
+const dataSource = computed(() => dataSourceStore.getSource(props.name))
 
-const searchQuery = ref('')
-const filteredTables = ref<DataSourceTable[]>()
-watchDebounced(searchQuery, () => updateTablesList(), { debounce: 300, immediate: true })
+const listWrapper = ref<HTMLElement | null>(null)
+const listView = ref<any>(null)
 
-function updateTablesList() {
-	tableStore.getTables(props.name, searchQuery.value).then((tables) => {
-		filteredTables.value = tables
-	})
-}
+const {
+	searchQuery,
+	items: filteredTables,
+	totalCount,
+	currentPage,
+	isLoading,
+	isError,
+	refresh,
+} = useUrlPagination(
+	(search, limit, offset) => tableStore.getTables(props.name, search, limit, offset),
+	(search) => tableStore.getTablesCount(props.name, search),
+	100,
+	() => {
+		if (listWrapper.value) {
+			const scrollEl = listWrapper.value.querySelector('.overflow-y-auto')
+			if (scrollEl) {
+				scrollEl.scrollTop = 0
+			}
+		}
+		if (listView.value?.selections) {
+			listView.value.selections.clear()
+		}
+	},
+)
 
-const listOptions = ref({
+const pagination = usePagination({
+	rowCount: computed(() => filteredTables.value.length),
+	totalRowCount: totalCount,
+	pageSize: 100,
+	currentPage: currentPage,
+	onPageChange: (page) => {
+		router.replace({ query: { ...route.query, page } })
+	},
+})
+
+const listOptions = computed(() => ({
 	columns: [
 		{
 			label: __('Table Name'),
 			key: 'table_name',
 		},
 	],
-	rows: filteredTables,
+	rows: filteredTables.value,
 	rowKey: 'table_name',
 	options: {
 		showTooltip: false,
@@ -44,17 +78,14 @@ const listOptions = ref({
 				iconLeft: 'refresh-ccw',
 				variant: 'outline',
 				loading: tableStore.updatingDataSourceTables,
-				onClick: () =>
-					tableStore.updateDataSourceTables(props.name).then(() => updateTablesList()),
+				onClick: () => tableStore.updateDataSourceTables(props.name).then(refresh),
 			},
 		},
 	},
-})
+}))
 
-const dataSourceStore = useDataSourceStore()
 watchEffect(() => {
-	const ds = dataSourceStore.getSource(props.name)
-	document.title = `Tables | ${props.name || ds?.title}`
+	document.title = `Tables | ${dataSource.value?.title || props.name}`
 })
 </script>
 
@@ -66,12 +97,15 @@ watchEffect(() => {
 				{ label: dataSource?.title || props.name, route: `/data-source/${props.name}` },
 			]"
 		/>
-		<div class="flex items-center gap-2"></div>
 	</header>
 
-	<div class="mb-4 flex h-full flex-col gap-3 overflow-auto px-5 py-3">
-		<div class="flex gap-2 overflow-visible py-1">
-			<FormControl placeholder="Search by Title" v-model="searchQuery" :debounce="300">
+	<div class="flex flex-1 flex-col overflow-hidden">
+		<div class="flex gap-2 overflow-visible px-5 py-4">
+			<FormControl
+				:placeholder="__('Search by Table Name')"
+				v-model="searchQuery"
+				autocomplete="off"
+			>
 				<template #prefix>
 					<SearchIcon class="h-4 w-4 text-gray-500" />
 				</template>
@@ -81,9 +115,7 @@ watchEffect(() => {
 					{
 						label: __('Update Tables'),
 						onClick: () =>
-							tableStore
-								.updateDataSourceTables(props.name)
-								.then(() => updateTablesList()),
+							tableStore.updateDataSourceTables(props.name).then(() => refresh()),
 						icon: () =>
 							h(RefreshCcw, {
 								class: 'h-4 w-4 text-gray-700',
@@ -110,6 +142,14 @@ watchEffect(() => {
 				</Button>
 			</Dropdown>
 		</div>
-		<ListView class="h-full" v-bind="listOptions"> </ListView>
+		<div class="flex flex-1 flex-col min-h-0 overflow-hidden px-5" ref="listWrapper">
+			<ListView ref="listView" class="h-full" v-bind="listOptions"> </ListView>
+		</div>
+		<DataTableFooter
+			:pagination="pagination"
+			:total-row-count="totalCount ?? undefined"
+			@prev="pagination.prev()"
+			@next="pagination.next()"
+		/>
 	</div>
 </template>

--- a/frontend/src2/data_source/tables.ts
+++ b/frontend/src2/data_source/tables.ts
@@ -23,7 +23,7 @@ export async function getTables(data_source?: string, search_term?: string, limi
 		offset,
 	})
 	loading.value = false
-	
+
 	const key = data_source || '__all'
 	if (offset === 0) {
 		tables.value[key] = _tables

--- a/frontend/src2/data_source/tables.ts
+++ b/frontend/src2/data_source/tables.ts
@@ -14,20 +14,31 @@ export type DataSourceTable = {
 const tables = ref<Record<string, DataSourceTable[]>>({})
 
 const loading = ref(false)
-export async function getTables(data_source?: string, search_term?: string, limit: number = 100) {
+export async function getTables(data_source?: string, search_term?: string, limit: number = 100, offset: number = 0) {
 	loading.value = true
 	const _tables = await call('insights.api.data_sources.get_data_source_tables', {
 		data_source,
 		search_term,
 		limit,
+		offset,
 	})
 	loading.value = false
-	if (data_source) {
-		tables.value[data_source] = _tables
+	
+	const key = data_source || '__all'
+	if (offset === 0) {
+		tables.value[key] = _tables
 	} else {
-		tables.value['__all'] = _tables
+		if (!tables.value[key]) tables.value[key] = []
+		tables.value[key].push(..._tables)
 	}
 	return _tables
+}
+
+export async function getTablesCount(data_source?: string, search_term?: string) {
+	return await call('insights.api.data_sources.get_data_source_tables_count', {
+		data_source,
+		search_term,
+	})
 }
 
 const fetchingTable = ref(false)
@@ -142,6 +153,7 @@ export default function useTableStore() {
 		tables,
 		loading,
 		getTables,
+		getTablesCount,
 		getRowCount,
 		getOptions: getTableOptions,
 

--- a/insights/api/data_sources.py
+++ b/insights/api/data_sources.py
@@ -295,7 +295,9 @@ def get_all_data_sources():
 
 @insights_whitelist()
 @validate_type
-def get_data_source_tables(data_source: str | None = None, search_term: str | None = None, limit: int = 100, offset: int = 0):
+def get_data_source_tables(
+    data_source: str | None = None, search_term: str | None = None, limit: int = 100, offset: int = 0
+):
     tables = frappe.get_list(
         "Insights Table v3",
         filters={

--- a/insights/api/data_sources.py
+++ b/insights/api/data_sources.py
@@ -295,7 +295,7 @@ def get_all_data_sources():
 
 @insights_whitelist()
 @validate_type
-def get_data_source_tables(data_source: str | None = None, search_term: str | None = None, limit: int = 100):
+def get_data_source_tables(data_source: str | None = None, search_term: str | None = None, limit: int = 100, offset: int = 0):
     tables = frappe.get_list(
         "Insights Table v3",
         filters={
@@ -307,6 +307,8 @@ def get_data_source_tables(data_source: str | None = None, search_term: str | No
         },
         fields=["name", "table", "label", "data_source", "last_synced_on"],
         limit=limit,
+        start=offset,
+        order_by="name asc",
     )
 
     ret = []
@@ -323,6 +325,23 @@ def get_data_source_tables(data_source: str | None = None, search_term: str | No
             )
         )
     return ret
+
+
+@insights_whitelist()
+@validate_type
+def get_data_source_tables_count(data_source: str | None = None, search_term: str | None = None):
+    tables = frappe.get_all(
+        "Insights Table v3",
+        filters={
+            "data_source": data_source or ["is", "set"],
+        },
+        or_filters={
+            "label": ["is", "set"] if not search_term else ["like", f"%{search_term}%"],
+            "table": ["is", "set"] if not search_term else ["like", f"%{search_term}%"],
+        },
+        pluck="name",
+    )
+    return len(tables)
 
 
 @insights_whitelist()

--- a/insights/api/data_sources.py
+++ b/insights/api/data_sources.py
@@ -1,5 +1,6 @@
 import frappe
 from frappe.utils.caching import redis_cache, site_cache
+from pypika.functions import Count
 
 from insights import notify
 from insights.decorators import insights_whitelist, validate_type
@@ -332,7 +333,7 @@ def get_data_source_tables(
 @insights_whitelist()
 @validate_type
 def get_data_source_tables_count(data_source: str | None = None, search_term: str | None = None):
-    tables = frappe.get_all(
+    partial_query = frappe.get_list(
         "Insights Table v3",
         filters={
             "data_source": data_source or ["is", "set"],
@@ -341,9 +342,14 @@ def get_data_source_tables_count(data_source: str | None = None, search_term: st
             "label": ["is", "set"] if not search_term else ["like", f"%{search_term}%"],
             "table": ["is", "set"] if not search_term else ["like", f"%{search_term}%"],
         },
-        pluck="name",
+        fields=["name"],
+        run=0,
     )
-    return len(tables)
+
+    count_query = frappe.qb.from_(partial_query).select(Count("*"))
+    result = count_query.run()
+
+    return result[0][0] if result else 0
 
 
 @insights_whitelist()


### PR DESCRIPTION
## Overview
Previously, `DataSourceTableList` was hardcoded to fetch a maximum of 100 tables. This PR introduces a URL-driven pagination architecture to seamlessly handle data sources with massive amounts of tables.

## Key Changes
- **Backend API (`data_sources.py`)**: Modified the `get_tables` endpoint to accept an `offset` parameter, and introduced a new `get_tables_count` endpoint.
- **Pinia Store (`tables.ts`)**: Updated `getTables` to pass the offset to the backend and added `getTablesCount` to retrieve the total rows.
- **Universal Pagination (`useUrlPagination.ts`)**: Created a brand new, highly reusable Vue composable that orchestrates URL state (`?page=2`), search debouncing, and concurrent data fetching with native Vue `onCleanup` abort handling to prevent network race conditions.
- **UI Integration (`DataSourceTableList.vue`)**: Replaced the hardcoded fetch logic with the new pagination approach and wired up `DataTableFooter` to display dynamic row counts and page controls.


Closes #1095