### PR TITLE
feat: workbook template updates via version + checksum

### DIFF
--- a/frontend/src2/workbook/WorkbookList.vue
+++ b/frontend/src2/workbook/WorkbookList.vue
@@ -85,16 +85,13 @@ function openNewWorkbook() {
 // workbooks in their list once an admin imports.
 const templates = ref<WorkbookTemplate[]>([])
 const showTemplates = ref(false)
-wheneverChanges(
-	() => session.user.is_admin,
-	(isAdmin) => {
-		if (!isAdmin) return
-		call('insights.api.templates.get_workbook_templates').then(
-			(data: WorkbookTemplate[]) => (templates.value = data || []),
-		)
-	},
-	{ immediate: true },
-)
+function fetchTemplates() {
+	if (!session.user.is_admin) return
+	call('insights.api.templates.get_workbook_templates').then(
+		(data: WorkbookTemplate[]) => (templates.value = data || []),
+	)
+}
+wheneverChanges(() => session.user.is_admin, fetchTemplates, { immediate: true })
 
 const columns = getWorkbookColumns({ userStore })
 
@@ -164,7 +161,7 @@ watchEffect(() => {
 		</div>
 	</header>
 
-	<WorkbookTemplates v-model="showTemplates" :templates="templates" />
+	<WorkbookTemplates v-model="showTemplates" :templates="templates" @refresh="fetchTemplates" />
 
 	<div class="mb-4 flex h-full flex-col gap-3 overflow-auto px-5 pt-3">
 		<div class="flex items-center justify-between gap-2 overflow-visible py-1">

--- a/frontend/src2/workbook/WorkbookTemplates.vue
+++ b/frontend/src2/workbook/WorkbookTemplates.vue
@@ -18,9 +18,13 @@ export type WorkbookTemplate = {
 	has_data: boolean
 	preview_image: string | null
 	imported_workbook: number | null
+	imported_version: number | null
+	update_available: boolean
+	customized: boolean
 }
 
 const props = defineProps<{ templates: WorkbookTemplate[] }>()
+const emit = defineEmits<{ refresh: [] }>()
 const show = defineModel<boolean>({ default: false })
 
 // group by the app each template is for, so an app's dashboards read as one
@@ -66,6 +70,40 @@ function importTemplate(template: WorkbookTemplate) {
 
 function openImported(template: WorkbookTemplate) {
 	router.push(`/workbook/${template.imported_workbook}`)
+}
+
+// name of the template currently updating, so only its card's button spins
+const updating = ref<string | null>(null)
+// a customized copy is confirmed before its edits are overwritten
+const confirmTarget = ref<WorkbookTemplate | null>(null)
+const showConfirm = ref(false)
+
+function updateTemplate(template: WorkbookTemplate) {
+	if (template.customized) {
+		confirmTarget.value = template
+		showConfirm.value = true
+		return
+	}
+	runUpdate(template)
+}
+
+function runUpdate(template: WorkbookTemplate) {
+	showConfirm.value = false
+	updating.value = template.name
+	call('insights.api.templates.update_workbook_from_template', {
+		template_name: template.name,
+	})
+		.then(() => {
+			createToast({ message: __('{0} updated', template.title), variant: 'success' })
+			emit('refresh')
+		})
+		.catch(() => {
+			createToast({
+				message: __('Failed to update {0}', template.title),
+				variant: 'error',
+			})
+		})
+		.finally(() => (updating.value = null))
 }
 </script>
 
@@ -134,6 +172,13 @@ function openImported(template: WorkbookTemplate) {
 									}}
 								</div>
 
+								<div
+									v-if="template.update_available"
+									class="mt-2 text-p-sm text-ink-blue-3"
+								>
+									{{ __('A newer version is available.') }}
+								</div>
+
 								<div class="mt-4 flex items-center gap-2">
 									<template v-if="template.imported_workbook">
 										<div
@@ -142,9 +187,19 @@ function openImported(template: WorkbookTemplate) {
 											<CheckCircle2 class="h-4 w-4" />
 											{{ __('Imported') }}
 										</div>
-										<Button class="ml-auto" @click="openImported(template)">
-											{{ __('Open') }}
-										</Button>
+										<div class="ml-auto flex items-center gap-2">
+											<Button
+												v-if="template.update_available"
+												:loading="updating === template.name"
+												:disabled="!!updating"
+												@click="updateTemplate(template)"
+											>
+												{{ __('Update') }}
+											</Button>
+											<Button @click="openImported(template)">
+												{{ __('Open') }}
+											</Button>
+										</div>
 									</template>
 									<Button
 										v-else
@@ -163,4 +218,22 @@ function openImported(template: WorkbookTemplate) {
 			</div>
 		</template>
 	</Dialog>
+
+	<Dialog
+		v-model="showConfirm"
+		:options="{
+			title: __('Replace your changes?'),
+			message: __(
+				'This dashboard has been edited on your site. Updating replaces its contents with the latest version — your changes will be lost.',
+			),
+			actions: [
+				{
+					label: __('Update'),
+					variant: 'solid',
+					theme: 'red',
+					onClick: () => confirmTarget && runUpdate(confirmTarget),
+				},
+			],
+		}"
+	/>
 </template>

--- a/insights/api/templates.py
+++ b/insights/api/templates.py
@@ -315,7 +315,7 @@ def create_workbook_from_template(template_name: str) -> dict:
         # Commit inside the lock so the copy is visible to the next admin who
         # takes it — the lock only serializes; without the commit the next holder
         # reads a pre-insert snapshot and creates a silent duplicate.
-        frappe.db.commit()
+        frappe.db.commit()  # nosemgrep — intentional commit inside the import lock (see above)
 
     return _template_import_result(workbook_name)
 
@@ -397,7 +397,9 @@ def update_workbook_from_template(template_name: str) -> dict:
     lock_key = f"insights_template_import_{template_name.replace('/', '_')}"
     with filelock(lock_key, timeout=60):
         _update_imported_workbook(template_name, workbook_name)
-        frappe.db.commit()
+        # commit inside the lock so a concurrent caller sees the finished copy,
+        # not a half-rebuilt one
+        frappe.db.commit()  # nosemgrep — intentional commit inside the import lock
 
     return _template_import_result(workbook_name)
 
@@ -409,7 +411,7 @@ def sync_workbook_template_updates() -> None:
     registry = _discover_templates()
     # persist whatever earlier after_migrate steps left pending, so the per-copy
     # rollback below can only ever discard the copy it was updating
-    frappe.db.commit()
+    frappe.db.commit()  # nosemgrep — flush prior after_migrate work before per-copy rollbacks
     for template_name, workbook_name in get_imported_templates().items():
         entry = registry.get(template_name)
         if not entry:
@@ -429,7 +431,7 @@ def sync_workbook_template_updates() -> None:
             # commit per copy so each update is atomic — the delete-then-rebuild in
             # _update_imported_workbook either lands whole or, on failure below, is
             # rolled back, never left committed with the copy emptied
-            frappe.db.commit()
+            frappe.db.commit()  # nosemgrep — land each copy atomically (paired with the rollback below)
         except Exception:
             frappe.db.rollback()
             frappe.log_error(title=f"Failed to sync workbook template {template_name}")

--- a/insights/api/templates.py
+++ b/insights/api/templates.py
@@ -407,19 +407,29 @@ def sync_workbook_template_updates() -> None:
     with no clicks (nothing of the site's to clobber). A copy the site has edited
     is left alone — the library surfaces a manual update for it instead."""
     registry = _discover_templates()
+    # persist whatever earlier after_migrate steps left pending, so the per-copy
+    # rollback below can only ever discard the copy it was updating
+    frappe.db.commit()
     for template_name, workbook_name in get_imported_templates().items():
         entry = registry.get(template_name)
         if not entry:
             continue
         version = cint(entry["manifest"].get("version") or 1)
         imported_version = cint(frappe.db.get_value("Insights Workbook", workbook_name, "imported_version"))
-        if not imported_version:
-            # a copy imported before versioning existed: adopt the current version
-            # as its baseline (so it doesn't read as "update available"), but leave
-            # its checksum empty so it counts as customized and is never auto-updated
-            frappe.db.set_value("Insights Workbook", workbook_name, "imported_version", version)
-            continue
-        if imported_version >= version or _is_customized(workbook_name):
-            continue
-        _update_imported_workbook(template_name, workbook_name)
-    frappe.db.commit()
+        try:
+            if not imported_version:
+                # a copy imported before versioning existed: adopt the current version
+                # as its baseline (so it doesn't read as "update available"), but leave
+                # its checksum empty so it counts as customized and is never auto-updated
+                frappe.db.set_value("Insights Workbook", workbook_name, "imported_version", version)
+            elif imported_version < version and not _is_customized(workbook_name):
+                _update_imported_workbook(template_name, workbook_name)
+            else:
+                continue
+            # commit per copy so each update is atomic — the delete-then-rebuild in
+            # _update_imported_workbook either lands whole or, on failure below, is
+            # rolled back, never left committed with the copy emptied
+            frappe.db.commit()
+        except Exception:
+            frappe.db.rollback()
+            frappe.log_error(title=f"Failed to sync workbook template {template_name}")

--- a/insights/api/templates.py
+++ b/insights/api/templates.py
@@ -1,13 +1,15 @@
 import base64
+import hashlib
 import json
 import os
 
 import frappe
 from frappe import _
+from frappe.utils import cint
 from frappe.utils.synchronization import filelock
 
 from insights.decorators import insights_whitelist
-from insights.utils import DocShare
+from insights.utils import DocShare, deep_convert_dict_to_dict
 
 MANIFEST_REQUIRED_KEYS = ["title", "description", "required_apps", "source_doctypes"]
 
@@ -180,6 +182,16 @@ def get_workbook_templates() -> list[dict]:
         if not has_required_apps(manifest):
             continue
         group_app = _grouping_app(entry)
+        version = cint(manifest.get("version") or 1)
+        imported_workbook = imported.get(name)
+        # only the shipped version differing from the imported one is an update;
+        # only then is it worth exporting the copy to check for local edits
+        imported_version = (
+            cint(frappe.db.get_value("Insights Workbook", imported_workbook, "imported_version"))
+            if imported_workbook
+            else None
+        )
+        update_available = bool(imported_workbook) and version > imported_version
         templates.append(
             {
                 "name": name,
@@ -190,12 +202,17 @@ def get_workbook_templates() -> list[dict]:
                 # the app the template is for — its section in the library
                 "app": group_app,
                 "app_title": _app_title(group_app),
-                # absent = v1; the key that makes "update available" possible later
-                "version": manifest.get("version") or 1,
+                # absent = v1; the key that makes "update available" possible
+                "version": version,
                 "has_data": has_source_data(manifest),
                 "preview_image": get_template_preview(name),
                 # workbook the site already imported from the template, else None
-                "imported_workbook": imported.get(name),
+                "imported_workbook": imported_workbook,
+                "imported_version": imported_version,
+                "update_available": update_available,
+                # whether taking the update would overwrite local edits — the
+                # library warns before replacing a touched copy
+                "customized": update_available and _is_customized(imported_workbook),
             }
         )
     return templates
@@ -291,9 +308,118 @@ def create_workbook_from_template(template_name: str) -> dict:
         frappe.db.set_value("Insights Workbook", workbook_name, "from_template", template_name)
         _reassign_to_administrator(workbook_name)
         _share_with_organization(workbook_name)
+        # record which shipped version this copy holds, and a fingerprint of it as
+        # imported — the fingerprint is what later tells a pristine copy (safe to
+        # auto-update) from one the site has edited (update only on request)
+        _stamp_template_version(workbook_name, manifest)
         # Commit inside the lock so the copy is visible to the next admin who
         # takes it — the lock only serializes; without the commit the next holder
         # reads a pre-insert snapshot and creates a silent duplicate.
         frappe.db.commit()
 
     return _template_import_result(workbook_name)
+
+
+def _workbook_checksum(workbook_name: str) -> str:
+    """A content fingerprint of the workbook, stable across re-reads but sensitive
+    to any edit of its queries/charts/dashboards. Compared against the value
+    stored at import to tell whether the site has touched the shipped copy.
+    `timestamp` is dropped because export() stamps it fresh every call."""
+    payload = frappe.get_doc("Insights Workbook", workbook_name).export()
+    payload.pop("timestamp", None)
+    serialized = json.dumps(payload, sort_keys=True, default=str)
+    return hashlib.sha256(serialized.encode()).hexdigest()
+
+
+def _is_customized(workbook_name: str) -> bool:
+    """True if the copy has drifted from what was imported — or if we never
+    recorded a fingerprint (a pre-versioning copy), which we treat as customized
+    so it's never silently overwritten."""
+    stored = frappe.db.get_value("Insights Workbook", workbook_name, "imported_checksum")
+    return not stored or stored != _workbook_checksum(workbook_name)
+
+
+def _stamp_template_version(workbook_name: str, manifest: dict) -> None:
+    frappe.db.set_value(
+        "Insights Workbook",
+        workbook_name,
+        {
+            "imported_version": cint(manifest.get("version") or 1),
+            "imported_checksum": _workbook_checksum(workbook_name),
+        },
+    )
+
+
+def _replace_workbook_contents(workbook_name: str, workbook_json: dict) -> None:
+    """Swap the workbook's contents for the template's, keeping the workbook's own
+    name (so URLs and shares survive). Drops the existing children and rebuilds
+    them from the shipped definition — safe on a pristine copy because there's
+    nothing of the site's to lose."""
+    workbook = deep_convert_dict_to_dict(frappe.parse_json(workbook_json))
+    for doctype in _WORKBOOK_CHILD_DOCTYPES:
+        for row in frappe.get_all(doctype, {"workbook": workbook_name}):
+            frappe.delete_doc(doctype, row.name, force=True, ignore_permissions=True)
+
+    doc = frappe.get_doc("Insights Workbook", workbook_name)
+    new_title = (workbook.get("doc") or {}).get("title")
+    if new_title:
+        doc.db_set("title", new_title)
+    doc.restore_workbook_contents(workbook, workbook_name, ignore_permissions=True)
+
+
+def _update_imported_workbook(template_name: str, workbook_name: str) -> None:
+    manifest = _resolve_template(template_name)["manifest"]
+    _replace_workbook_contents(workbook_name, get_template_workbook(template_name))
+    # rebuilt children default to the actor's ownership; hand them back to
+    # Administrator so the shared-copy invariant from import still holds
+    _reassign_to_administrator(workbook_name)
+    _stamp_template_version(workbook_name, manifest)
+
+
+@insights_whitelist(role="Insights Admin")
+def update_workbook_from_template(template_name: str) -> dict:
+    """Re-take the shipped version into the already-imported workbook, in place.
+    The library offers this when a newer version ships; a customized copy is
+    warned about client-side before the call, since this replaces its contents."""
+    manifest = _resolve_template(template_name)["manifest"]
+    if not has_required_apps(manifest):
+        frappe.throw(
+            _("Workbook template {0} requires apps that are not installed: {1}").format(
+                frappe.bold(manifest.get("title") or template_name),
+                ", ".join(manifest.get("required_apps") or []),
+            )
+        )
+
+    workbook_name = _find_imported_workbook(template_name)
+    if not workbook_name:
+        return create_workbook_from_template(template_name)
+
+    lock_key = f"insights_template_import_{template_name.replace('/', '_')}"
+    with filelock(lock_key, timeout=60):
+        _update_imported_workbook(template_name, workbook_name)
+        frappe.db.commit()
+
+    return _template_import_result(workbook_name)
+
+
+def sync_workbook_template_updates() -> None:
+    """Run on migrate: carry a newer shipped version into pristine imported copies
+    with no clicks (nothing of the site's to clobber). A copy the site has edited
+    is left alone — the library surfaces a manual update for it instead."""
+    registry = _discover_templates()
+    for template_name, workbook_name in get_imported_templates().items():
+        entry = registry.get(template_name)
+        if not entry:
+            continue
+        version = cint(entry["manifest"].get("version") or 1)
+        imported_version = cint(frappe.db.get_value("Insights Workbook", workbook_name, "imported_version"))
+        if not imported_version:
+            # a copy imported before versioning existed: adopt the current version
+            # as its baseline (so it doesn't read as "update available"), but leave
+            # its checksum empty so it counts as customized and is never auto-updated
+            frappe.db.set_value("Insights Workbook", workbook_name, "imported_version", version)
+            continue
+        if imported_version >= version or _is_customized(workbook_name):
+            continue
+        _update_imported_workbook(template_name, workbook_name)
+    frappe.db.commit()

--- a/insights/insights/doctype/insights_workbook/insights_workbook.json
+++ b/insights/insights/doctype/insights_workbook/insights_workbook.json
@@ -7,7 +7,9 @@
  "field_order": [
   "title",
   "data_backup",
-  "from_template"
+  "from_template",
+  "imported_version",
+  "imported_checksum"
  ],
  "fields": [
   {
@@ -29,6 +31,20 @@
    "fieldtype": "Data",
    "hidden": 1,
    "label": "From Template",
+   "read_only": 1
+  },
+  {
+   "fieldname": "imported_version",
+   "fieldtype": "Int",
+   "hidden": 1,
+   "label": "Imported Version",
+   "read_only": 1
+  },
+  {
+   "fieldname": "imported_checksum",
+   "fieldtype": "Data",
+   "hidden": 1,
+   "label": "Imported Checksum",
    "read_only": 1
   }
  ],

--- a/insights/insights/doctype/insights_workbook/insights_workbook.py
+++ b/insights/insights/doctype/insights_workbook/insights_workbook.py
@@ -23,6 +23,8 @@ class InsightsWorkbook(Document):
 
         data_backup: DF.JSON | None
         from_template: DF.Data | None
+        imported_checksum: DF.Data | None
+        imported_version: DF.Int
         name: DF.Int | None
         title: DF.Data
     # end: auto-generated types

--- a/insights/migrate.py
+++ b/insights/migrate.py
@@ -11,6 +11,13 @@ def after_migrate():
     except Exception:
         frappe.log_error(title="Error creating Admin Team")
 
+    try:
+        from insights.api.templates import sync_workbook_template_updates
+
+        sync_workbook_template_updates()
+    except Exception:
+        frappe.log_error(title="Error syncing workbook template updates")
+
 
 def create_admin_team():
     if not frappe.db.exists("Insights Team", "Admin"):
@@ -21,4 +28,3 @@ def create_admin_team():
                 "team_members": [{"user": "Administrator"}],
             }
         ).insert(ignore_permissions=True)
-

--- a/insights/tests/test_workbook_templates.py
+++ b/insights/tests/test_workbook_templates.py
@@ -6,12 +6,16 @@ import frappe
 
 from insights.api.templates import (
     MANIFEST_REQUIRED_KEYS,
+    _discover_templates,
+    _is_customized,
     create_workbook_from_template,
     get_template_manifest,
     get_template_names,
     get_template_path,
     get_template_workbook,
     get_workbook_templates,
+    sync_workbook_template_updates,
+    update_workbook_from_template,
 )
 from insights.insights.doctype.insights_workbook.insights_workbook import import_workbook
 from insights.tests.base import InsightsIntegrationTestCase
@@ -37,6 +41,17 @@ def installed_apps(apps):
     # patch our narrow seam, not the global — patching frappe.get_installed_apps
     # breaks other apps' insert hooks on multi-app sites
     return patch("insights.api.templates.get_installed_apps", return_value=set(apps))
+
+
+def bumped_version(template_name, version):
+    # simulate the app shipping a newer version of a template without a second
+    # fixture: reuse the real folder (so workbook.json still resolves) but override
+    # the discovered manifest's version
+    registry = {name: dict(entry) for name, entry in _discover_templates().items()}
+    entry = dict(registry[template_name])
+    entry["manifest"] = {**entry["manifest"], "version": version}
+    registry[template_name] = entry
+    return patch("insights.api.templates._discover_templates", return_value=registry)
 
 
 def cleanup_template_workbooks():
@@ -214,6 +229,93 @@ class TestWorkbookTemplates(InsightsIntegrationTestCase):
         self.assertEqual(len(chart_items), len(template_charts))
         for item in chart_items:
             self.assertIn(item["chart"], new_chart_names)
+
+    def test_import_records_version_and_is_pristine(self):
+        with self.as_user(ADMIN_USER), installed_apps(APPS_WITH_ERPNEXT):
+            workbook_name = create_workbook_from_template(TEMPLATE)["workbook"]
+
+        # the copy remembers which shipped version it holds, and reads as pristine
+        self.assertEqual(frappe.db.get_value("Insights Workbook", workbook_name, "imported_version"), 1)
+        self.assertFalse(_is_customized(workbook_name))
+
+        # same version shipped -> no update offered
+        with self.as_user(USER_2), installed_apps(APPS_WITH_ERPNEXT):
+            sales = {t["name"]: t for t in get_workbook_templates()}[TEMPLATE]
+        self.assertEqual(sales["imported_version"], 1)
+        self.assertFalse(sales["update_available"])
+        self.assertFalse(sales["customized"])
+
+    def test_update_offered_when_newer_version_ships(self):
+        with self.as_user(ADMIN_USER), installed_apps(APPS_WITH_ERPNEXT):
+            create_workbook_from_template(TEMPLATE)
+
+        with installed_apps(APPS_WITH_ERPNEXT), bumped_version(TEMPLATE, 2), self.as_user(USER_2):
+            sales = {t["name"]: t for t in get_workbook_templates()}[TEMPLATE]
+        self.assertTrue(sales["update_available"])
+        self.assertFalse(sales["customized"])  # untouched copy
+
+    def test_update_replaces_contents_in_place(self):
+        with self.as_user(ADMIN_USER), installed_apps(APPS_WITH_ERPNEXT):
+            workbook_name = create_workbook_from_template(TEMPLATE)["workbook"]
+            chart = frappe.get_all("Insights Chart v3", {"workbook": workbook_name}, pluck="name")[0]
+            # a local edit that the update must roll back to the shipped definition
+            frappe.db.set_value("Insights Chart v3", chart, "title", "Edited")
+
+        with self.as_user(ADMIN_USER), installed_apps(APPS_WITH_ERPNEXT), bumped_version(TEMPLATE, 2):
+            result = update_workbook_from_template(TEMPLATE)
+
+        # same workbook name (URLs/shares survive), version advanced, edit gone
+        self.assertEqual(result["workbook"], workbook_name)
+        self.assertEqual(frappe.db.get_value("Insights Workbook", workbook_name, "imported_version"), 2)
+        self.assertFalse(frappe.db.exists("Insights Chart v3", chart))
+        # stays an Administrator-owned shared copy after the rebuild
+        self.assertEqual(frappe.db.get_value("Insights Workbook", workbook_name, "owner"), "Administrator")
+        self.assertFalse(_is_customized(workbook_name))
+
+    def test_migrate_sync_auto_updates_pristine_copy(self):
+        with self.as_user(ADMIN_USER), installed_apps(APPS_WITH_ERPNEXT):
+            workbook_name = create_workbook_from_template(TEMPLATE)["workbook"]
+
+        with bumped_version(TEMPLATE, 2):
+            sync_workbook_template_updates()
+
+        self.assertEqual(frappe.db.get_value("Insights Workbook", workbook_name, "imported_version"), 2)
+
+    def test_migrate_sync_leaves_customized_copy_for_manual_update(self):
+        with self.as_user(ADMIN_USER), installed_apps(APPS_WITH_ERPNEXT):
+            workbook_name = create_workbook_from_template(TEMPLATE)["workbook"]
+            chart = frappe.get_all("Insights Chart v3", {"workbook": workbook_name}, pluck="name")[0]
+            frappe.db.set_value("Insights Chart v3", chart, "title", "Locally Edited")
+
+        self.assertTrue(_is_customized(workbook_name))
+
+        with bumped_version(TEMPLATE, 2):
+            sync_workbook_template_updates()
+
+        # not silently overwritten: kept at its imported version with the edit intact
+        self.assertEqual(frappe.db.get_value("Insights Workbook", workbook_name, "imported_version"), 1)
+        self.assertEqual(frappe.db.get_value("Insights Chart v3", chart, "title"), "Locally Edited")
+
+        # the library still offers the update, flagged as a clobber
+        with installed_apps(APPS_WITH_ERPNEXT), bumped_version(TEMPLATE, 2), self.as_user(USER_2):
+            sales = {t["name"]: t for t in get_workbook_templates()}[TEMPLATE]
+        self.assertTrue(sales["update_available"])
+        self.assertTrue(sales["customized"])
+
+    def test_legacy_copy_without_version_adopts_current_as_baseline(self):
+        with self.as_user(ADMIN_USER), installed_apps(APPS_WITH_ERPNEXT):
+            workbook_name = create_workbook_from_template(TEMPLATE)["workbook"]
+        # simulate a copy imported before versioning existed
+        frappe.db.set_value(
+            "Insights Workbook",
+            workbook_name,
+            {"imported_version": 0, "imported_checksum": ""},
+        )
+
+        sync_workbook_template_updates()
+
+        # backfilled to the current version so it reads as up-to-date, not stale
+        self.assertEqual(frappe.db.get_value("Insights Workbook", workbook_name, "imported_version"), 1)
 
     def test_every_committed_template_is_valid_and_importable(self):
         """CI guard: every committed manifest parses with the required keys and

--- a/insights/tests/test_workbook_templates.py
+++ b/insights/tests/test_workbook_templates.py
@@ -17,7 +17,10 @@ from insights.api.templates import (
     sync_workbook_template_updates,
     update_workbook_from_template,
 )
-from insights.insights.doctype.insights_workbook.insights_workbook import import_workbook
+from insights.insights.doctype.insights_workbook.insights_workbook import (
+    InsightsWorkbook,
+    import_workbook,
+)
 from insights.tests.base import InsightsIntegrationTestCase
 from insights.tests.factories import USER_1, create_test_user, delete_users
 from insights.tests.workbook_utils import get_workbook
@@ -301,6 +304,27 @@ class TestWorkbookTemplates(InsightsIntegrationTestCase):
             sales = {t["name"]: t for t in get_workbook_templates()}[TEMPLATE]
         self.assertTrue(sales["update_available"])
         self.assertTrue(sales["customized"])
+
+    def test_migrate_sync_rolls_back_a_failed_update(self):
+        with self.as_user(ADMIN_USER), installed_apps(APPS_WITH_ERPNEXT):
+            workbook_name = create_workbook_from_template(TEMPLATE)["workbook"]
+        charts_before = frappe.get_all("Insights Chart v3", {"workbook": workbook_name}, pluck="name")
+        self.assertTrue(charts_before)
+
+        def boom(*args, **kwargs):
+            # fail mid-rebuild, after _replace_workbook_contents has dropped the children
+            raise RuntimeError("restore failed")
+
+        with (
+            bumped_version(TEMPLATE, 2),
+            patch.object(InsightsWorkbook, "restore_workbook_contents", boom),
+        ):
+            sync_workbook_template_updates()  # must swallow the failure, not raise
+
+        # the copy is left whole: children rolled back in, version not advanced
+        charts_after = frappe.get_all("Insights Chart v3", {"workbook": workbook_name}, pluck="name")
+        self.assertEqual(set(charts_after), set(charts_before))
+        self.assertEqual(frappe.db.get_value("Insights Workbook", workbook_name, "imported_version"), 1)
 
     def test_legacy_copy_without_version_adopts_current_as_baseline(self):
         with self.as_user(ADMIN_USER), installed_apps(APPS_WITH_ERPNEXT):

--- a/insights/workbook_templates/accounting/manifest.json
+++ b/insights/workbook_templates/accounting/manifest.json
@@ -1,4 +1,5 @@
 {
+	"version": 1,
 	"title": "Receivables, Payables & Cash",
 	"description": "AR/AP ageing, a collections worklist and a cash-flow view for receivables, payables and cash.",
 	"notes": "Built from submitted Sales/Purchase Invoices, Payment Entries and GL (docstatus=1). Outstanding is reconstructed from GL Entry (is_cancelled=0) so payment-rounding residuals don't inflate receivables/payables. Snapshot figures are as-of-today in the company's base currency; the date filter drives the cash-flow trends.",

--- a/insights/workbook_templates/purchasing/manifest.json
+++ b/insights/workbook_templates/purchasing/manifest.json
@@ -1,4 +1,5 @@
 {
+	"version": 1,
 	"title": "Purchasing Overview",
 	"description": "Supplier spend, order workload and receiving risk at a glance — spend trend with month-on-month KPIs, spend by item group, top suppliers, purchase-order status mix and an overdue-POs list.",
 	"notes": "Built from submitted Purchase Invoices and Purchase Orders. Amounts are in the company's base currency and net of returns (debit notes ride along as negative rows). Order count and average order value are measured on Purchase Orders by transaction date.",

--- a/insights/workbook_templates/sales/manifest.json
+++ b/insights/workbook_templates/sales/manifest.json
@@ -1,4 +1,5 @@
 {
+	"version": 1,
 	"title": "Sales Performance",
 	"description": "Revenue, customers and fulfilment at a glance — revenue trend with month-on-month KPIs, top customers and items, a quotation-to-order funnel and an overdue-deliveries list.",
 	"notes": "Built from submitted Sales Invoices, Quotations and Sales Orders. Amounts are in the company's base currency and net of returns. POS invoices are reflected only after POS closing.",

--- a/insights/workbook_templates/stock/manifest.json
+++ b/insights/workbook_templates/stock/manifest.json
@@ -1,4 +1,5 @@
 {
+	"version": 1,
 	"title": "Inventory Health",
 	"description": "Stock value, ageing and reorder health — value by warehouse and item group, incoming vs outgoing movement, a reorder alert list and top items by value.",
 	"notes": "Built from live Bin balances and Stock Ledger Entries. Values are in the company's base currency and reflect the site's current valuation state (backdated or un-reposted entries can skew Bin values). Stock ageing and dead-stock use an item-level last-movement proxy, not FIFO lot ageing.",


### PR DESCRIPTION
Adds an update path to the workbook template library. A template carries an integer `version` in its manifest; an imported copy records `imported_version` + `imported_checksum` (a fingerprint of its contents as imported).

- **Pristine copies auto-update on migrate** — checksum matches, so nothing local to clobber.
- **Edited copies** get a warned, manual update from the library instead.
- Updates replace contents **in place**, so the workbook name, URL and share survive.
- Legacy copies (pre-versioning) adopt the current version as baseline and are never silently overwritten.

Kept copies editable + owned rather than read-only `is_standard` content: import is one Administrator-owned, org-shared copy per site, so the only hard-to-add-later bit is lineage + version. A preference overlay (so Update stops colliding with edits) is the intended next step, not in this PR.

Bump a manifest `version` to ship an update. 6 new tests; full module (17) passes, pre-commit clean.