### PR TITLE
perf(datatable): paginate large result sets on the client

### DIFF
--- a/frontend/src2/components/DataTable.vue
+++ b/frontend/src2/components/DataTable.vue
@@ -50,6 +50,7 @@ const props = defineProps<{
 	columnWidths?: Record<string, number>
 	textWrap?: Record<string, boolean>
 	pageSize?: number
+	displayPageSize?: number
 	totalRowCount?: number
 	onPageChange?: (page: number) => void
 	currentPage?: number
@@ -216,6 +217,7 @@ const totalColumnTotal = computed(() => {
 
 const pagination = usePagination({
 	pageSize: computed(() => props.pageSize ?? 100),
+	displayPageSize: computed(() => props.displayPageSize ?? 100),
 	rowCount: computed(() => visibleRows.value?.length ?? 0),
 	totalRowCount: computed(() => props.totalRowCount),
 	currentPage: computed(() => props.currentPage),

--- a/frontend/src2/composables/usePagination.ts
+++ b/frontend/src2/composables/usePagination.ts
@@ -34,12 +34,12 @@ export function usePagination(options: PaginationOptions): PaginationState {
 	const cursor = useCursor(options, config)
 	const bounds = useBounds(config, cursor)
 
-	const { serverPage, clientPage, clientPageCount, fetchChunk } = cursor
+	const { serverPage, clientPage, clientPageCount, lastSubPage, fetchChunk } = cursor
 
 	function prev() {
 		if (bounds.isFirstPage.value) return
 		if (clientPage.value > 1) clientPage.value--
-		else fetchChunk(serverPage.value - 1)
+		else fetchChunk(serverPage.value - 1, lastSubPage.value)
 	}
 	function next() {
 		if (bounds.isLastPage.value) return
@@ -74,22 +74,27 @@ function useCursor(options: PaginationOptions, config: Config) {
 	)
 	const chunkOffset = computed(() => (serverPage.value - 1) * config.serverPageSize.value)
 
-	function loadChunk(page: number) {
+	function loadChunk(page: number, subPage = 1) {
 		if (page < 1 || page === serverPage.value) return
 		serverPage.value = page
-		clientPage.value = 1
+		clientPage.value = subPage
 	}
-	function fetchChunk(page: number) {
+	function fetchChunk(page: number, subPage = 1) {
 		if (page < 1) return
-		loadChunk(page)
+		loadChunk(page, subPage)
 		options.onPageChange?.(page)
 	}
+
+	// last sub-page of a full chunk — where a backward chunk hop should land
+	const lastSubPage = computed(() =>
+		Math.ceil(config.serverPageSize.value / config.displayPageSize.value)
+	)
 
 	// follow external page changes; clamp the sub-page when the chunk shrinks
 	watch(() => toValue(options.currentPage), (page) => page !== undefined && loadChunk(page))
 	watch(clientPageCount, (count) => (clientPage.value = Math.min(clientPage.value, count)))
 
-	return { serverPage, clientPage, clientPageCount, chunkOffset, fetchChunk }
+	return { serverPage, clientPage, clientPageCount, chunkOffset, lastSubPage, fetchChunk }
 }
 
 type Cursor = ReturnType<typeof useCursor>

--- a/frontend/src2/composables/usePagination.ts
+++ b/frontend/src2/composables/usePagination.ts
@@ -1,7 +1,19 @@
-import { computed, ref, watch, toValue, type Ref, type ComputedRef, type MaybeRefOrGetter } from 'vue'
+import { computed, ref, watch, toValue, type ComputedRef, type MaybeRefOrGetter } from 'vue'
+
+const DEFAULT_PAGE_SIZE = 100
+
+export type PaginationOptions = {
+	rowCount: MaybeRefOrGetter<number>
+	pageSize: MaybeRefOrGetter<number>
+	displayPageSize?: MaybeRefOrGetter<number>
+	totalRowCount?: MaybeRefOrGetter<number | undefined>
+	currentPage?: MaybeRefOrGetter<number | undefined>
+	onPageChange?: (page: number) => void
+	enabled?: MaybeRefOrGetter<boolean>
+}
 
 export type PaginationState = {
-	currentPage: Ref<number>
+	currentPage: ComputedRef<number>
 	from: ComputedRef<number>
 	to: ComputedRef<number>
 	isFirstPage: ComputedRef<boolean>
@@ -15,78 +27,111 @@ export type PaginationState = {
 	goTo: (pageNum: number) => void
 }
 
-export function usePagination(options: {
-	rowCount: MaybeRefOrGetter<number>
-	pageSize: MaybeRefOrGetter<number>
-	totalRowCount?: MaybeRefOrGetter<number | undefined>
-	currentPage?: MaybeRefOrGetter<number | undefined>
-	onPageChange?: (page: number) => void
-	enabled?: MaybeRefOrGetter<boolean>
-}): PaginationState {
-	const pageSize = computed(() => toValue(options.pageSize) ?? 100)
-	const currentPage = ref(toValue(options.currentPage) ?? 1)
+// `pageSize` is the server chunk stride; `displayPageSize` is the client slice rendered
+// into the DOM. When they differ, a chunk is sub-paginated on the client with no fetch.
+export function usePagination(options: PaginationOptions): PaginationState {
+	const config = useConfig(options)
+	const cursor = useCursor(options, config)
+	const bounds = useBounds(config, cursor)
 
-	watch(
-		() => toValue(options.currentPage),
-		(val) => {
-			if (val !== undefined) currentPage.value = val
-		}
-	)
-
-	const isServerPaged = computed(() => Boolean(options.onPageChange))
-
-	const isFirstPage = computed(() => currentPage.value <= 1)
-	const isLastPage = computed(() => {
-		const total = toValue(options.totalRowCount)
-		if (total) return currentPage.value >= Math.ceil(total / pageSize.value)
-		return toValue(options.rowCount) < pageSize.value
-	})
-	const isSinglePage = computed(() => isFirstPage.value && isLastPage.value)
-
-	const from = computed(() => (currentPage.value - 1) * pageSize.value + 1)
-	const to = computed(() => from.value + toValue(options.rowCount) - 1)
-
-	const startIndex = computed(() => {
-		if (!toValue(options.enabled)) return 0
-		if (isServerPaged.value) return 0
-		return (currentPage.value - 1) * pageSize.value
-	})
-	const endIndex = computed(() => {
-		const len = toValue(options.rowCount)
-		if (!toValue(options.enabled)) return len
-		if (isServerPaged.value) return Math.min(pageSize.value, len)
-		return Math.min(currentPage.value * pageSize.value, len)
-	})
-
-	const rowDisplayOffset = computed(() => (currentPage.value - 1) * pageSize.value)
+	const { serverPage, clientPage, clientPageCount, fetchChunk } = cursor
 
 	function prev() {
-		if (isFirstPage.value) return
-		currentPage.value--
-		options.onPageChange?.(currentPage.value)
+		if (bounds.isFirstPage.value) return
+		if (clientPage.value > 1) clientPage.value--
+		else fetchChunk(serverPage.value - 1)
 	}
 	function next() {
-		if (isLastPage.value) return
-		currentPage.value++
-		options.onPageChange?.(currentPage.value)
-	}
-	function goTo(pageNum: number) {
-		currentPage.value = pageNum
-		options.onPageChange?.(currentPage.value)
+		if (bounds.isLastPage.value) return
+		if (clientPage.value < clientPageCount.value) clientPage.value++
+		else fetchChunk(serverPage.value + 1)
 	}
 
+	return { ...bounds, prev, next, goTo: fetchChunk }
+}
+
+function useConfig(options: PaginationOptions) {
+	const serverPageSize = computed(() => toValue(options.pageSize) ?? DEFAULT_PAGE_SIZE)
 	return {
+		serverPageSize,
+		displayPageSize: computed(() => toValue(options.displayPageSize) ?? serverPageSize.value),
+		rowCount: computed(() => toValue(options.rowCount)),
+		total: computed(() => toValue(options.totalRowCount)),
+		enabled: computed(() => Boolean(toValue(options.enabled))),
+		isServerPaged: computed(() => Boolean(options.onPageChange)),
+	}
+}
+
+type Config = ReturnType<typeof useConfig>
+
+// Tracks which server chunk is loaded and which sub-page within it is shown.
+function useCursor(options: PaginationOptions, config: Config) {
+	const serverPage = ref(toValue(options.currentPage) ?? 1)
+	const clientPage = ref(1)
+
+	const clientPageCount = computed(() =>
+		Math.max(1, Math.ceil(config.rowCount.value / config.displayPageSize.value))
+	)
+	const chunkOffset = computed(() => (serverPage.value - 1) * config.serverPageSize.value)
+
+	function loadChunk(page: number) {
+		if (page < 1 || page === serverPage.value) return
+		serverPage.value = page
+		clientPage.value = 1
+	}
+	function fetchChunk(page: number) {
+		if (page < 1) return
+		loadChunk(page)
+		options.onPageChange?.(page)
+	}
+
+	// follow external page changes; clamp the sub-page when the chunk shrinks
+	watch(() => toValue(options.currentPage), (page) => page !== undefined && loadChunk(page))
+	watch(clientPageCount, (count) => (clientPage.value = Math.min(clientPage.value, count)))
+
+	return { serverPage, clientPage, clientPageCount, chunkOffset, fetchChunk }
+}
+
+type Cursor = ReturnType<typeof useCursor>
+
+// Translates the cursor into the row indices and labels the table/footer render.
+function useBounds(config: Config, cursor: Cursor) {
+	const { serverPageSize, displayPageSize, rowCount, total, enabled, isServerPaged } = config
+	const { serverPage, clientPage, clientPageCount, chunkOffset } = cursor
+
+	const startIndex = computed(() =>
+		enabled.value ? (clientPage.value - 1) * displayPageSize.value : 0
+	)
+	const endIndex = computed(() =>
+		enabled.value
+			? Math.min(clientPage.value * displayPageSize.value, rowCount.value)
+			: rowCount.value
+	)
+
+	const from = computed(() => chunkOffset.value + startIndex.value + 1)
+	const to = computed(() => chunkOffset.value + endIndex.value)
+	const rowDisplayOffset = computed(() => chunkOffset.value + startIndex.value)
+	const currentPage = computed(
+		() => Math.floor(chunkOffset.value / displayPageSize.value) + clientPage.value
+	)
+
+	const hasNextChunk = computed(() => {
+		if (!isServerPaged.value) return false
+		return total.value != null ? to.value < total.value : rowCount.value >= serverPageSize.value
+	})
+	const isFirstPage = computed(() => serverPage.value <= 1 && clientPage.value <= 1)
+	const isLastPage = computed(() => clientPage.value >= clientPageCount.value && !hasNextChunk.value)
+	const isSinglePage = computed(() => isFirstPage.value && isLastPage.value)
+
+	return {
+		startIndex,
+		endIndex,
+		rowDisplayOffset,
+		from,
+		to,
 		currentPage,
 		isFirstPage,
 		isLastPage,
 		isSinglePage,
-		from,
-		to,
-		startIndex,
-		endIndex,
-		rowDisplayOffset,
-		prev,
-		next,
-		goTo,
 	}
 }


### PR DESCRIPTION
## Problem

`DataTable` rendered **every fetched row** into the DOM. A table chart configured with a large row limit (e.g. 30k) produced tens of thousands of `<tr>` nodes at once, making the table sluggish to render and scroll.

## Change

Decouple the **display page size** (client) from the **server fetch size** in `usePagination`:

- `pageSize` stays the server chunk stride (the fetch limit).
- New `displayPageSize` (default **100**) is the client slice actually rendered into the DOM.
- A loaded chunk is sub-paginated on the client with **no round-trip**; reaching the last sub-page of a chunk transparently fetches the next/previous server page.
- When the two sizes are equal there is exactly one display page per chunk, so behavior is **identical to the previous server pagination** — the query builder is unchanged.

`usePagination` was also refactored into small focused helpers (`useConfig`, `useCursor`, `useBounds`) and the footer index/label math was fixed for client mode.

## Result

| Context | Before | After |
|---|---|---|
| Table chart, 30k limit | 30k DOM rows | 100 rows/page, instant client sub-pages |
| Query builder (100/page) | server pagination | unchanged |
| < 100 rows | single page | single page (pager hidden) |

Column totals / color scales still span the whole loaded chunk.
