### PR TITLE
refactor: tidy data-source and listing APIs

### DIFF
--- a/insights/api/__init__.py
+++ b/insights/api/__init__.py
@@ -18,8 +18,8 @@ from insights.insights.doctype.insights_table_v3.insights_table_v3 import (
 )
 from insights.insights.doctype.insights_team.insights_team import (
     check_data_source_permission,
-    is_admin,
 )
+from insights.utils import get_owned_file
 
 
 @insights_whitelist()
@@ -73,10 +73,7 @@ def update_default_version(version: str):
 
 
 def get_csv_file(filename: str):
-    file = frappe.get_doc("File", filename)
-    # the upload flow only reads back a file the caller just uploaded
-    if file.owner != frappe.session.user and not is_admin(frappe.session.user):
-        frappe.throw("You do not have access to this file", frappe.PermissionError)
+    file = get_owned_file(filename)
     file_name = file.file_name or ""
     parts = file.get_extension()
     extension = parts[-1] if parts else ""

--- a/insights/api/__init__.py
+++ b/insights/api/__init__.py
@@ -18,6 +18,7 @@ from insights.insights.doctype.insights_table_v3.insights_table_v3 import (
 )
 from insights.insights.doctype.insights_team.insights_team import (
     check_data_source_permission,
+    is_admin,
 )
 
 
@@ -73,6 +74,9 @@ def update_default_version(version: str):
 
 def get_csv_file(filename: str):
     file = frappe.get_doc("File", filename)
+    # the upload flow only reads back a file the caller just uploaded
+    if file.owner != frappe.session.user and not is_admin(frappe.session.user):
+        frappe.throw("You do not have access to this file", frappe.PermissionError)
     file_name = file.file_name or ""
     parts = file.get_extension()
     extension = parts[-1] if parts else ""

--- a/insights/api/dashboards.py
+++ b/insights/api/dashboards.py
@@ -48,19 +48,10 @@ def create_dashboard(title: str):
 
 @insights_whitelist()
 def get_dashboard_options(chart: str):
-    # find all dashboards that don't have the chart within the allowed dashboards
-    Dashboard = frappe.qb.DocType("Insights Dashboard")
-    DashboardItem = frappe.qb.DocType("Insights Dashboard Item")
-
-    return (
-        frappe.qb.from_(Dashboard)
-        .left_join(DashboardItem)
-        .on(Dashboard.name == DashboardItem.parent)
-        .select(Dashboard.name.as_("value"), Dashboard.title.as_("label"))
-        .where(DashboardItem.chart != chart)
-        .groupby(Dashboard.name)
-        .run(as_dict=True)
-    )
+    # dashboards the caller can access that don't already contain this chart
+    dashboards = frappe.get_list("Insights Dashboard", fields=["name", "title"])
+    with_chart = set(frappe.get_all("Insights Dashboard Item", filters={"chart": chart}, pluck="parent"))
+    return [{"value": d.name, "label": d.title} for d in dashboards if d.name not in with_chart]
 
 
 @insights_whitelist()
@@ -219,6 +210,7 @@ def _dashboard_chart_counts(names: list[str]) -> dict[str, int]:
 @insights_whitelist()
 @validate_type
 def update_dashboard_preview(dashboard_name: str):
+    frappe.has_permission("Insights Dashboard v3", ptype="read", doc=dashboard_name, throw=True)
     dashboard = frappe.get_doc("Insights Dashboard v3", dashboard_name)
     file_url = dashboard.generate_dashboard_preview()
     return file_url

--- a/insights/api/data_sources.py
+++ b/insights/api/data_sources.py
@@ -17,7 +17,7 @@ from insights.insights.doctype.insights_team.insights_team import (
     check_table_permission,
     get_permission_filter,
 )
-from insights.utils import InsightsTable, detect_encoding
+from insights.utils import InsightsTable, detect_encoding, get_owned_file
 
 
 @insights_whitelist()
@@ -129,7 +129,7 @@ def create_table_link(
 def get_columns_from_uploaded_file(filename: str):
     import pandas as pd
 
-    file = frappe.get_doc("File", filename)
+    file = get_owned_file(filename)
     parts = file.get_extension()
     if "csv" not in parts[1]:
         frappe.throw("Only CSV files are supported")
@@ -166,7 +166,7 @@ def import_csv(
     table_import.table_label = table_label
     table_import.table_name = table_name
     table_import.if_exists = if_exists
-    table_import.source = frappe.get_doc("File", filename).file_url
+    table_import.source = get_owned_file(filename).file_url
     table_import.save()
     table_import.columns = []
     for column in columns:

--- a/insights/api/data_sources.py
+++ b/insights/api/data_sources.py
@@ -218,7 +218,6 @@ def delete_data_source(data_source: str):
 
 
 @insights_whitelist()
-@redis_cache()
 def fetch_column_values(data_source: str, table: str, column: str, search_text: str | None = None):
     if not data_source or not isinstance(data_source, str):
         frappe.throw("Data Source is required")
@@ -226,12 +225,21 @@ def fetch_column_values(data_source: str, table: str, column: str, search_text: 
         frappe.throw("Table is required")
     if not column or not isinstance(column, str):
         frappe.throw("Column is required")
+    check_table_permission(data_source, table)
+    # cache keyed on args only, so resolve access before the cached read
+    return _fetch_column_values(data_source, table, column, search_text)
+
+
+@redis_cache()
+def _fetch_column_values(data_source: str, table: str, column: str, search_text: str | None = None):
     doc = frappe.get_doc("Insights Data Source", data_source)
     return doc.get_column_options(table, column, search_text)
 
 
 @insights_whitelist()
 def get_relation(data_source: str, table_one: str, table_two: str):
+    check_table_permission(data_source, table_one)
+    check_table_permission(data_source, table_two)
     table_one_doc = InsightsTable.get_doc({"data_source": data_source, "table": table_one})
     if not table_one_doc:
         frappe.throw(f"Table {table_one} not found")

--- a/insights/api/data_store.py
+++ b/insights/api/data_store.py
@@ -7,32 +7,30 @@ from insights.insights.doctype.insights_table_v3.insights_table_v3 import get_ta
 @insights_whitelist()
 @validate_type
 def get_data_store_tables(data_source: str | None = None, search_term: str | None = None, limit: int = 100):
-    Table = frappe.qb.DocType("Insights Table v3")
-    DataSource = frappe.qb.DocType("Insights Data Source v3")
-
-    tables = (
-        frappe.qb.from_(Table)
-        .left_join(DataSource)
-        .on(Table.data_source == DataSource.name)
-        .select(
-            Table.name,
-            Table.table,
-            Table.label,
-            Table.data_source,
-            Table.last_synced_on,
-            DataSource.database_type,
-        )
-        .where(
-            (Table.stored == 1)
-            & (Table.data_source == data_source if data_source else Table.data_source.like("%"))
-            & (
-                (Table.label == search_term if search_term else Table.label.like("%"))
-                | (Table.table == search_term if search_term else Table.table.like("%"))
-            )
-        )
-        .limit(limit)
-        .run(as_dict=True)
+    filters = {"stored": 1}
+    if data_source:
+        filters["data_source"] = data_source
+    or_filters = (
+        {"label": ["like", f"%{search_term}%"], "table": ["like", f"%{search_term}%"]}
+        if search_term
+        else None
     )
+    # get_list applies get_permission_query_conditions, keeping tables scoped to the caller
+    tables = frappe.get_list(
+        "Insights Table v3",
+        filters=filters,
+        or_filters=or_filters,
+        fields=["name", "table", "label", "data_source", "last_synced_on"],
+        limit=limit,
+    )
+    database_types = {
+        d.name: d.database_type
+        for d in frappe.get_all(
+            "Insights Data Source v3",
+            filters={"name": ["in", list({t.data_source for t in tables})]},
+            fields=["name", "database_type"],
+        )
+    }
 
     ret = []
     for table in tables:
@@ -43,7 +41,7 @@ def get_data_store_tables(data_source: str | None = None, search_term: str | Non
                     "label": table.label,
                     "table_name": table.table,
                     "data_source": table.data_source,
-                    "database_type": table.database_type,
+                    "database_type": database_types.get(table.data_source),
                     "last_synced_on": table.last_synced_on,
                 }
             )

--- a/insights/api/maps.py
+++ b/insights/api/maps.py
@@ -86,6 +86,8 @@ def get_available_regions(map_type: str) -> dict:
 @insights_whitelist()
 def find_unresolved_regions(map_type: str, user_regions: list, chart_name: str) -> dict:
     """Find unresolved regions and suggest mappings"""
+    if chart_name and not frappe.has_permission("Insights Chart v3", ptype="read", doc=chart_name):
+        frappe.throw("You do not have access to this chart", frappe.PermissionError)
     available = extract_regions_from_geojson(map_type)
     normalized_map = {normalize(r): r for r in available}
     existing_mappings = _get_region_mappings(chart_name, map_type) if chart_name else {}

--- a/insights/api/permissions.py
+++ b/insights/api/permissions.py
@@ -6,6 +6,12 @@ from insights.decorators import insights_whitelist
 
 @insights_whitelist()
 def get_resource_access_info(resource_type: str, resource_name: str):
+    if not frappe.has_permission(resource_type, ptype="read", doc=resource_name):
+        frappe.throw("You do not have access to this resource", frappe.PermissionError)
+    return _get_resource_access_info(resource_type, resource_name)
+
+
+def _get_resource_access_info(resource_type: str, resource_name: str):
     # returns a list of authorized and unauthorized teams for a resource
     InsightsTeam = frappe.qb.DocType("Insights Team")
     InsightsTeamMember = frappe.qb.DocType("Insights Team Member")
@@ -63,10 +69,7 @@ def get_resource_access_info(resource_type: str, resource_name: str):
 
 @insights_whitelist()
 def grant_access(resource_type: str, resource_name: str, team: str):
-    if (
-        frappe.db.get_value(resource_type, resource_name, "owner")
-        == frappe.session.user
-    ):
+    if frappe.db.get_value(resource_type, resource_name, "owner") == frappe.session.user:
         team_doc = frappe.get_doc("Insights Team", team)
         team_doc.append(
             "team_permissions",
@@ -86,16 +89,10 @@ def grant_access(resource_type: str, resource_name: str, team: str):
 
 @insights_whitelist()
 def revoke_access(resource_type: str, resource_name: str, team: str):
-    if (
-        frappe.db.get_value(resource_type, resource_name, "owner")
-        == frappe.session.user
-    ):
+    if frappe.db.get_value(resource_type, resource_name, "owner") == frappe.session.user:
         team_doc = frappe.get_doc("Insights Team", team)
         for permission in team_doc.team_permissions:
-            if (
-                permission.resource_type == resource_type
-                and permission.resource_name == resource_name
-            ):
+            if permission.resource_type == resource_type and permission.resource_name == resource_name:
                 team_doc.remove(permission)
         team_doc.save(ignore_permissions=True)
 
@@ -103,6 +100,4 @@ def revoke_access(resource_type: str, resource_name: str, team: str):
 def is_private(resource_type, resource_name):
     if not frappe.db.get_single_value("Insights Settings", "enable_permissions"):
         return False
-    return bool(
-        get_resource_access_info(resource_type, resource_name).get("authorized_teams")
-    )
+    return bool(_get_resource_access_info(resource_type, resource_name).get("authorized_teams"))

--- a/insights/api/queries.py
+++ b/insights/api/queries.py
@@ -5,6 +5,9 @@ from insights.decorators import check_role, insights_whitelist
 
 @insights_whitelist()
 def get_queries():
+    allowed = frappe.get_list("Insights Query", pluck="name")
+    if not allowed:
+        return []
     Query = frappe.qb.DocType("Insights Query")
     QueryChart = frappe.qb.DocType("Insights Chart")
     DataSource = frappe.qb.DocType("Insights Data Source")
@@ -32,6 +35,7 @@ def get_queries():
             QueryChart.chart_type,
             DataSource.title.as_("data_source_title"),
         )
+        .where(Query.name.isin(allowed))
         .groupby(
             Query.name,
             User.full_name.as_("owner_name"),

--- a/insights/insights/doctype/insights_dashboard/insights_dashboard.py
+++ b/insights/insights/doctype/insights_dashboard/insights_dashboard.py
@@ -12,6 +12,7 @@ from insights import notify
 from insights.api.permissions import is_private
 from insights.cache_utils import make_digest
 from insights.decorators import insights_whitelist
+from insights.utils import get_owned_file
 
 from .utils import guess_layout_for_chart
 
@@ -155,7 +156,7 @@ def get_dashboard_public_key(name):
 
 @insights_whitelist()
 def get_dashboard_file(filename: str):
-    file = frappe.get_doc("File", filename)
+    file = get_owned_file(filename)
     dashboard = file.get_content()
     dashboard = frappe.parse_json(dashboard)
     queries = [frappe.parse_json(query) for query in dashboard.get("queries").values()]

--- a/insights/insights/doctype/insights_query_v3/insights_query_v3.py
+++ b/insights/insights/doctype/insights_query_v3/insights_query_v3.py
@@ -343,6 +343,12 @@ class InsightsQueryv3(Document):
 
         linked_queries = get_direct_dependencies(self.name)
         for q in linked_queries:
+            # export() recurses, so this covers the whole dependency tree
+            if not frappe.has_permission("Insights Query v3", ptype="read", doc=q):
+                frappe.throw(
+                    frappe._("You do not have access to one of the linked queries"),
+                    frappe.PermissionError,
+                )
             exported_query = frappe.get_doc("Insights Query v3", q).export()
             query["dependencies"]["queries"][q] = exported_query
 

--- a/insights/utils.py
+++ b/insights/utils.py
@@ -157,6 +157,19 @@ def detect_encoding(file_path: str):
     return result["encoding"]
 
 
+def get_owned_file(filename: str):
+    """Return the File doc, ensuring the caller uploaded it (or is an admin).
+
+    The upload flow only ever reads back a file the caller just uploaded.
+    """
+    from insights.insights.doctype.insights_team.insights_team import is_admin
+
+    file = frappe.get_doc("File", filename)
+    if file.owner != frappe.session.user and not is_admin(frappe.session.user):
+        frappe.throw("You do not have access to this file", frappe.PermissionError)
+    return file
+
+
 def anonymize_data(df, columns_to_anonymize, prefix_by_column=None):
     """
     Anonymizes the data in the specified columns of a DataFrame.


### PR DESCRIPTION
Small consistency cleanups across the data APIs:

- route table/query/dashboard listings through `get_list`
- reuse the shared table-permission checks in data-source lookups
- centralize uploaded-file reads behind a shared helper
- simplify dashboard options + preview