### PR TITLE
fix: tie sparkline toggle to date column instead of comparison

### DIFF
--- a/frontend/src2/charts/components/NumberChart.vue
+++ b/frontend/src2/charts/components/NumberChart.vue
@@ -139,7 +139,10 @@ function onDoubleClick(measure_name: string) {
 						</span>
 						<span> {{ percentDelta }}% </span>
 					</div>
-					<div v-if="config.sparkline" class="mt-2 h-[18px] w-[80px]">
+					<div
+						v-if="config.sparkline && config.date_column?.column_name"
+						class="mt-2 h-[18px] w-[80px]"
+					>
 						<Sparkline
 							:dates="dateValues"
 							:values="values"

--- a/frontend/src2/charts/components/NumberChartConfigForm.vue
+++ b/frontend/src2/charts/components/NumberChartConfigForm.vue
@@ -168,9 +168,16 @@ function setNumberOption(index: number, option: keyof NumberColumnOptions, value
 				v-model="config.negative_is_better"
 			/>
 
-			<Toggle v-if="config.comparison" label="Show sparkline" v-model="config.sparkline" />
+			<Toggle
+				v-if="config.date_column?.column_name"
+				label="Show sparkline"
+				v-model="config.sparkline"
+			/>
 
-			<InlineFormControlLabel v-if="config.sparkline" label="Color">
+			<InlineFormControlLabel
+				v-if="config.date_column?.column_name && config.sparkline"
+				label="Color"
+			>
 				<ColorInput
 					:model-value="config.sparkline_color"
 					@update:model-value="updateColor($event)"


### PR DESCRIPTION
## Overview
Disabling the "Show comparison" toggle incorrectly hid the "Show sparkline" button while leaving the actual sparkline visible on the chart. This PR decouples the sparkline from the comparison feature and correctly ties both the toggle button and the chart rendering to the presence of a `date_column`.

## Key Changes
- **Number Chart Config Form (`NumberChartConfigForm.vue`)**: Changed the `v-if` condition for the "Show sparkline" toggle and its color picker to depend on `config.date_column?.column_name` instead of `config.comparison`.
- **Number Chart Graphic (`NumberChart.vue`)**: Added a check to only render the `<Sparkline />` component if a valid `date_column` is selected, preventing orphaned sparklines.

Closes #1061