### PR TITLE
fix: resolve incorrect drill-down data on sorted date charts

### DIFF
--- a/frontend/src2/charts/components/ChartRenderer.vue
+++ b/frontend/src2/charts/components/ChartRenderer.vue
@@ -15,6 +15,8 @@ import {
 	MapChartConfig,
 	NumberChartConfig,
 	SankeyChartConfig,
+	AXIS_CHARTS,
+	AxisChartConfig,
 } from '../../types/chart.types'
 import { Chart } from '../chart'
 import {
@@ -25,6 +27,7 @@ import {
 	getLineChartOptions,
 	getMapChartOptions,
 	getSankeyChartOptions,
+	getAxisChartRowOrder,
 } from '../helpers'
 import BaseChart from './BaseChart.vue'
 import DrillDown from './DrillDown.vue'
@@ -146,9 +149,13 @@ function handleMapChartClick(params: any) {
 function handleGeneralChartClick(params: any) {
 	let dataIndex = params.dataIndex
 
-	// Adjust index for Row charts (they're displayed in reverse order)
-	if (chart_type.value === 'Row') {
-		dataIndex = result.value.formattedRows.length - 1 - dataIndex
+	if (AXIS_CHARTS.includes(chart_type.value)) {
+		const rowOrder = getAxisChartRowOrder(
+			result.value.rows,
+			(config.value as AxisChartConfig).x_axis,
+			chart_type.value === 'Row',
+		)
+		dataIndex = rowOrder[dataIndex]
 	}
 
 	const row = result.value.formattedRows[dataIndex]

--- a/frontend/src2/charts/helpers.ts
+++ b/frontend/src2/charts/helpers.ts
@@ -51,6 +51,24 @@ export function guessChart(columns: QueryResultColumn[], rows: QueryResultRow[])
 	if (discreteDimensions.length > 1 && measures.length) return 'table'
 }
 
+export function getAxisChartRowOrder(rows: any[], xAxisConfig: any, reversed = false) {
+	let indices = rows.map((_, i) => i)
+	const xAxisIsDate = isCalendarDateType(xAxisConfig.dimension?.data_type)
+
+	if (xAxisIsDate) {
+		indices.sort((a, b) => {
+			const a_date = new Date(rows[a][xAxisConfig.dimension.dimension_name])
+			const b_date = new Date(rows[b][xAxisConfig.dimension.dimension_name])
+			return a_date.getTime() - b_date.getTime()
+		})
+	}
+
+	if (reversed) {
+		indices.reverse()
+	}
+	return indices
+}
+
 export function getLineChartOptions(config: LineChartConfig, result: QueryResult) {
 	const _columns = result.columns
 	const _rows = result.rows
@@ -69,13 +87,8 @@ export function getLineChartOptions(config: LineChartConfig, result: QueryResult
 	const hasRightAxis = config.y_axis.series.some((s) => s.align === 'Right')
 	const yAxis = !hasRightAxis ? [leftYAxis] : [leftYAxis, rightYAxis]
 
-	const sortedRows = xAxisIsDate
-		? [..._rows].sort((a, b) => {
-				const a_date = new Date(a[config.x_axis.dimension.dimension_name])
-				const b_date = new Date(b[config.x_axis.dimension.dimension_name])
-				return a_date.getTime() - b_date.getTime()
-		  })
-		: _rows
+	const rowOrder = getAxisChartRowOrder(_rows, config.x_axis)
+	const sortedRows = rowOrder.map((i) => _rows[i])
 
 	const getSeriesData = (column: string) =>
 		sortedRows.map((r) => {
@@ -205,13 +218,8 @@ export function getBarChartOptions(config: BarChartConfig, result: QueryResult, 
 	const hasRightAxis = config.y_axis.series.some((s) => s.align === 'Right')
 	const yAxis = !hasRightAxis ? [leftYAxis] : [leftYAxis, rightYAxis]
 
-	const sortedRows = xAxisIsDate
-		? [..._rows].sort((a, b) => {
-				const a_date = new Date(a[config.x_axis.dimension.dimension_name])
-				const b_date = new Date(b[config.x_axis.dimension.dimension_name])
-				return a_date.getTime() - b_date.getTime()
-		  })
-		: _rows
+	const rowOrder = getAxisChartRowOrder(_rows, config.x_axis, swapAxes)
+	const sortedRows = rowOrder.map((i) => _rows[i])
 
 	const total_per_x_value = _rows.reduce((acc, row) => {
 		const x_value = row[config.x_axis.dimension.dimension_name]
@@ -264,7 +272,7 @@ export function getBarChartOptions(config: BarChartConfig, result: QueryResult, 
 			type,
 			stack: config.y_axis.overlap ? undefined : stack,
 			name,
-			data: swapAxes ? data.reverse() : data,
+			data,
 			color: color,
 			label: {
 				show: hide_from_chart ? false : show_data_labels,


### PR DESCRIPTION
## Overview
Previously, when a user sorted a table containing a Date axis, clicking a chart bar in ECharts would map to the wrong index and fetch incorrect drill-down data. This is because the Chart Builder (`helpers.ts`) forcefully applies a chronological sort to prevent rendering glitches in Line charts, but the Click Handler (`ChartRenderer.vue`) was completely unaware of this hidden sort.

This PR fixes this issue while preserving the rendering of Line chart.

## Key Changes
- **(`helpers.ts`)**: Instead of having `getLineChartOptions` and `getBarChartOptions` each do their own custom array sorting, I extracted the sorting logic into a pure function `getAxisChartRowOrder`.
- **(`ChartRenderer.vue`)**: Updated `handleGeneralChartClick` to use the new shared `getAxisChartRowOrder` function, now whenever ECharts fires a click event and hands us a visual index, the click handler runs that new `getAxisChartRowOrder` function to easily trace that visual index right back to the correct row in the original database.

### Before

https://github.com/user-attachments/assets/513c5d9a-98fa-42ee-948a-659ac346e2cd


### After

https://github.com/user-attachments/assets/f28238bc-b458-4f4f-8557-81aac2fc2c0e


Closes #1065 