### PR TITLE
feat: add date presets, assign default operators, and unify formatting across dashboard, query builder, and chart

### DIFF
--- a/frontend/src2/dashboard/DashboardFilter.vue
+++ b/frontend/src2/dashboard/DashboardFilter.vue
@@ -2,8 +2,10 @@
 import { Icon } from 'frappe-ui/icons'
 import { computed, inject, reactive, watchEffect, watch } from 'vue'
 import { copy, wheneverChanges } from '../helpers'
+import dayjs from '../helpers/dayjs'
 import { FIELDTYPES } from '../helpers/constants'
 import DataTypeIcon from '../query/components/DataTypeIcon.vue'
+import { formatDateFilterValue } from '../query/components/formatting_utils'
 import { ColumnDataType, FilterOperator } from '../types/query.types'
 import { WorkbookDashboardFilter } from '../types/workbook.types'
 import { Dashboard } from './dashboard'
@@ -72,9 +74,14 @@ wheneverChanges(
 const label = computed(() => {
 	let _label = filter.filter_name
 	if (filterState.operator && filterState.value) {
-		const value_str = Array.isArray(filterState.value)
-			? filterState.value.join(', ')
-			: filterState.value
+		let value_str = ''
+		if (filter.filter_type === 'Date') {
+			value_str = formatDateFilterValue(filterState.operator, filterState.value)
+		} else {
+			value_str = Array.isArray(filterState.value)
+				? filterState.value.join(', ')
+				: String(filterState.value)
+		}
 		_label += ` ${filterState.operator} ${value_str}`
 	}
 	return _label

--- a/frontend/src2/dashboard/DashboardFilter.vue
+++ b/frontend/src2/dashboard/DashboardFilter.vue
@@ -2,7 +2,6 @@
 import { Icon } from 'frappe-ui/icons'
 import { computed, inject, reactive, watchEffect, watch } from 'vue'
 import { copy, wheneverChanges } from '../helpers'
-import dayjs from '../helpers/dayjs'
 import { FIELDTYPES } from '../helpers/constants'
 import DataTypeIcon from '../query/components/DataTypeIcon.vue'
 import { formatDateFilterValue } from '../query/components/formatting_utils'

--- a/frontend/src2/dashboard/DashboardFilterEditor.vue
+++ b/frontend/src2/dashboard/DashboardFilterEditor.vue
@@ -27,6 +27,11 @@ if (!filter.links) {
 	filter.links = {}
 }
 
+// set a default operator initially
+if (!filter.filter_name && !filter.default_operator) {
+	filter.default_operator = getOperatorOptions(filter.filter_type)[0]?.value
+}
+
 const tabIndex = ref(0)
 const tabs = [
 	{
@@ -95,7 +100,7 @@ function disableColumnOptions(options: ColumnOption[]) {
 }
 
 function onFilterTypeChange() {
-	filter.default_operator = undefined
+	filter.default_operator = getOperatorOptions(filter.filter_type)[0]?.value
 	filter.default_value = undefined
 	filter.links = {}
 }

--- a/frontend/src2/dashboard/DashboardFilterEditor.vue
+++ b/frontend/src2/dashboard/DashboardFilterEditor.vue
@@ -17,7 +17,8 @@ import { ColumnOption, FilterOperator } from '../types/query.types'
 import { WorkbookDashboardFilter } from '../types/workbook.types'
 import { Dashboard } from './dashboard'
 import { __ } from '../translation'
-import { Switch, Tabs, DatePicker, DateRangePicker } from 'frappe-ui'
+import { Switch, Tabs, DatePicker } from 'frappe-ui'
+import AbsoluteDatePicker from '../query/components/AbsoluteDatePicker.vue'
 
 const dashboard = inject<Dashboard>('dashboard')!
 const props = defineProps<{ item: WorkbookDashboardFilter }>()
@@ -280,7 +281,7 @@ function saveEdit() {
 												:modelValue="filter.default_value as string"
 												@update:modelValue="filter.default_value = $event"
 											/>
-											<DateRangePicker
+											<AbsoluteDatePicker
 												v-else-if="
 													defaultValueSelectorType === 'date_range'
 												"

--- a/frontend/src2/dashboard/Filter.vue
+++ b/frontend/src2/dashboard/Filter.vue
@@ -2,7 +2,8 @@
 import { computed, reactive } from 'vue'
 import { copy } from '../helpers'
 import { FilterType } from '../helpers/constants'
-import { DatePicker, DateRangePicker } from 'frappe-ui'
+import { DatePicker } from 'frappe-ui'
+import AbsoluteDatePicker from '../query/components/AbsoluteDatePicker.vue'
 import ColumnFilterValueSelector from '../query/components/ColumnFilterValueSelector.vue'
 import {
 	getOperatorOptions,
@@ -89,7 +90,7 @@ const dateRangeVal = computed({
 					:modelValue="state.value as string"
 					@update:modelValue="state.value = $event"
 				/>
-				<DateRangePicker
+				<AbsoluteDatePicker
 					v-else-if="valueSelectorType === 'date_range'"
 					v-model="dateRangeVal as string[]"
 				/>

--- a/frontend/src2/query/components/AbsoluteDatePicker.vue
+++ b/frontend/src2/query/components/AbsoluteDatePicker.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+import { DateRangePicker } from 'frappe-ui'
+import PresetWrapper from './PresetWrapper.vue'
+import { getDatePresets } from './filter_utils'
+
+const dateRange = defineModel<string[]>()
+
+const presets = getDatePresets('between')
+</script>
+
+<template>
+	<div class="w-[18rem] select-none text-base flex flex-col gap-2">
+		<PresetWrapper v-model="dateRange" :presets="presets">
+			<DateRangePicker v-model="dateRange" class="w-full" />
+		</PresetWrapper>
+	</div>
+</template>

--- a/frontend/src2/query/components/AbsoluteDatePicker.vue
+++ b/frontend/src2/query/components/AbsoluteDatePicker.vue
@@ -1,17 +1,25 @@
 <script setup lang="ts">
+import { computed } from 'vue'
 import { DateRangePicker } from 'frappe-ui'
 import PresetWrapper from './PresetWrapper.vue'
-import { getDatePresets } from './filter_utils'
+import { getDatePresets, normalizeDateRange } from './filter_utils'
 
 const dateRange = defineModel<string[]>()
+
+const normalizedDateRange = computed({
+	get: () => normalizeDateRange(dateRange.value),
+	set: (val: any) => {
+		dateRange.value = normalizeDateRange(val)
+	},
+})
 
 const presets = getDatePresets('between')
 </script>
 
 <template>
 	<div class="w-[18rem] select-none text-base flex flex-col gap-2">
-		<PresetWrapper v-model="dateRange" :presets="presets">
-			<DateRangePicker v-model="dateRange" class="w-full" />
+		<PresetWrapper v-model="normalizedDateRange" :presets="presets">
+			<DateRangePicker v-model="normalizedDateRange" class="w-full" />
 		</PresetWrapper>
 	</div>
 </template>

--- a/frontend/src2/query/components/AbsoluteDatePickerControl.vue
+++ b/frontend/src2/query/components/AbsoluteDatePickerControl.vue
@@ -1,9 +1,15 @@
 <script setup lang="ts">
-import RelativeDatePicker from './RelativeDatePicker.vue'
+import { computed } from 'vue'
+import AbsoluteDatePicker from './AbsoluteDatePicker.vue'
+import { formatDateFilterValue } from './formatting_utils'
 
 const props = defineProps<{ placeholder?: string }>()
 
-const relativeDate = defineModel<string>()
+const dates = defineModel<string[]>()
+
+const displayDate = computed(() => {
+	return formatDateFilterValue('between', dates.value)
+})
 </script>
 
 <template>
@@ -12,15 +18,15 @@ const relativeDate = defineModel<string>()
 			<input
 				readonly
 				type="text"
-				:value="relativeDate"
-				:placeholder="props.placeholder || 'Relative Date'"
+				:value="displayDate"
+				:placeholder="props.placeholder || 'Select Date Range'"
 				@focus="togglePopover()"
 				class="form-input block h-7 w-full cursor-text select-none rounded border-gray-400 text-sm placeholder-gray-500"
 			/>
 		</template>
 		<template #body-main="{ togglePopover }">
 			<div class="flex flex-col p-2">
-				<RelativeDatePicker v-model="relativeDate" />
+				<AbsoluteDatePicker v-model="dates" />
 				<div class="mt-2 flex justify-end">
 					<Button variant="solid" @click="togglePopover"> Done </Button>
 				</div>

--- a/frontend/src2/query/components/FilterRule.vue
+++ b/frontend/src2/query/components/FilterRule.vue
@@ -11,6 +11,7 @@ import {
 import { column } from '../helpers'
 import useQuery from '../query'
 import DatePickerControl from './DatePickerControl.vue'
+import AbsoluteDatePickerControl from './AbsoluteDatePickerControl.vue'
 import { getFilterType, getOperatorOptions, getValueSelectorType } from './filter_utils'
 import RelativeDatePickerControl from './RelativeDatePickerControl.vue'
 
@@ -124,15 +125,14 @@ const fetchColumnValues = debounce((searchTxt: string) => {
 				:modelValue="[filter.value as string]"
 				@update:modelValue="filter.value = $event[0]"
 			/>
-			<DatePickerControl
+			<AbsoluteDatePickerControl
 				v-else-if="valueSelectorType === 'date_range'"
-				:range="true"
-				v-model="(filter.value as string[])"
+				v-model="filter.value as string[]"
 				placeholder="Select Date"
 			/>
 			<RelativeDatePickerControl
 				v-else-if="valueSelectorType === 'relative_date'"
-				v-model="(filter.value as string)"
+				v-model="filter.value as string"
 				placeholder="Relative Date"
 			/>
 			<Autocomplete

--- a/frontend/src2/query/components/PresetWrapper.vue
+++ b/frontend/src2/query/components/PresetWrapper.vue
@@ -26,11 +26,12 @@ watch(
 	() => modelValue.value,
 	(newVal) => {
 		if (!newVal || (Array.isArray(newVal) && newVal.length === 0)) {
-			if (props.presets.length > 0 && !isCustom.value) {
-				selectPreset(props.presets[0])
-			}
-		} else if (!currentPresetMatch.value) {
+			return
+		}
+		if (!currentPresetMatch.value) {
 			isCustom.value = true
+		} else {
+			isCustom.value = false
 		}
 	},
 	{ immediate: true, deep: true },

--- a/frontend/src2/query/components/PresetWrapper.vue
+++ b/frontend/src2/query/components/PresetWrapper.vue
@@ -1,0 +1,83 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { Autocomplete } from 'frappe-ui'
+import { __ } from '../../translation'
+import type { Preset } from '../../types/query.types'
+import { findPresetByValue } from './filter_utils'
+
+const props = defineProps<{
+	presets: Preset[]
+}>()
+
+const modelValue = defineModel<any>()
+
+const isCustom = ref(false)
+
+const currentPresetMatch = computed(() => {
+	return findPresetByValue(props.presets, modelValue.value)
+})
+
+function selectPreset(preset: Preset) {
+	isCustom.value = false
+	modelValue.value = preset.value()
+}
+
+watch(
+	() => modelValue.value,
+	(newVal) => {
+		if (!newVal || (Array.isArray(newVal) && newVal.length === 0)) {
+			if (props.presets.length > 0 && !isCustom.value) {
+				selectPreset(props.presets[0])
+			}
+		} else if (!currentPresetMatch.value) {
+			isCustom.value = true
+		}
+	},
+	{ immediate: true, deep: true },
+)
+
+// Dropdown Options
+const formControlOptions = computed(() => {
+	const options = props.presets.map((p) => ({
+		label: p.label,
+		value: p.label,
+		description: p.description?.(),
+	}))
+	options.push({ label: __('Custom'), value: 'Custom', description: '' })
+	return options
+})
+
+const selectedFormControlValue = computed({
+	get: () => {
+		if (isCustom.value) return 'Custom'
+		return currentPresetMatch.value ? currentPresetMatch.value.label : 'Custom'
+	},
+	set: (selectedLabel) => {
+		if (selectedLabel === 'Custom') {
+			isCustom.value = true
+		} else {
+			const preset = props.presets.find((p) => p.label === selectedLabel)
+			if (preset) selectPreset(preset)
+		}
+	},
+})
+
+function onOptionChange(val: string | { value?: string } | null | undefined) {
+	const selectedLabel = typeof val === 'string' ? val : val?.value
+	if (!selectedLabel) return
+	selectedFormControlValue.value = selectedLabel
+}
+</script>
+
+<template>
+	<Autocomplete
+		class="w-full"
+		:modelValue="selectedFormControlValue"
+		@update:modelValue="onOptionChange"
+		:options="formControlOptions"
+		:hide-search="true"
+	/>
+	<div class="mt-2 w-full">
+		<slot></slot>
+	</div>
+</template>

--- a/frontend/src2/query/components/RelativeDatePicker.vue
+++ b/frontend/src2/query/components/RelativeDatePicker.vue
@@ -1,23 +1,24 @@
 <script setup lang="ts">
-import { reactive, watchEffect } from 'vue'
+import { reactive, watchEffect, watch } from 'vue'
 import { FormControl } from 'frappe-ui'
 import { RelativeDateParts, SPAN_OPTIONS, INTERVAL_TYPE_OPTIONS } from '../../types/query.types'
+import { __ } from '../../translation'
+import PresetWrapper from './PresetWrapper.vue'
+import { getDatePresets } from './filter_utils'
 
-const relativeDate = defineModel<string>({
-	default: () => 'Last 1 Day',
-	required: true,
-})
+const relativeDate = defineModel<string>()
 
 const parts = reactive<RelativeDateParts>({
-	span: 'Last',
+	span: 'Current',
 	interval: '1',
 	intervalType: 'Day',
 	includeCurrent: false,
 })
 
-if (relativeDate.value) {
-	const includeCurrent = /\(include current\)$/.test(relativeDate.value)
-	const clean = relativeDate.value.replace(/\s*\(include current\)$/, '')
+const parseRelativeDate = (relativeDateString: string | undefined) => {
+	if (!relativeDateString) return
+	const includeCurrent = /\(include current\)$/.test(relativeDateString)
+	const clean = relativeDateString.replace(/\s*\(include current\)$/, '')
 	const tokens = clean.split(' ')
 	parts.span = tokens[0]
 	if (parts.span === 'Current') {
@@ -30,47 +31,64 @@ if (relativeDate.value) {
 	parts.includeCurrent = includeCurrent
 }
 
+watch(
+	() => relativeDate.value,
+	(newRelativeDate) => {
+		parseRelativeDate(newRelativeDate)
+	},
+	{ immediate: true },
+)
+
 watchEffect(() => {
 	if (parts.intervalType === 'Fiscal Year') parts.includeCurrent = false
-	const base = parts.span === 'Current'
-		? `${parts.span} ${parts.intervalType}`
-		: `${parts.span} ${parts.interval} ${parts.intervalType}`
-	relativeDate.value = parts.includeCurrent && parts.span !== 'Current'
-		? `${base} (include current)`
-		: base
+	const base =
+		parts.span === 'Current'
+			? `${parts.span} ${parts.intervalType}`
+			: `${parts.span} ${parts.interval} ${parts.intervalType}`
+	relativeDate.value =
+		parts.includeCurrent && parts.span !== 'Current' ? `${base} (include current)` : base
 })
 
 const toggleLabel = (span: string, intervalType: string) =>
 	span === 'Current' ? `${intervalType} to Date` : `Include Current ${intervalType}`
+
+const presets = getDatePresets('within')
 </script>
 
 <template>
-	<div class="flex w-[15rem] select-none flex-col gap-2 rounded bg-white text-base">
-		<div class="flex gap-2">
-			<FormControl
-				type="select"
-				v-model="parts.span"
-				class="flex-[3] flex-shrink-0 text-sm"
-				:options="SPAN_OPTIONS"
-			/>
-			<FormControl
-				v-if="parts.span !== 'Current'"
-				type="number"
-				v-model="parts.interval"
-				class="flex-[2] flex-shrink-0 text-sm"
-			/>
-			<FormControl
-				type="select"
-				v-model="parts.intervalType"
-				class="flex-[3] flex-shrink-0 text-sm"
-				:options="INTERVAL_TYPE_OPTIONS"
-			/>
-		</div>
-		<div v-if="parts.span !== 'Current' && parts.intervalType !== 'Fiscal Year'" class="flex items-center gap-2">
-			<Toggle size="sm" v-model="parts.includeCurrent" />
-			<span class="text-p-sm text-gray-600">
-				{{ toggleLabel(parts.span, parts.intervalType) }}
-			</span>
-		</div>
+	<div class="w-[15rem] select-none text-base flex flex-col gap-2">
+		<PresetWrapper v-model="relativeDate" :presets="presets">
+			<div class="flex flex-col gap-2 rounded bg-white w-full">
+				<div class="flex gap-2">
+					<FormControl
+						type="select"
+						v-model="parts.span"
+						class="flex-[3] flex-shrink-0 text-sm"
+						:options="SPAN_OPTIONS"
+					/>
+					<FormControl
+						v-if="parts.span !== 'Current'"
+						type="number"
+						v-model="parts.interval"
+						class="flex-[2] flex-shrink-0 text-sm"
+					/>
+					<FormControl
+						type="select"
+						v-model="parts.intervalType"
+						class="flex-[3] flex-shrink-0 text-sm"
+						:options="INTERVAL_TYPE_OPTIONS"
+					/>
+				</div>
+				<div
+					v-if="parts.span !== 'Current' && parts.intervalType !== 'Fiscal Year'"
+					class="flex items-center gap-2"
+				>
+					<Toggle size="sm" v-model="parts.includeCurrent" />
+					<span class="text-p-sm text-gray-600">
+						{{ toggleLabel(parts.span, parts.intervalType) }}
+					</span>
+				</div>
+			</div>
+		</PresetWrapper>
 	</div>
 </template>

--- a/frontend/src2/query/components/filter_utils.ts
+++ b/frontend/src2/query/components/filter_utils.ts
@@ -5,7 +5,10 @@ import {
 	FilterExpression,
 	FilterOperator,
 	FilterRule,
+	Preset,
 } from '../../types/query.types'
+import dayjs from '../../helpers/dayjs'
+import { formatDateRangeDescription } from './formatting_utils'
 
 export function getOperatorOptions(filterType: FilterType) {
 	const options = [] as { label: string; value: FilterOperator }[]
@@ -151,4 +154,78 @@ export function normalizeDateRange(val: any) {
 		return val.split(',')
 	}
 	return val
+}
+
+export function getDatePresets(operator: FilterOperator) {
+	const presets: Preset[] = []
+	if (operator === 'within') {
+		presets.push({ label: __('Today'), value: () => 'Current Day' })
+		presets.push({ label: __('This Week'), value: () => 'Current Week' })
+		presets.push({ label: __('This Month'), value: () => 'Current Month' })
+		presets.push({ label: __('Last 7 Days'), value: () => 'Last 7 Day' })
+		presets.push({ label: __('Last 30 Days'), value: () => 'Last 30 Day' })
+		presets.push({ label: __('Last 3 Months'), value: () => 'Last 3 Month' })
+		presets.push({ label: __('Last Year'), value: () => 'Last 1 Year' })
+	}
+	if (operator === 'between') {
+		const format = 'YYYY-MM-DD'
+		const d = {
+			today: () => dayjs(),
+			yesterday: () => dayjs().subtract(1, 'day'),
+			monthStart: () => dayjs().startOf('month'),
+			monthEnd: () => dayjs().endOf('month'),
+			lastMonthStart: () => dayjs().subtract(1, 'month').startOf('month'),
+			lastMonthEnd: () => dayjs().subtract(1, 'month').endOf('month'),
+			quarterStart: () => dayjs().startOf('quarter'),
+			quarterEnd: () => dayjs().endOf('quarter'),
+			lastYearStart: () => dayjs().subtract(1, 'year').startOf('year'),
+			lastYearEnd: () => dayjs().subtract(1, 'year').endOf('year'),
+		}
+		presets.push({
+			label: __('Today'),
+			value: () => [d.today().format(format), d.today().format(format)],
+			description: () => formatDateRangeDescription(d.today()),
+		})
+		presets.push({
+			label: __('Yesterday'),
+			value: () => [d.yesterday().format(format), d.yesterday().format(format)],
+			description: () => formatDateRangeDescription(d.yesterday()),
+		})
+		presets.push({
+			label: __('This Month'),
+			value: () => [d.monthStart().format(format), d.monthEnd().format(format)],
+			description: () => formatDateRangeDescription(d.monthStart(), d.monthEnd()),
+		})
+		presets.push({
+			label: __('Last Month'),
+			value: () => [d.lastMonthStart().format(format), d.lastMonthEnd().format(format)],
+			description: () => formatDateRangeDescription(d.lastMonthStart(), d.lastMonthEnd()),
+		})
+		presets.push({
+			label: __('This Quarter'),
+			value: () => [d.quarterStart().format(format), d.quarterEnd().format(format)],
+			description: () => formatDateRangeDescription(d.quarterStart(), d.quarterEnd()),
+		})
+		presets.push({
+			label: __('Last Year'),
+			value: () => [d.lastYearStart().format(format), d.lastYearEnd().format(format)],
+			description: () => formatDateRangeDescription(d.lastYearStart(), d.lastYearEnd()),
+		})
+	}
+	return presets
+}
+
+export function isPresetValueMatch(val1: any, val2: any): boolean {
+	if (!val1 && !val2) return true
+	if (!val1 || !val2) return false
+	const a1 = normalizeDateRange(val1)
+	const a2 = normalizeDateRange(val2)
+	if (Array.isArray(a1) && Array.isArray(a2)) {
+		return a1.length === a2.length && a1.every((v, i) => v === a2[i])
+	}
+	return a1 === a2
+}
+
+export function findPresetByValue(presets: Preset[], value: any): Preset | undefined {
+	return presets.find(p => isPresetValueMatch(p.value(), value))
 }

--- a/frontend/src2/query/components/formatting_utils.ts
+++ b/frontend/src2/query/components/formatting_utils.ts
@@ -312,12 +312,13 @@ export function applyRankRule(
 export const formatDateRangeDescription = (from: ReturnType<typeof dayjs>, to?: ReturnType<typeof dayjs>): string => {
 	if (!from || !from.isValid()) return ''
 	const currentYear = dayjs().year()
-	const fromStr = from.year() === currentYear ? from.format('MMM D') : from.format('MMM D, YYYY')
 	if (!to || !to.isValid() || from.isSame(to, 'day')) {
-		return fromStr
+		return from.year() === currentYear ? from.format('MMM D') : from.format('MMM D, YYYY')
 	}
-	const toStr = to.year() === currentYear ? to.format('MMM D') : to.format('MMM D, YYYY')
-	return `${fromStr} - ${toStr}`
+	const sameYear = from.year() === to.year()
+	const isCurrentYear = sameYear && from.year() === currentYear
+	const formatStr = isCurrentYear ? 'MMM D' : 'MMM D, YYYY'
+	return `${from.format(formatStr)} - ${to.format(formatStr)}`
 }
 
 export function formatDateFilterValue(operator: FilterOperator, value: any): string {

--- a/frontend/src2/query/components/formatting_utils.ts
+++ b/frontend/src2/query/components/formatting_utils.ts
@@ -1,4 +1,5 @@
-import { Column } from "../../types/query.types";
+import { Column, FilterOperator } from "../../types/query.types";
+import dayjs from '../../helpers/dayjs'
 
 export type ConditionalColor = 'red' | 'amber' | 'green'
 
@@ -306,4 +307,33 @@ export function applyRankRule(
         default:
             return false;
     }
+}
+
+export const formatDateRangeDescription = (from: ReturnType<typeof dayjs>, to?: ReturnType<typeof dayjs>): string => {
+	if (!from || !from.isValid()) return ''
+	const currentYear = dayjs().year()
+	const fromStr = from.year() === currentYear ? from.format('MMM D') : from.format('MMM D, YYYY')
+	if (!to || !to.isValid() || from.isSame(to, 'day')) {
+		return fromStr
+	}
+	const toStr = to.year() === currentYear ? to.format('MMM D') : to.format('MMM D, YYYY')
+	return `${fromStr} - ${toStr}`
+}
+
+export function formatDateFilterValue(operator: FilterOperator, value: any): string {
+	if (!value || (Array.isArray(value) && value.length === 0)) return ''
+	if (operator === 'within' && typeof value === 'string') {
+		return value
+	}
+	if (operator === 'between') {
+		const arr = typeof value === 'string' ? value.split(',') : value
+		if (Array.isArray(arr)) {
+			if (arr[0] && !arr[1]) return formatDateRangeDescription(dayjs(arr[0].trim()))
+			if (arr[0] && arr[1]) return formatDateRangeDescription(dayjs(arr[0].trim()), dayjs(arr[1].trim()))
+		}
+	}
+	if (typeof value === 'string' && dayjs(value).isValid()) {
+		return formatDateRangeDescription(dayjs(value))
+	}
+	return Array.isArray(value) ? value.join(', ') : String(value)
 }

--- a/frontend/src2/types/query.types.ts
+++ b/frontend/src2/types/query.types.ts
@@ -199,6 +199,12 @@ export type DropdownOption = {
 	description?: string
 }
 
+export type Preset = {
+	label: string
+	value: () => string | string[]
+	description?: () => string
+}
+
 export type GroupedDropdownOption = {
 	group: string
 	items: DropdownOption[]


### PR DESCRIPTION
## Overview
This PR adds date range presets for absolute and relative dates (`between` and `within` operator), introduces a `<PresetWrapper>` component, and unifies date filtering UI and label formatting across Dashboard, Query Builder, and Chart filters for consistency across the application.
Previously, absolute date range (`between`) filters and relative date range (`within`) did not have preset options, requiring users to select ranges on the calendar manually or select from the dropdown components in within. In addition, custom date selections displayed raw ISO strings, and Dashboard filters used a separate implementation from the Query Builder and Chart filters.

## Key Changes
### 1. Added Date Range Presets (`between` & `within`)
* Added quick-select preset options (`Today`, `Yesterday`, `This Month`, `Last Month`, `This Quarter`, `Last Year`, etc.) for both absolute (`between`) and relative (`within`) date filters.
*  Created the `Preset` type structure (`value: () => string | string[]`). This ensures dynamic date ranges (like *This Month*) are evaluated fresh when selected, preventing dates from becoming stale if the application stays open across day boundaries.

### 2. Created Shared UI Wrapper (`<PresetWrapper>`)
* Built `<PresetWrapper.vue>` to handle dropdown preset selection above custom calendar or relative form controls.
*  Users can select a preset from the dropdown or interact directly with the calendar and relative forms below without needing to toggle between views.
*  The dropdown automatically switches to **"Custom"** whenever a user manually modifies a date on the calendar or changes interval inputs.

### 3. Unified Formatting Across Dashboard, Query, and Charts
* Added `formatDateFilterValue()` and `formatDateRangeDescription()` to serve as the single source of truth for date labels across the frontend.
* **Year Formatting Rules:** 
  * Current year dates omit the year: `Jan 1 - Dec 31`
  * Different years include the year: `Jan 1, 2024 - Dec 31, 2024`
*  Replaced raw ISO strings (`2025-01-01,2025-12-31`) with clean, formatted date spans (`Jan 1 - Dec 31, 2025`) across filter button labels.
---
## Component & Architectural Breakdown
### Core Types & Utilities (`query/components/`)
* **`query.types.ts`**: Added the `Preset` type to use consistent function returns (`label: string`, `value: () => string | string[]`, `description?: () => string`).
* **`filter_utils.ts`**: Added `getDatePresets(operator)`, and `findPresetByValue()`.
* **`formatting_utils.ts`**: Added `formatDateFilterValue()` and `formatDateRangeDescription()` to handle date label formatting centrally.

### Shared Pickers & Wrappers (`query/components/`)
* **`PresetWrapper.vue`** *(NEW)*: Built the shared wrapper component that manages dropdown selection and custom override state.
* **`AbsoluteDatePicker.vue`** *(NEW)*: Created a shared component combining `<PresetWrapper>` with `<DateRangePicker>`.
* **`AbsoluteDatePickerControl.vue`** *(NEW)*: Created a popover-wrapped input trigger for both Query Builder rows and Chart sidebar filter rules.
* **`RelativeDatePicker.vue` & `RelativeDatePickerControl.vue`**: Wrapped these components in `<PresetWrapper>` so they share the exact same preset dropdown and automatic "Custom" detection as the absolute date pickers.
### Query Builder & Chart Filters (`query/components/`)
* **`FilterRule.vue`**: Integrated `<AbsoluteDatePickerControl>` for `between` operators and `<RelativeDatePickerControl>` for `within` operators so Chart sidebar filters and Query Builder rules share the exact same UI.
### Dashboard Filters (`dashboard/`)
* **`DashboardFilter.vue`**: Updated button label formatting to use centralized `formatFilterValue()` calls for consistency.
* **`DashboardFilterEditor.vue`**: Replaced standard `<DateRangePicker>` with `<AbsoluteDatePicker>`, making presets available when setting default dashboard filters.
* **`Filter.vue`**: Updated popover rendering to use `<AbsoluteDatePicker>` for absolute date ranges.
---

#### 1. Dashboard Filter Presets



https://github.com/user-attachments/assets/2a723212-7f7f-4b10-9755-c7995150bcce





#### 2. Chart Filter Presets


https://github.com/user-attachments/assets/560c2df6-6bd6-4c27-92bc-6f69903c7ccb


