### PR TITLE
fix: keep POT updates in a single self-updating PR

### DIFF
--- a/.github/helpers/update_pot_file.sh
+++ b/.github/helpers/update_pot_file.sh
@@ -22,18 +22,37 @@ git config user.email "developers@erpnext.com"
 git config user.name "frappe-pr-bot"
 
 echo "Setting the correct git remote..."
-git remote set-url upstream "https://x-access-token:${GH_TOKEN}@github.com/frappe/insights.git"
+git remote set-url upstream https://github.com/frappe/insights.git
+gh auth setup-git
 
-echo "Creating a new branch..."
-isodate=$(date -u +"%Y-%m-%d")
-branch_name="pot_${BASE_BRANCH}_${isodate}"
-git checkout -b "${branch_name}"
+# One stable branch, not a dated one. The POT file is fully regenerated every run, so a
+# fresh dated branch/PR each week just piles up and conflicts once any one is merged. Reusing
+# a single branch (reset to the base tip, force-pushed) keeps exactly one PR that updates in
+# place and can never conflict, since it's always rebuilt from the current base.
+branch_name="pot_${BASE_BRANCH}"
+
+echo "Resetting ${branch_name} onto ${BASE_BRANCH}..."
+generated_pot=$(mktemp)
+cp insights/locale/main.pot "${generated_pot}"
+git fetch upstream "${BASE_BRANCH}"
+git checkout -f -B "${branch_name}" "upstream/${BASE_BRANCH}"
+cp "${generated_pot}" insights/locale/main.pot
+
+git add insights/locale/main.pot
+if git diff --cached --quiet; then
+  echo "No POT changes; nothing to do."
+  exit 0
+fi
 
 echo "Commiting changes..."
-git add insights/locale/main.pot
 git commit -m "chore: update POT file"
 
-git push -u upstream "${branch_name}"
+echo "Pushing ${branch_name}..."
+git push -u upstream "${branch_name}" --force
 
-echo "Creating a PR..."
-gh pr create --fill --base "${BASE_BRANCH}" --head "${branch_name}" -R frappe/insights
+if gh pr view "${branch_name}" -R frappe/insights --json state -q '.state' 2>/dev/null | grep -q OPEN; then
+  echo "PR already open for ${branch_name}; force-push updated it."
+else
+  echo "Creating a PR..."
+  gh pr create --fill --base "${BASE_BRANCH}" --head "${branch_name}" -R frappe/insights
+fi


### PR DESCRIPTION
## Problem

The weekly *Regenerate POT file* job (`generate-pot-file.yml` → `update_pot_file.sh`) creates a **new dated branch and PR every run** (`pot_develop_<date>`), with no awareness of whether a previous POT PR is still open. They accumulate, and because `main.pot` is fully regenerated each time, the moment one is merged the others conflict against it.

## Fix

Reuse a **single stable branch** (`pot_${BASE_BRANCH}`) that updates in place:

- Reset the branch onto the current base tip each run and re-apply the regenerated POT, so the diff is always "base → regenerated" and can never conflict.
- Force-push, so an already-open PR just updates itself.
- Skip entirely when there are no string changes (no more empty PRs).
- Only `gh pr create` when a PR isn't already open.

Also aligns auth with `frappe/frappe`'s script (`gh auth setup-git` + tokenless remote) instead of embedding the token in the remote URL.

Result: at most one open POT PR at a time; merging it lets the next run open a fresh one on the same branch.