### PR TITLE
fix: use heart icon for dashboard favorites

### DIFF
--- a/frontend/src2/dashboard/DashboardCard.vue
+++ b/frontend/src2/dashboard/DashboardCard.vue
@@ -1,5 +1,5 @@
 <script setup lang="tsx">
-import { BarChart2, Clock, Eye, MoreVertical, RefreshCw, Bookmark } from 'lucide-vue-next'
+import { BarChart2, Clock, Eye, Heart, MoreVertical, RefreshCw } from 'lucide-vue-next'
 import { DashboardListItem } from './dashboards'
 
 interface Props {
@@ -76,7 +76,7 @@ const emit = defineEmits<{
 			</div>
 			<div class="flex flex-shrink-0 items-center">
 				<button @click.stop="emit('toggle-favorite')">
-					<Bookmark
+					<Heart
 						class="h-4 w-4"
 						:class="{
 							'fill-blue-500 text-blue-500 transition-all hover:scale-110 active:scale-90':


### PR DESCRIPTION
- Replace bookmark icon with heart on dashboard cards for the favorite toggle
- Bookmark was misleading since the action adds dashboards to the Favorites tab

<img width="1890" height="904" alt="image" src="https://github.com/user-attachments/assets/abd1ada6-dc68-43f6-ab37-f5acf4f313dd" />
