### PR TITLE
fix: dashboard preview thumbnails fail for guest API calls during screenshot

### DIFF
--- a/frontend/src2/dashboard/DashboardCard.vue
+++ b/frontend/src2/dashboard/DashboardCard.vue
@@ -1,5 +1,6 @@
 <script setup lang="tsx">
 import { BarChart2, Clock, Eye, MoreVertical, RefreshCw, Bookmark } from 'lucide-vue-next'
+import { ref, watch } from 'vue'
 import { DashboardListItem } from './dashboards'
 
 interface Props {
@@ -16,6 +17,15 @@ const emit = defineEmits<{
 	'toggle-favorite': []
 	'update-preview': []
 }>()
+
+const previewFailed = ref(false)
+
+watch(
+	() => props.dashboard.preview_image,
+	() => {
+		previewFailed.value = false
+	},
+)
 </script>
 
 <template>
@@ -25,12 +35,12 @@ const emit = defineEmits<{
 			class="flex h-[150px] overflow-hidden rounded shadow transition-transform duration-200 group-hover:scale-[1.01]"
 		>
 			<img
-				v-if="dashboard.preview_image"
+				v-if="dashboard.preview_image && !previewFailed"
 				:src="dashboard.preview_image"
 				loading="lazy"
 				decoding="async"
-				onerror="this.src = ''"
-				class="object-cover opacity-80"
+				@error="previewFailed = true"
+				class="h-full w-full object-cover object-top opacity-80"
 			/>
 			<div v-else class="flex h-full w-full items-center justify-center bg-gray-50/70">
 				<Button

--- a/insights/api/shared.py
+++ b/insights/api/shared.py
@@ -56,7 +56,11 @@ def is_public_workbook(name: str):
 
 def has_valid_preview_key():
     # used to generate preview images of a dashboard
-    preview_key = frappe.request.headers.get("X-Insights-Preview-Key")
+    preview_key = (
+        frappe.request.headers.get("X-Insights-Preview-Key")
+        or frappe.form_dict.get("insights_preview_key")
+        or frappe.request.cookies.get("insights_preview_key")
+    )
     return preview_key and frappe.cache.get_value(f"insights_preview_key:{preview_key}")
 
 

--- a/insights/insights/doctype/insights_dashboard_v3/insights_dashboard_v3.py
+++ b/insights/insights/doctype/insights_dashboard_v3/insights_dashboard_v3.py
@@ -86,7 +86,10 @@ class InsightsDashboardv3(Document):
     ):
         is_guest = frappe.session.user == "Guest"
         if is_guest and not self.is_public:
-            raise frappe.PermissionError
+            from insights.api.shared import has_valid_preview_key
+
+            if not has_valid_preview_key():
+                raise frappe.PermissionError
 
         if not self.is_filter_column(query, column_name):
             frappe.throw(
@@ -136,18 +139,25 @@ class InsightsDashboardv3(Document):
         self.generate_dashboard_preview()
 
     def generate_dashboard_preview(self):
-        with generate_preview_key() as key:
-            preview = get_page_preview(
-                frappe.utils.get_url(f"/insights/shared/dashboard/{self.name}"),
-                headers={
-                    "X-Insights-Preview-Key": key,
-                },
-            )
-            file_url = create_preview_file(preview, self.name)
-            random_hash = frappe.generate_hash()[0:4]
-            file_url = f"{file_url}?{random_hash}"
-            self.db_set("preview_image", file_url)
-            return file_url
+        try:
+            with generate_preview_key() as key:
+                preview_url = frappe.utils.get_url(
+                    f"/insights/shared/dashboard/{self.name}?insights_preview_key={key}"
+                )
+                preview = get_page_preview(
+                    preview_url,
+                    headers={"X-Insights-Preview-Key": key},
+                )
+                if not is_valid_preview_image(preview):
+                    return self.preview_image
+
+                file_url = create_preview_file(preview, self.name)
+                file_url = f"{file_url}?{frappe.generate_hash()[0:4]}"
+                self.db_set("preview_image", file_url)
+                return file_url
+        except Exception:
+            frappe.log_error(title="Failed to generate dashboard preview")
+            return self.preview_image
 
     def get_acess_data(self):
         DocShare = frappe.qb.DocType("DocShare")
@@ -257,7 +267,7 @@ def get_page_preview(url: str, headers: dict | None = None) -> bytes:
         json={
             "url": url,
             "headers": headers or {},
-            "wait_for": 1000,
+            "wait_for": 3000,
         },
     )
     if response.status_code == 200:
@@ -266,6 +276,10 @@ def get_page_preview(url: str, headers: dict | None = None) -> bytes:
         exception = response.json()
         frappe.log_error(message=exception, title="Failed to generate preview")
         frappe.throw("Failed to generate preview")
+
+
+def is_valid_preview_image(content: bytes) -> bool:
+    return content[:3] == b"\xff\xd8\xff"
 
 
 def create_preview_file(content: bytes, dashboard_name: str):
@@ -298,7 +312,7 @@ def create_preview_file(content: bytes, dashboard_name: str):
 def generate_preview_key():
     try:
         key = frappe.generate_hash()
-        frappe.cache.set_value(f"insights_preview_key:{key}", True)
+        frappe.cache.set_value(f"insights_preview_key:{key}", True, expires_in_sec=300)
         yield key
     finally:
         frappe.cache.delete_value(f"insights_preview_key:{key}")

--- a/insights/www/insights.py
+++ b/insights/www/insights.py
@@ -71,6 +71,17 @@ def continue_to_v3(context):
         "socketio_port": frappe.conf.get("socketio_port"),
     }
 
+    preview_key = frappe.form_dict.get("insights_preview_key")
+    if preview_key and frappe.cache.get_value(f"insights_preview_key:{preview_key}"):
+        # headless preview loads the SPA then calls APIs as Guest — cookie carries the key
+        frappe.local.cookie_manager.set_cookie(
+            "insights_preview_key",
+            preview_key,
+            max_age=120,
+            httponly=0,
+            samesite="Lax",
+        )
+
 
 def redirect_to_v2():
     path = frappe.request.full_path


### PR DESCRIPTION
Before:-
<img width="1919" height="927" alt="image" src="https://github.com/user-attachments/assets/ba4e9eb1-1f03-4124-bbc0-857a10ad483d" />

After:-
<img width="1919" height="905" alt="image" src="https://github.com/user-attachments/assets/a3c9f5f6-9e3a-4b23-942f-5a582f883708" />
