### PR TITLE
fix: synchronize dashboard filter state with default config on save

### DIFF
--- a/frontend/src2/dashboard/DashboardFilter.vue
+++ b/frontend/src2/dashboard/DashboardFilter.vue
@@ -14,7 +14,7 @@ const dashboard = inject<Dashboard>('dashboard')!
 const props = defineProps<{ item: WorkbookDashboardFilter }>()
 
 const filter = reactive(copy(props.item))
-watchEffect(() => Object.assign(filter, copy(props.item)))
+watchEffect(() => Object.assign(filter, props.item))
 if (!filter.links) {
 	filter.links = {}
 }

--- a/frontend/src2/dashboard/DashboardFilter.vue
+++ b/frontend/src2/dashboard/DashboardFilter.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
 import { Icon } from 'frappe-ui/icons'
-import { computed, inject, reactive, watchEffect } from 'vue'
+import { computed, inject, reactive, watchEffect, watch } from 'vue'
 import { copy, wheneverChanges } from '../helpers'
 import { FIELDTYPES } from '../helpers/constants'
 import DataTypeIcon from '../query/components/DataTypeIcon.vue'
-import { ColumnDataType } from '../types/query.types'
+import { ColumnDataType, FilterOperator } from '../types/query.types'
 import { WorkbookDashboardFilter } from '../types/workbook.types'
 import { Dashboard } from './dashboard'
 import DashboardFilterEditor from './DashboardFilterEditor.vue'
@@ -49,6 +49,18 @@ function stringValuesProvider(search: string) {
 }
 
 const filterState = reactive(copy(dashboard.filterStates[filter.filter_name] || {}))
+
+watch(
+	() => [filter.default_operator, filter.default_value],
+	([op, val]) => {
+		if (op !== null && val !== null) {
+			filterState.operator = op as FilterOperator
+			filterState.value = val
+		}
+	},
+	{ immediate: true, deep: true },
+)
+
 wheneverChanges(
 	() => filterState,
 	() => {

--- a/frontend/src2/dashboard/DashboardFilterEditor.vue
+++ b/frontend/src2/dashboard/DashboardFilterEditor.vue
@@ -9,8 +9,7 @@ import ColumnFilterValueSelector from '../query/components/ColumnFilterValueSele
 import {
 	getOperatorOptions,
 	getValueSelectorType,
-	parseDateRange,
-	serializeDateRange,
+	normalizeDateRange,
 } from '../query/components/filter_utils'
 import NumberFilterPicker from '../query/components/NumberFilterPicker.vue'
 import RelativeDatePicker from '../query/components/RelativeDatePicker.vue'
@@ -117,9 +116,9 @@ function onDefaultOperatorChange(operator: FilterOperator) {
 }
 
 const dateRangeVal = computed({
-	get: () => parseDateRange(filter.default_value),
-	set: (val: string | string[]) => {
-		filter.default_value = serializeDateRange(val)
+	get: () => normalizeDateRange(filter.default_value),
+	set: (val: any) => {
+		filter.default_value = normalizeDateRange(val)
 	},
 })
 

--- a/frontend/src2/dashboard/DashboardFilterEditor.vue
+++ b/frontend/src2/dashboard/DashboardFilterEditor.vue
@@ -6,7 +6,12 @@ import useQuery from '../query/query'
 import { copy } from '../helpers'
 import { FIELDTYPES } from '../helpers/constants'
 import ColumnFilterValueSelector from '../query/components/ColumnFilterValueSelector.vue'
-import { getOperatorOptions, getValueSelectorType } from '../query/components/filter_utils'
+import {
+	getOperatorOptions,
+	getValueSelectorType,
+	parseDateRange,
+	serializeDateRange,
+} from '../query/components/filter_utils'
 import NumberFilterPicker from '../query/components/NumberFilterPicker.vue'
 import RelativeDatePicker from '../query/components/RelativeDatePicker.vue'
 import { ColumnOption, FilterOperator } from '../types/query.types'
@@ -110,6 +115,13 @@ function onDefaultOperatorChange(operator: FilterOperator) {
 		filter.default_value = undefined
 	}
 }
+
+const dateRangeVal = computed({
+	get: () => parseDateRange(filter.default_value),
+	set: (val: string | string[]) => {
+		filter.default_value = serializeDateRange(val)
+	},
+})
 
 function clearDefault() {
 	filter.default_operator = undefined
@@ -270,7 +282,7 @@ function saveEdit() {
 												"
 												class="flex-1"
 												:range="true"
-												v-model="filter.default_value as string[]"
+												v-model="dateRangeVal as string[]"
 											/>
 											<RelativeDatePicker
 												v-else-if="

--- a/frontend/src2/dashboard/Filter.vue
+++ b/frontend/src2/dashboard/Filter.vue
@@ -7,8 +7,7 @@ import ColumnFilterValueSelector from '../query/components/ColumnFilterValueSele
 import {
 	getOperatorOptions,
 	getValueSelectorType,
-	parseDateRange,
-	serializeDateRange,
+	normalizeDateRange,
 } from '../query/components/filter_utils'
 import NumberFilterPicker from '../query/components/NumberFilterPicker.vue'
 import RelativeDatePicker from '../query/components/RelativeDatePicker.vue'
@@ -59,9 +58,9 @@ function clearFilter() {
 
 // For a bried period, the value of a date filter with 'between' operator is stored as `from_date,to_date` string. This computed property helps to convert it to array and vice versa for the DateRangePicker component.
 const dateRangeVal = computed({
-	get: () => parseDateRange(state.value),
-	set: (val: string | string[]) => {
-		state.value = serializeDateRange(val) as any
+	get: () => normalizeDateRange(state.value),
+	set: (val: any) => {
+		state.value = normalizeDateRange(val)
 	},
 })
 </script>

--- a/frontend/src2/dashboard/Filter.vue
+++ b/frontend/src2/dashboard/Filter.vue
@@ -4,7 +4,12 @@ import { copy } from '../helpers'
 import { FilterType } from '../helpers/constants'
 import { DatePicker, DateRangePicker } from 'frappe-ui'
 import ColumnFilterValueSelector from '../query/components/ColumnFilterValueSelector.vue'
-import { getOperatorOptions, getValueSelectorType } from '../query/components/filter_utils'
+import {
+	getOperatorOptions,
+	getValueSelectorType,
+	parseDateRange,
+	serializeDateRange,
+} from '../query/components/filter_utils'
 import NumberFilterPicker from '../query/components/NumberFilterPicker.vue'
 import RelativeDatePicker from '../query/components/RelativeDatePicker.vue'
 import { FilterOperator, FilterValue } from '../types/query.types'
@@ -54,16 +59,9 @@ function clearFilter() {
 
 // For a bried period, the value of a date filter with 'between' operator is stored as `from_date,to_date` string. This computed property helps to convert it to array and vice versa for the DateRangePicker component.
 const dateRangeVal = computed({
-	get() {
-		let val = state.value
-		if (typeof val === 'string') {
-			const [from_date, to_date] = val.split(',')
-			return [from_date, to_date]
-		}
-		return val
-	},
-	set(val: string) {
-		state.value = val.split(',')
+	get: () => parseDateRange(state.value),
+	set: (val: string | string[]) => {
+		state.value = serializeDateRange(val) as any
 	},
 })
 </script>

--- a/frontend/src2/query/components/filter_utils.ts
+++ b/frontend/src2/query/components/filter_utils.ts
@@ -146,15 +146,7 @@ export function isValidNumber(value: any) {
 }
 
 // dateRangePicker string/array conversion
-export function parseDateRange(val: any) {
-	if (typeof val === 'string') {
-		const [from_date, to_date] = val.split(',')
-		return [from_date, to_date]
-	}
-	return val
-}
-
-export function serializeDateRange(val: string | string[]) {
+export function normalizeDateRange(val: any) {
 	if (typeof val === 'string') {
 		return val.split(',')
 	}

--- a/frontend/src2/query/components/filter_utils.ts
+++ b/frontend/src2/query/components/filter_utils.ts
@@ -144,3 +144,19 @@ export function isValidNumber(value: any) {
 		!isNaN(parseFloat(value))
 	)
 }
+
+// dateRangePicker string/array conversion
+export function parseDateRange(val: any) {
+	if (typeof val === 'string') {
+		const [from_date, to_date] = val.split(',')
+		return [from_date, to_date]
+	}
+	return val
+}
+
+export function serializeDateRange(val: string | string[]) {
+	if (typeof val === 'string') {
+		return val.split(',')
+	}
+	return val
+}


### PR DESCRIPTION
## Overview

Previously, when saving a filter's default config via `DashboardFilterEditor.vue`, the dashboard filter (`DashboardFilter.vue`) did not immediately reflect the newly saved default config. The user had to reload the page for the defaults to take effect. This PR synchronize filterState operator and filterState value with default filter config upon saving with proper from_date and to_date formatting

## Key Changes

- **(`DashboardFilter.vue`)**: Added a `watch` block to sync `default_operator` and `default_value` to `filterState`, saving a default config in the modal applies instantly to the filter button without requiring a page reload, Furthermore , removed the `copy()` wrapper inside `watchEffect` to prevent stripping `undefined` properties allowing the "Clear" button to successfully propagate empty (undefined) config.

- **(`DashboardFilterEditor.vue`, `Filter.vue`, `filter_utils.ts`)**: Extracted `dateRangeVal` logic in `parseDateRange` and `serializeDateRange` helpers to convert these strings into array where `<DateRangePicker>` returned comma-separated strings.

## Testing

1. Create a new filter in the dashboard.
2. Link it to a chart and fill the config and hit save.
3. The config will immediately reflect on to the Filter button.
4. Similarly tested the clear config logic.

Closes #1188