### PR TITLE
feat: dashboard & workbook list improvements

### DIFF
--- a/frontend/src2/dashboard/DashboardCard.vue
+++ b/frontend/src2/dashboard/DashboardCard.vue
@@ -27,13 +27,12 @@ const emit = defineEmits<{
 			<img
 				v-if="dashboard.preview_image"
 				:src="dashboard.preview_image"
+				loading="lazy"
+				decoding="async"
 				onerror="this.src = ''"
 				class="object-cover opacity-80"
 			/>
-			<div
-				v-else
-				class="flex h-full w-full items-center justify-center bg-gray-50/70"
-			>
+			<div v-else class="flex h-full w-full items-center justify-center bg-gray-50/70">
 				<Button
 					variant="ghost"
 					@click.prevent.stop="emit('update-preview')"

--- a/frontend/src2/dashboard/DashboardList.vue
+++ b/frontend/src2/dashboard/DashboardList.vue
@@ -1,10 +1,11 @@
 <script setup lang="tsx">
-import { Breadcrumbs } from 'frappe-ui'
+import { useStorage } from '@vueuse/core'
+import { Breadcrumbs, TabButtons } from 'frappe-ui'
 import { SearchIcon } from 'lucide-vue-next'
-import { ref, toRef, watchEffect } from 'vue'
+import { computed, toRef, watchEffect } from 'vue'
 import { useRouter } from 'vue-router'
 import FolderCard from '../components/FolderCard.vue'
-import { wheneverChanges } from '../helpers'
+import { showErrorToast, wheneverChanges } from '../helpers'
 import { __ } from '../translation'
 import { useFolderNavigation } from '../workbook/useFolderNavigation'
 import useWorkbookFolders from '../workbook/workbookFolders'
@@ -19,13 +20,68 @@ const { currentFolder, searchQuery, drillInto, subfolders, breadcrumbs } = useFo
 	toRef(folderStore, 'folders'),
 	__('Dashboards'),
 )
-const filter = ref<'all' | 'favorites'>('all')
+type DashboardFilter = 'all' | 'recents' | 'favorites' | 'created' | 'shared'
 
-// dashboards of the current folder come from the server; subfolders + breadcrumb
-// are derived on the client from the shared workbook folder tree
+const filterTabs: { label: string; value: DashboardFilter }[] = [
+	{ label: __('All'), value: 'all' },
+	{ label: __('Recents'), value: 'recents' },
+	{ label: __('Favorites'), value: 'favorites' },
+	{ label: __('Created'), value: 'created' },
+	{ label: __('Shared'), value: 'shared' },
+]
+
+// persist the chosen filter locally so it survives reloads
+const filter = useStorage<DashboardFilter>('insights:dashboard-filter', 'all')
+
+// folders only make sense in the "all" view; the other lenses span folders
+const showFolders = computed(() => filter.value === 'all')
+
+// dashboards come from the server; subfolders + breadcrumb are derived on the
+// client from the shared workbook folder tree
 async function refresh() {
-	store.fetchDashboards(currentFolder.value, searchQuery.value, filter.value === 'favorites')
+	if (filter.value === 'recents') {
+		store.fetchRecentDashboards(searchQuery.value)
+		return
+	}
+	store.fetchDashboards({
+		// only the "all" view is folder-scoped; lenses span folders
+		folder: filter.value === 'all' ? currentFolder.value ?? 'root' : undefined,
+		search_term: searchQuery.value,
+		favorites: filter.value === 'favorites',
+		scope:
+			filter.value === 'created' ? 'owned' : filter.value === 'shared' ? 'shared' : undefined,
+	})
 }
+
+const emptyState = computed(() => {
+	switch (filter.value) {
+		case 'favorites':
+			return {
+				title: __('No Favorites'),
+				subtitle: __('Mark a dashboard as favorite to see it here.'),
+			}
+		case 'recents':
+			return {
+				title: __('No Recents'),
+				subtitle: __('Dashboards you open will show up here.'),
+			}
+		case 'created':
+			return {
+				title: __('Nothing here'),
+				subtitle: __("You haven't created any dashboards yet."),
+			}
+		case 'shared':
+			return {
+				title: __('Nothing here'),
+				subtitle: __('Dashboards shared with you will show up here.'),
+			}
+		default:
+			return {
+				title: __('Nothing here'),
+				subtitle: __('No folders or dashboards to display.'),
+			}
+	}
+})
 
 // reset on folder/filter change so a slow fetch can't keep showing the previous
 // folder's dashboards; search keeps previous data (no flicker)
@@ -54,7 +110,19 @@ const dropdownOptions = (dashboard: DashboardListItem) => [
 ]
 
 const toggleFavorite = (dashboard: DashboardListItem) => {
-	store.toggleLike(dashboard.name, !dashboard.is_favourite).then(refresh)
+	// optimistic: flip the icon locally instead of refetching the whole list
+	const next = !dashboard.is_favourite
+	dashboard.is_favourite = next
+	store
+		.toggleLike(dashboard.name, next)
+		.then(() => {
+			// in the favorites lens an un-favorited card should drop out, so refetch
+			if (filter.value === 'favorites') refresh()
+		})
+		.catch((error: Error) => {
+			dashboard.is_favourite = !next // revert on failure
+			showErrorToast(error, false)
+		})
 }
 
 watchEffect(() => {
@@ -68,9 +136,10 @@ watchEffect(() => {
 	</header>
 
 	<div class="mb-4 flex h-full flex-col gap-3 overflow-auto px-5 py-3">
-		<div class="flex gap-2 overflow-visible py-1">
+		<div class="flex items-center justify-between gap-2 overflow-visible py-1">
 			<FormControl
-				:placeholder="__('Search by Title')"
+				class="w-64"
+				:placeholder="__('Search by title')"
 				v-model="searchQuery"
 				:debounce="300"
 				autocomplete="off"
@@ -79,28 +148,23 @@ watchEffect(() => {
 					<SearchIcon class="h-4 w-4 text-gray-500" />
 				</template>
 			</FormControl>
-			<FormControl
-				type="select"
-				v-model="filter"
-				:options="[
-					{ label: __('All'), value: 'all' },
-					{ label: __('Favorites'), value: 'favorites' },
-				]"
-			/>
+			<TabButtons :buttons="filterTabs" v-model="filter" />
 		</div>
 
 		<div class="h-full w-full">
 			<!-- folders (sorted on top) and dashboards share one grid -->
 			<div
-				v-if="subfolders.length || store.dashboards.length"
+				v-if="(showFolders && subfolders.length) || store.dashboards.length"
 				class="grid grid-cols-1 gap-10 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"
 			>
-				<FolderCard
-					v-for="folder in subfolders"
-					:key="'folder-' + folder.name"
-					:title="folder.title"
-					@open="drillInto(folder.name)"
-				/>
+				<template v-if="showFolders">
+					<FolderCard
+						v-for="folder in subfolders"
+						:key="'folder-' + folder.name"
+						:title="folder.title"
+						@open="drillInto(folder.name)"
+					/>
+				</template>
 				<DashboardCard
 					v-for="dashboard in store.dashboards"
 					:key="dashboard.name"
@@ -114,19 +178,11 @@ watchEffect(() => {
 
 			<!-- empty -->
 			<div
-				v-if="!subfolders.length && !store.dashboards.length"
+				v-if="(!showFolders || !subfolders.length) && !store.dashboards.length"
 				class="flex h-full w-full flex-col items-center justify-center text-base"
 			>
-				<div class="text-xl font-medium">
-					{{ filter === 'favorites' ? __('No Favorites') : __('Nothing here') }}
-				</div>
-				<div class="mt-1 text-base text-gray-600">
-					{{
-						filter === 'favorites'
-							? __('Mark a dashboard as favorite to see it here.')
-							: __('No folders or dashboards to display.')
-					}}
-				</div>
+				<div class="text-xl font-medium">{{ emptyState.title }}</div>
+				<div class="mt-1 text-base text-gray-600">{{ emptyState.subtitle }}</div>
 			</div>
 		</div>
 	</div>

--- a/frontend/src2/dashboard/DashboardList.vue
+++ b/frontend/src2/dashboard/DashboardList.vue
@@ -2,7 +2,7 @@
 import { useStorage } from '@vueuse/core'
 import { Breadcrumbs, TabButtons } from 'frappe-ui'
 import { SearchIcon } from 'lucide-vue-next'
-import { computed, toRef, watchEffect } from 'vue'
+import { computed, ref, toRef, watchEffect } from 'vue'
 import { useRouter } from 'vue-router'
 import FolderCard from '../components/FolderCard.vue'
 import { showErrorToast, wheneverChanges } from '../helpers'
@@ -36,6 +36,11 @@ const filter = useStorage<DashboardFilter>('insights:dashboard-filter', 'all')
 // folders only make sense in the "all" view; the other lenses span folders
 const showFolders = computed(() => filter.value === 'all')
 
+// "Load more" grows the page size and refetches (recents is capped server-side)
+const PAGE_SIZE = 20
+const limit = ref(PAGE_SIZE)
+const hasMore = computed(() => filter.value !== 'recents' && store.dashboards.length >= limit.value)
+
 // dashboards come from the server; subfolders + breadcrumb are derived on the
 // client from the shared workbook folder tree
 async function refresh() {
@@ -50,7 +55,19 @@ async function refresh() {
 		favorites: filter.value === 'favorites',
 		scope:
 			filter.value === 'created' ? 'owned' : filter.value === 'shared' ? 'shared' : undefined,
+		limit: limit.value,
 	})
+}
+
+// reset pagination for a new query (filter/folder/search change)
+function reload() {
+	limit.value = PAGE_SIZE
+	refresh()
+}
+
+function loadMore() {
+	limit.value += PAGE_SIZE
+	refresh()
 }
 
 const emptyState = computed(() => {
@@ -89,11 +106,11 @@ wheneverChanges(
 	() => [filter.value, currentFolder.value],
 	() => {
 		store.dashboards = []
-		refresh()
+		reload()
 	},
 	{ immediate: true },
 )
-wheneverChanges(searchQuery, refresh, { debounce: 300 })
+wheneverChanges(searchQuery, reload, { debounce: 300 })
 
 const dropdownOptions = (dashboard: DashboardListItem) => [
 	{
@@ -174,6 +191,11 @@ watchEffect(() => {
 					@toggle-favorite="toggleFavorite(dashboard)"
 					@update-preview="store.updatePreviewImage(dashboard.name)"
 				/>
+			</div>
+
+			<!-- load more -->
+			<div v-if="hasMore" class="flex pt-8">
+				<Button :label="__('Load more')" :loading="store.loading" @click="loadMore" />
 			</div>
 
 			<!-- empty -->

--- a/frontend/src2/dashboard/dashboards.ts
+++ b/frontend/src2/dashboard/dashboards.ts
@@ -35,6 +35,7 @@ type FetchDashboardsOptions = {
 	search_term?: string
 	favorites?: boolean
 	scope?: DashboardScope
+	limit?: number
 }
 
 // folder filters to a workbook folder; favorites/scope are personal lenses.
@@ -44,6 +45,7 @@ async function fetchDashboards({
 	search_term,
 	favorites = false,
 	scope,
+	limit = 0,
 }: FetchDashboardsOptions = {}) {
 	loading.value = true
 	const result = await call('insights.api.dashboards.get_dashboards', {
@@ -51,7 +53,7 @@ async function fetchDashboards({
 		search_term,
 		get_favorites: favorites,
 		scope,
-		limit: 0,
+		limit,
 	})
 	dashboards.value = result.map(mapTimeAgo)
 	loading.value = false

--- a/frontend/src2/dashboard/dashboards.ts
+++ b/frontend/src2/dashboard/dashboards.ts
@@ -28,16 +28,40 @@ const mapTimeAgo = (dashboard: any) => ({
 	modified_from_now: useTimeAgo(dashboard.modified),
 })
 
-// dashboards of the current folder (favorites = the personal lens). subfolders
-// + breadcrumb are derived on the client from the shared workbook folder tree.
-async function fetchDashboards(folder?: string | null, search_term?: string, favorites = false) {
+export type DashboardScope = 'owned' | 'shared'
+type FetchDashboardsOptions = {
+	// omit folder for personal lenses (favorites/created/shared) so they span folders
+	folder?: string | null
+	search_term?: string
+	favorites?: boolean
+	scope?: DashboardScope
+}
+
+// folder filters to a workbook folder; favorites/scope are personal lenses.
+// subfolders + breadcrumb are derived on the client from the workbook folder tree.
+async function fetchDashboards({
+	folder,
+	search_term,
+	favorites = false,
+	scope,
+}: FetchDashboardsOptions = {}) {
 	loading.value = true
 	const result = await call('insights.api.dashboards.get_dashboards', {
-		folder: folder ?? 'root',
+		folder,
 		search_term,
 		get_favorites: favorites,
+		scope,
 		limit: 0,
 	})
+	dashboards.value = result.map(mapTimeAgo)
+	loading.value = false
+}
+
+// recents come from the per-user View Log on the server (populated by track_view
+// on every dashboard open), so they span folders and reflect opens from anywhere
+async function fetchRecentDashboards(search_term?: string) {
+	loading.value = true
+	const result = await call('insights.api.dashboards.get_recent_dashboards', { search_term })
 	dashboards.value = result.map(mapTimeAgo)
 	loading.value = false
 }
@@ -73,6 +97,7 @@ export default function useDashboardStore() {
 		dashboards,
 		loading,
 		fetchDashboards,
+		fetchRecentDashboards,
 
 		updatePreviewImage,
 		updatingPreviewImage,

--- a/frontend/src2/workbook/WorkbookList.vue
+++ b/frontend/src2/workbook/WorkbookList.vue
@@ -48,20 +48,42 @@ const scopeTabs: { label: string; value: WorkbookScope }[] = [
 // persist the chosen scope locally so it survives reloads
 const scope = useStorage<WorkbookScope>('insights:workbook-scope', 'all')
 
+// "Load more" grows the page size and refetches
+const PAGE_SIZE = 20
+const limit = ref(PAGE_SIZE)
+const hasMore = computed(() => workbookStore.workbooks.length >= limit.value)
+
 async function refresh() {
-	workbookStore.getWorkbooks(searchQuery.value, 100, scope.value, currentFolder.value || 'root')
+	workbookStore.getWorkbooks(
+		searchQuery.value,
+		limit.value,
+		scope.value,
+		currentFolder.value || 'root',
+	)
 }
+
+// reset pagination for a new query (scope/folder/search change)
+function reload() {
+	limit.value = PAGE_SIZE
+	refresh()
+}
+
+function loadMore() {
+	limit.value += PAGE_SIZE
+	refresh()
+}
+
 // reset the list when the folder/scope changes so a slow fetch can't keep
 // showing the previous folder's workbooks; search keeps previous data (no flicker)
 wheneverChanges(
 	() => [scope.value, currentFolder.value],
 	() => {
 		workbookStore.workbooks = []
-		refresh()
+		reload()
 	},
 	{ immediate: true },
 )
-wheneverChanges(searchQuery, refresh, { debounce: 300 })
+wheneverChanges(searchQuery, reload, { debounce: 300 })
 
 // ---- create workbook ----
 const creatingWorkbook = ref(false)
@@ -196,7 +218,7 @@ watchEffect(() => {
 		</div>
 	</header>
 
-	<div class="mb-4 flex h-full flex-col gap-3 overflow-auto px-5 py-3">
+	<div class="mb-4 flex h-full flex-col gap-3 overflow-auto px-5 pt-3">
 		<div class="flex items-center justify-between gap-2 overflow-visible py-1">
 			<FormControl
 				class="w-64"
@@ -211,21 +233,35 @@ watchEffect(() => {
 			</FormControl>
 			<TabButtons :buttons="scopeTabs" v-model="scope" />
 		</div>
-		<ListView class="h-full" v-bind="listOptions">
-			<ListHeader />
-			<ListRows v-if="rows.length" />
-			<ListEmptyState v-else />
-			<ListSelectBanner>
-				<template #actions="{ selections, unselectAll }">
-					<Dropdown :options="bulkMoveOptions(selections, unselectAll)" placement="right">
-						<Button :label="__('Move to folder')" variant="ghost">
-							<template #prefix>
-								<Folder class="h-4 w-4 text-gray-600" />
-							</template>
-						</Button>
-					</Dropdown>
-				</template>
-			</ListSelectBanner>
-		</ListView>
+		<!-- plain block wrapper so ListView flows to content height (its root is
+		flex-1 and would otherwise stretch and leave whitespace) -->
+		<div class="w-full">
+			<ListView v-bind="listOptions">
+				<ListHeader />
+				<ListRows v-if="rows.length" />
+				<ListEmptyState v-else />
+				<ListSelectBanner>
+					<template #actions="{ selections, unselectAll }">
+						<Dropdown
+							:options="bulkMoveOptions(selections, unselectAll)"
+							placement="right"
+						>
+							<Button :label="__('Move to folder')" variant="ghost">
+								<template #prefix>
+									<Folder class="h-4 w-4 text-gray-600" />
+								</template>
+							</Button>
+						</Dropdown>
+					</template>
+				</ListSelectBanner>
+			</ListView>
+			<div v-if="hasMore" class="flex pt-3">
+				<Button
+					:label="__('Load more')"
+					:loading="workbookStore.loading"
+					@click="loadMore"
+				/>
+			</div>
+		</div>
 	</div>
 </template>

--- a/frontend/src2/workbook/WorkbookList.vue
+++ b/frontend/src2/workbook/WorkbookList.vue
@@ -1,5 +1,5 @@
 <script setup lang="tsx">
-import { useMagicKeys, whenever } from '@vueuse/core'
+import { useMagicKeys, useStorage, whenever } from '@vueuse/core'
 import {
 	Breadcrumbs,
 	Dropdown,
@@ -8,6 +8,7 @@ import {
 	ListRows,
 	ListSelectBanner,
 	ListView,
+	TabButtons,
 } from 'frappe-ui'
 import { ChevronDown, Folder, FolderPlus, PlusIcon, SearchIcon } from 'lucide-vue-next'
 import { computed, ref, toRef, watchEffect } from 'vue'
@@ -36,7 +37,16 @@ const { currentFolder, searchQuery, drillInto, subfolders, breadcrumbs } = useFo
 	__('Workbooks'),
 )
 
-const scope = ref<'all' | 'owned' | 'shared'>('all')
+type WorkbookScope = 'all' | 'owned' | 'shared'
+
+const scopeTabs: { label: string; value: WorkbookScope }[] = [
+	{ label: __('All'), value: 'all' },
+	{ label: __('Created'), value: 'owned' },
+	{ label: __('Shared'), value: 'shared' },
+]
+
+// persist the chosen scope locally so it survives reloads
+const scope = useStorage<WorkbookScope>('insights:workbook-scope', 'all')
 
 async function refresh() {
 	workbookStore.getWorkbooks(searchQuery.value, 100, scope.value, currentFolder.value || 'root')
@@ -187,9 +197,10 @@ watchEffect(() => {
 	</header>
 
 	<div class="mb-4 flex h-full flex-col gap-3 overflow-auto px-5 py-3">
-		<div class="flex gap-2 overflow-visible py-1">
+		<div class="flex items-center justify-between gap-2 overflow-visible py-1">
 			<FormControl
-				:placeholder="__('Search by Title')"
+				class="w-64"
+				:placeholder="__('Search by title')"
 				v-model="searchQuery"
 				:debounce="300"
 				autocomplete="off"
@@ -198,15 +209,7 @@ watchEffect(() => {
 					<SearchIcon class="h-4 w-4 text-gray-500" />
 				</template>
 			</FormControl>
-			<FormControl
-				type="select"
-				v-model="scope"
-				:options="[
-					{ label: __('All'), value: 'all' },
-					{ label: __('Created by me'), value: 'owned' },
-					{ label: __('Shared with me'), value: 'shared' },
-				]"
-			/>
+			<TabButtons :buttons="scopeTabs" v-model="scope" />
 		</div>
 		<ListView class="h-full" v-bind="listOptions">
 			<ListHeader />

--- a/insights/api/dashboards.py
+++ b/insights/api/dashboards.py
@@ -118,7 +118,7 @@ def get_dashboards(
         filters=filters,
         fields=DASHBOARD_LIST_FIELDS,
         order_by="creation desc",
-        limit=0 if (get_favorites or folder is not None) else limit,
+        limit=limit,
     )
 
     _enrich_dashboards(dashboards)
@@ -175,23 +175,22 @@ DASHBOARD_LIST_FIELDS = [
     "creation",
     "modified",
     "preview_image",
-    "items",
     "_liked_by",
 ]
 
 
 def _enrich_dashboards(dashboards):
-    # batch the view counts into one grouped query instead of one COUNT per
-    # dashboard (avoids an N+1 over the whole list)
-    view_counts = _dashboard_view_counts([dashboard.name for dashboard in dashboards])
+    # batch counts into one grouped query each instead of per-dashboard queries
+    # (avoids N+1s over the whole list)
+    names = [dashboard.name for dashboard in dashboards]
+    view_counts = _dashboard_view_counts(names)
+    chart_counts = _dashboard_chart_counts(names)
     user = frappe.session.user
     for dashboard in dashboards:
-        items = frappe.parse_json(dashboard["items"])
-        dashboard["charts"] = sum(1 for item in items if item["type"] == "chart")
+        dashboard["charts"] = chart_counts.get(str(dashboard.name), 0)
         dashboard["views"] = view_counts.get(str(dashboard.name), 0)
         if dashboard._liked_by:
             dashboard["is_favourite"] = user in frappe.as_json(dashboard._liked_by)
-        del dashboard["items"]
 
 
 def _dashboard_view_counts(names: list[str]) -> dict[str, int]:
@@ -210,6 +209,25 @@ def _dashboard_view_counts(names: list[str]) -> dict[str, int]:
         .run(as_dict=True)
     )
     return {str(row.reference_name): row.views for row in rows}
+
+
+def _dashboard_chart_counts(names: list[str]) -> dict[str, int]:
+    # one chart == one row in the `linked_charts` child table (rebuilt from
+    # `items` on every save), so count rows per parent instead of parsing items
+    if not names:
+        return {}
+    linked_chart = frappe.qb.DocType("Insights Dashboard Chart v3")
+    rows = (
+        frappe.qb.from_(linked_chart)
+        .select(linked_chart.parent, Count(linked_chart.name).as_("charts"))
+        .where(
+            (linked_chart.parenttype == "Insights Dashboard v3")
+            & linked_chart.parent.isin([str(name) for name in names])
+        )
+        .groupby(linked_chart.parent)
+        .run(as_dict=True)
+    )
+    return {str(row.parent): row.charts for row in rows}
 
 
 @insights_whitelist()

--- a/insights/api/dashboards.py
+++ b/insights/api/dashboards.py
@@ -1,4 +1,5 @@
 import frappe
+from frappe.query_builder.functions import Count, Max
 
 from insights.api.permissions import is_private
 from insights.decorators import insights_whitelist, validate_type
@@ -78,16 +79,26 @@ def get_dashboards(
     limit: int = 50,
     get_favorites: bool = False,
     folder: str | None = None,
+    scope: str | None = None,
 ):
     """Return dashboards, optionally limited to a workbook folder.
 
     Dashboards inherit categorization from their workbook (no folder field of
     their own), so `folder` filters to dashboards whose workbook is filed there.
     Use the sentinel "" / "root" to restrict to dashboards of unfiled workbooks.
+
+    scope (a personal lens, spans folders):
+        "owned"  -> only dashboards created by the current user
+        "shared" -> only dashboards created by someone else (still permission filtered)
     """
     filters = {}
     if get_favorites:
         filters["_liked_by"] = ["like", f"%{frappe.session.user}%"]
+
+    if scope == "owned":
+        filters["owner"] = frappe.session.user
+    elif scope == "shared":
+        filters["owner"] = ["!=", frappe.session.user]
 
     if folder is not None:
         folder_workbooks = frappe.get_all(
@@ -105,36 +116,100 @@ def get_dashboards(
             "title": ["like", f"%{search_term}%" if search_term else "%"],
         },
         filters=filters,
-        fields=[
-            "name",
-            "title",
-            "workbook",
-            "creation",
-            "modified",
-            "preview_image",
-            "items",
-            "_liked_by",
-        ],
+        fields=DASHBOARD_LIST_FIELDS,
         order_by="creation desc",
         limit=0 if (get_favorites or folder is not None) else limit,
     )
 
+    _enrich_dashboards(dashboards)
+    return dashboards
+
+
+@insights_whitelist()
+def get_recent_dashboards(search_term: str | None = None, limit: int = 20):
+    """Dashboards the current user viewed most recently, newest first.
+
+    Recency comes from the per-user View Log (populated by `track_view` on
+    every dashboard open), so it spans folders and reflects opens from
+    anywhere, not just this list.
+    """
+    view_log = frappe.qb.DocType("View Log")
+    recent = (
+        frappe.qb.from_(view_log)
+        .select(view_log.reference_name, Max(view_log.modified).as_("last_viewed"))
+        .where(
+            (view_log.viewed_by == frappe.session.user)
+            & (view_log.reference_doctype == "Insights Dashboard v3")
+        )
+        .groupby(view_log.reference_name)
+        .orderby(Max(view_log.modified), order=frappe.qb.desc)
+        .limit(limit)
+        .run(as_dict=True)
+    )
+    order = {row.reference_name: i for i, row in enumerate(recent)}
+    if not order:
+        return []
+
+    dashboards = frappe.get_list(
+        "Insights Dashboard v3",
+        or_filters={
+            "name": ["like", f"%{search_term}%" if search_term else "%"],
+            "title": ["like", f"%{search_term}%" if search_term else "%"],
+        },
+        filters={"name": ["in", list(order.keys())]},
+        fields=DASHBOARD_LIST_FIELDS,
+        limit=0,
+    )
+
+    _enrich_dashboards(dashboards)
+    # get_list ignores the View Log order and silently drops dashboards the user
+    # can no longer access, so re-sort by recency over what survived
+    dashboards.sort(key=lambda dashboard: order[dashboard.name])
+    return dashboards
+
+
+DASHBOARD_LIST_FIELDS = [
+    "name",
+    "title",
+    "workbook",
+    "creation",
+    "modified",
+    "preview_image",
+    "items",
+    "_liked_by",
+]
+
+
+def _enrich_dashboards(dashboards):
+    # batch the view counts into one grouped query instead of one COUNT per
+    # dashboard (avoids an N+1 over the whole list)
+    view_counts = _dashboard_view_counts([dashboard.name for dashboard in dashboards])
+    user = frappe.session.user
     for dashboard in dashboards:
         items = frappe.parse_json(dashboard["items"])
-        charts = [item for item in items if item["type"] == "chart"]
-        dashboard["charts"] = len(charts)
-        dashboard["views"] = frappe.db.count(
-            "View Log",
-            filters={
-                "reference_doctype": "Insights Dashboard v3",
-                "reference_name": dashboard.name,
-            },
-        )
+        dashboard["charts"] = sum(1 for item in items if item["type"] == "chart")
+        dashboard["views"] = view_counts.get(str(dashboard.name), 0)
         if dashboard._liked_by:
-            dashboard["is_favourite"] = frappe.session.user in frappe.as_json(dashboard._liked_by)
+            dashboard["is_favourite"] = user in frappe.as_json(dashboard._liked_by)
         del dashboard["items"]
 
-    return dashboards
+
+def _dashboard_view_counts(names: list[str]) -> dict[str, int]:
+    if not names:
+        return {}
+    view_log = frappe.qb.DocType("View Log")
+    rows = (
+        frappe.qb.from_(view_log)
+        .select(view_log.reference_name, Count(view_log.name).as_("views"))
+        .where(
+            (view_log.reference_doctype == "Insights Dashboard v3")
+            # reference_name is stored as a string; cast names to match
+            & view_log.reference_name.isin([str(name) for name in names])
+        )
+        .groupby(view_log.reference_name)
+        .run(as_dict=True)
+    )
+    return {str(row.reference_name): row.views for row in rows}
 
 
 @insights_whitelist()

--- a/insights/api/workbooks.py
+++ b/insights/api/workbooks.py
@@ -65,33 +65,57 @@ def get_workbooks(
         views = [view for view in workbook_views if str(view["reference_name"]) == str(workbook["name"])]
         workbook["views"] = len(views)
 
+    # batch the share lookups into two grouped queries instead of ~2 per
+    # workbook (avoids an N+1 over the whole list)
+    org_shared, shared_users = _workbook_shares(workbook_names)
     for workbook in workbooks:
-        organization_has_access = frappe.db.exists(
-            "DocShare",
-            {
-                "share_doctype": "Insights Workbook",
-                "share_name": workbook["name"],
-                "everyone": 1,
-                "read": 1,
-            },
-        )
-        if organization_has_access:
+        # share_name is stored as a string; workbook name may be an int — cast to match
+        name = str(workbook["name"])
+        if name in org_shared:
             workbook["shared_with_organization"] = True
             continue
+        workbook["shared_with"] = [user for user in shared_users.get(name, []) if user != workbook["owner"]]
 
-        shared_with = frappe.get_all(
+    return workbooks
+
+
+def _workbook_shares(names: list[str]) -> tuple[set, dict]:
+    """Return (org-shared workbook names, {workbook name -> [users it's read-shared with]}).
+
+    Two queries for the whole list instead of an exists-check + fetch per workbook.
+    Keys are stringified since DocShare.share_name is stored as a string.
+    """
+    if not names:
+        return set(), {}
+
+    org_shared = {
+        str(name)
+        for name in frappe.get_all(
             "DocShare",
             filters={
                 "share_doctype": "Insights Workbook",
-                "share_name": workbook["name"],
-                "user": ["!=", workbook["owner"]],
+                "share_name": ["in", names],
+                "everyone": 1,
                 "read": 1,
             },
-            pluck="user",
+            pluck="share_name",
         )
-        workbook["shared_with"] = shared_with
+    }
 
-    return workbooks
+    shared_users: dict[str, list] = {}
+    rows = frappe.get_all(
+        "DocShare",
+        filters={
+            "share_doctype": "Insights Workbook",
+            "share_name": ["in", names],
+            "read": 1,
+        },
+        fields=["share_name", "user"],
+    )
+    for row in rows:
+        shared_users.setdefault(str(row["share_name"]), []).append(row["user"])
+
+    return org_shared, shared_users
 
 
 @insights_whitelist()


### PR DESCRIPTION

- Filter tabs via a segmented switcher (All / Recents / Favorites / Created / Shared for dashboards; All / Created / Shared for workbooks); selection persisted locally.
- New **Recents** view (from per-user View Log) and a **Load more** button on both lists.
- Perf: dropped the `items` payload (chart count now from `linked_charts`), batched the View Log and DocShare lookups (removed N+1s), lazy preview images, optimistic favorite toggle.

No schema changes. Note: "Shared" = owned by someone else (matches existing workbook scope semantics).