### PR TITLE
fix: add psycopg2-binary dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "ibis-framework[postgres]",
     # "ibis-framework[mssql]",
     # "ibis-framework[bigquery]",
-    "psycopg2-binary",
+    "psycopg[binary]",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "ibis-framework[postgres]",
     # "ibis-framework[mssql]",
     # "ibis-framework[bigquery]",
+    "psycopg2-binary",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
ibis-framework[postgres] requires psycopg3 but doesn't pull in a libpq implementation. On Frappe Cloud, libpq is not available system-wide, so psycopg falls back to nothing and raises an ImportError, breaking all external PostgreSQL data source connections.

Adding psycopg[binary] bundles libpq in the wheel, resolving the import without needing apt-level dependencies.