### PR TITLE
fix: prevent double quoting of database names in Ibis table listing

### DIFF
--- a/insights/insights/doctype/insights_data_source_v3/insights_data_source_v3.py
+++ b/insights/insights/doctype/insights_data_source_v3/insights_data_source_v3.py
@@ -356,8 +356,7 @@ class InsightsDataSourcev3(InsightsDataSourceDocument, Document):
         if not contains_special_chars:
             return db.list_tables()
 
-        quoted_db_name = f"{db.dialect.QUOTE_START}{database_name}{db.dialect.QUOTE_END}"
-        return db.list_tables(database=quoted_db_name)
+        return db.list_tables(database=database_name)
 
     @frappe.whitelist()
     def test_connection(self, raise_exception: bool | None = False):


### PR DESCRIPTION
## Overview
Previously, data sources with special characters (like hyphens) in their database name failed to load tables initially or when clicking "Refresh". This PR fixes the issue by preventing Ibis from improperly double-quoting the database name.

## Key Changes
- **DocType Model (`insights_data_source_v3.py`)**: Removed the `db.dialect.QUOTE_START/END` manual string injection in `get_table_list` and replaced it with passing the raw `database_name` directly to `db.list_tables()`.

Closes #1122