### PR TITLE
fix(telemetry): restore telemetry via boot_config + track library adoption

### DIFF
--- a/frontend/src2/dashboard/dashboard.ts
+++ b/frontend/src2/dashboard/dashboard.ts
@@ -1,6 +1,6 @@
 import { reactive, ref, toRefs } from 'vue'
 // @ts-ignore
-import { useTelemetry } from 'frappe-ui/frappe'
+import { useTelemetry } from '../telemetry'
 import useChart from '../charts/chart'
 import {
 	getUniqueId,

--- a/frontend/src2/main.ts
+++ b/frontend/src2/main.ts
@@ -8,8 +8,7 @@ import { registerControllers, registerGlobalComponents } from './globals.ts'
 import './index.css'
 import router from './router.ts'
 import { translationPlugin } from './translation.ts'
-//@ts-ignore
-import { telemetryPlugin } from 'frappe-ui/frappe'
+import telemetryPlugin from './telemetry'
 import session from './session.ts'
 
 setConfig('resourceFetcher', frappeRequest)

--- a/frontend/src2/query/Query.vue
+++ b/frontend/src2/query/Query.vue
@@ -7,7 +7,7 @@ import ScriptQueryEditor from './components/ScriptQueryEditor.vue'
 import useQuery from './query'
 import { waitUntil } from '../helpers'
 // @ts-ignore
-import { useTelemetry } from 'frappe-ui/frappe'
+import { useTelemetry } from '../telemetry'
 
 const { capture } = useTelemetry()
 const props = defineProps<{ query_name: string }>()

--- a/frontend/src2/telemetry/index.ts
+++ b/frontend/src2/telemetry/index.ts
@@ -1,0 +1,125 @@
+// TEMPORARY vendored copy of frappe-ui@1.0.0-beta.24's telemetry plugin. See
+// ./pulse.ts for why this lives in insights instead of `frappe-ui/frappe`.
+
+import { reactive, readonly, ref, type App } from 'vue'
+import type { Router, RouteLocationNormalized } from 'vue-router'
+
+import {
+  fetchBootConfig,
+  loadPulseClient,
+  type BootConfig,
+  type PulseAnonymousMode,
+  type PulseClient,
+  type PulseContext,
+} from './pulse.ts'
+
+let client: PulseClient | null = null
+let removePageviewHook: (() => void) | null = null
+
+const appName = ref<string>()
+const isEnabled = ref(false)
+
+export function useTelemetry() {
+  return reactive({
+    isEnabled: readonly(isEnabled),
+    disable: () => {
+      isEnabled.value = false
+      client?.stop()
+    },
+    capture: (event_name: string, data: Record<string, any> = {}) => {
+      if (!isEnabled.value || !appName.value) return
+      client?.capture(event_name, appName.value, data)
+    },
+    getDistinctId: () => client?.getDistinctId?.() ?? '',
+  })
+}
+
+export interface TelemetryPluginOptions {
+  app_name: string
+  host?: string
+  apiKey?: string
+  site?: string
+  enabled?: boolean
+  getContext?: () => PulseContext
+  anonymousMode?: PulseAnonymousMode
+  clientUrl?: string
+  // Pass your vue-router to auto-capture a "pageview" per navigation (new sites only,
+  // site_age <= 15 days, like desk).
+  router?: Router
+  // Route → PII-safe string. Defaults to the matched path pattern (e.g. "/orders/:id").
+  scrubRoute?: (to: RouteLocationNormalized) => string
+}
+
+function defaultScrubRoute(to: RouteLocationNormalized): string {
+  const matched = to.matched[to.matched.length - 1]
+  return matched?.path || to.path || ''
+}
+
+export default {
+  async install(app: App, options: TelemetryPluginOptions) {
+    appName.value = options.app_name
+
+    if (!appName.value) {
+      console.warn(
+        `Telemetry plugin installed without app_name. \n` +
+          `To enable telemetry, please provide the app_name while installing the plugin: \n` +
+          `app.use(telemetryPlugin, { app_name: 'your_app_name' })`,
+      )
+      return
+    }
+
+    // Explicit options win; fetch the rest from the backend (skip when self-sufficient).
+    const fetched: BootConfig =
+      options.host != null && options.apiKey != null ? {} : await fetchBootConfig()
+
+    const getContext =
+      options.getContext || (() => ({ user: fetched.user, team: fetched.team }))
+
+    // Reinstalls (tests, HMR, SSR-per-request) reuse the module singletons, so tear
+    // down the previous client's flush timer and router hook before replacing them.
+    client?.stop()
+    removePageviewHook?.()
+    removePageviewHook = null
+
+    client = await loadPulseClient({
+      host: options.host ?? fetched.host,
+      apiKey: options.apiKey ?? fetched.key,
+      site: options.site ?? fetched.site,
+      enabled: options.enabled ?? fetched.enabled ?? false,
+      getContext,
+      anonymousMode: options.anonymousMode,
+      clientUrl: options.clientUrl ?? fetched.client_url,
+    })
+    if (!client) return
+
+    isEnabled.value = await client.init()
+    if (isEnabled.value) {
+      removePageviewHook = setupPageviewTracking(options, fetched.site_age)
+    }
+  },
+}
+
+// Older backends omit site_age → track anyway (permissive, matching desk's
+// `site_age && site_age > 15` skip check).
+function setupPageviewTracking(
+  options: TelemetryPluginOptions,
+  site_age: number | undefined,
+): (() => void) | null {
+  if (!options.router || (site_age && site_age > 15)) return null
+
+  const scrub = options.scrubRoute || defaultScrubRoute
+  let lastFullPath = ''
+  const capturePageview = (to: RouteLocationNormalized) => {
+    // Dedupe so the initial capture and afterEach can't double-count the same route.
+    if (!isEnabled.value || !appName.value || to.fullPath === lastFullPath) return
+    lastFullPath = to.fullPath
+    client?.capture('pageview', appName.value, { route: scrub(to) })
+  }
+
+  // afterEach missed the initial navigation if it resolved during install's awaits,
+  // so capture the landing route once the router is ready.
+  options.router.isReady().then(() => {
+    if (options.router) capturePageview(options.router.currentRoute.value)
+  })
+  return options.router.afterEach((to) => capturePageview(to))
+}

--- a/frontend/src2/telemetry/pulse.ts
+++ b/frontend/src2/telemetry/pulse.ts
@@ -1,0 +1,98 @@
+// TEMPORARY vendored copy of frappe-ui@1.0.0-beta.24's telemetry client.
+// Insights ships frappe-ui 0.1.x, whose telemetry calls the now-unwhitelisted
+// `is_enabled` method and stays silently disabled. This local copy uses the new
+// `boot_config` endpoint + direct CDN pulse client so telemetry works regardless
+// of the frappe-ui version. Delete once the frappe-ui v1 migration lands and
+// switch the imports back to `frappe-ui/frappe`.
+
+import { call } from 'frappe-ui'
+
+export interface PulseContext {
+  user?: string
+  team?: string
+}
+
+// "cookieless" (default): host derives the anon id at ingest. "client": mints a
+// persistent localStorage anon id.
+export type PulseAnonymousMode = 'cookieless' | 'client'
+
+export interface PulseClientOptions {
+  host?: string
+  apiKey?: string
+  site?: string
+  enabled?: boolean
+  getContext?: () => PulseContext
+  anonymousMode?: PulseAnonymousMode
+  flushInterval?: number
+  maxQueueSize?: number
+  now?: () => string
+  clientUrl?: string
+}
+
+export interface PulseClient {
+  init(): Promise<boolean>
+  setEnabled(enabled: boolean): void
+  capture(event_name: string, app: string, props?: Record<string, any>): void
+  // Distinct id on events (known identity, else anon id); used to alias() pre-signup
+  // activity. Optional: an older CDN build may not expose it.
+  getDistinctId?(): string
+  flush(): Promise<void> | undefined
+  stop(): void
+}
+
+// Shape returned by the framework's whitelisted boot_config method.
+export interface BootConfig {
+  enabled?: boolean
+  host?: string
+  key?: string
+  site?: string
+  user?: string
+  team?: string
+  client_url?: string
+  site_age?: number
+}
+
+export const BOOT_CONFIG_METHOD = 'frappe.utils.telemetry.pulse.client.boot_config'
+
+// Direct-mode config from the app's own backend (frappe-ui SPAs lack desk's
+// window.frappe.boot). Degrades to {} on any error, including old backends (404).
+export async function fetchBootConfig(): Promise<BootConfig> {
+  try {
+    return (await call(BOOT_CONFIG_METHOD)) || {}
+  } catch (error) {
+    return {}
+  }
+}
+
+export const DEFAULT_PULSE_CLIENT_URL =
+  'https://pulse.m.frappe.cloud/assets/pulse/js/pulse_client.js'
+
+// Only import from a trusted origin: pulse's CDN or the ingest host (self-hosted
+// pulse). Stops a tampered boot_config from redirecting import() to an attacker
+// origin — an untrusted url falls back to the canonical CDN.
+function trustedClientUrl(clientUrl: string | undefined, host?: string): string {
+  if (!clientUrl) return DEFAULT_PULSE_CLIENT_URL
+  try {
+    const target = new URL(clientUrl)
+    if (target.protocol !== 'https:') return DEFAULT_PULSE_CLIENT_URL
+    const allowed = new Set([new URL(DEFAULT_PULSE_CLIENT_URL).origin])
+    try {
+      if (host) allowed.add(new URL(host).origin)
+    } catch {}
+    if (allowed.has(target.origin)) return clientUrl
+  } catch {}
+  return DEFAULT_PULSE_CLIENT_URL
+}
+
+export async function loadPulseClient(
+  options: PulseClientOptions = {},
+): Promise<PulseClient | null> {
+  const { clientUrl, ...clientOptions } = options
+  try {
+    const url = trustedClientUrl(clientUrl, clientOptions.host)
+    const mod = await import(/* @vite-ignore */ url)
+    return new mod.PulseClient(clientOptions) as PulseClient
+  } catch (error) {
+    return null
+  }
+}

--- a/frontend/src2/workbook/WorkbookList.vue
+++ b/frontend/src2/workbook/WorkbookList.vue
@@ -20,10 +20,12 @@ import useWorkbook, { newWorkbookName } from './workbook'
 import { getWorkbookColumns } from './workbookListColumns'
 import useWorkbooks from './workbooks'
 import WorkbookTemplates, { WorkbookTemplate } from './WorkbookTemplates.vue'
+import { useTelemetry } from '../telemetry'
 
 const router = useRouter()
 const userStore = useUserStore()
 const workbookStore = useWorkbooks()
+const { capture } = useTelemetry()
 
 type WorkbookScope = 'all' | 'owned' | 'shared'
 
@@ -96,6 +98,11 @@ wheneverChanges(
 	{ immediate: true },
 )
 
+function openLibrary() {
+	showTemplates.value = true
+	capture('workbook_library_opened')
+}
+
 const columns = getWorkbookColumns({ userStore })
 
 function onRowClick(row: any) {
@@ -145,7 +152,7 @@ watchEffect(() => {
 				v-if="templates.length"
 				:label="__('Library')"
 				variant="outline"
-				@click="showTemplates = true"
+				@click="openLibrary"
 			>
 				<template #prefix>
 					<LayoutTemplateIcon class="w-4" />
@@ -205,7 +212,7 @@ watchEffect(() => {
 							v-if="templates.length"
 							:label="__('Library')"
 							variant="outline"
-							@click="showTemplates = true"
+							@click="openLibrary"
 						>
 							<template #prefix>
 								<LayoutTemplateIcon class="w-4" />

--- a/frontend/src2/workbook/WorkbookTemplates.vue
+++ b/frontend/src2/workbook/WorkbookTemplates.vue
@@ -4,6 +4,7 @@ import { CheckCircle2, LayoutTemplate } from 'lucide-vue-next'
 import { computed, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { createToast } from '../helpers/toasts'
+import { useTelemetry } from '../telemetry'
 import { __ } from '../translation'
 
 export type WorkbookTemplate = {
@@ -38,6 +39,7 @@ const sections = computed(() => {
 })
 
 const router = useRouter()
+const { capture } = useTelemetry()
 
 // name of the template currently being imported, so only its card spins
 const importing = ref<string | null>(null)
@@ -48,6 +50,11 @@ function importTemplate(template: WorkbookTemplate) {
 		template_name: template.name,
 	})
 		.then((result: { workbook: number; dashboard: string | null }) => {
+			capture('workbook_template_imported', {
+				template: template.name,
+				app: template.app,
+				module: template.module,
+			})
 			createToast({ message: __('{0} imported', template.title), variant: 'success' })
 			router.push(
 				result.dashboard
@@ -65,6 +72,8 @@ function importTemplate(template: WorkbookTemplate) {
 }
 
 function openImported(template: WorkbookTemplate) {
+	// usage is tracked centrally via `workbook_template_used` on workbook load,
+	// which covers every open path (list, direct URL, here) — no event needed here
 	router.push(`/workbook/${template.imported_workbook}`)
 }
 </script>

--- a/frontend/src2/workbook/workbook.ts
+++ b/frontend/src2/workbook/workbook.ts
@@ -1,6 +1,5 @@
 import { call } from 'frappe-ui'
 import { __ } from '../translation'
-// @ts-ignore
 import { useTelemetry } from '../telemetry'
 import { computed, InjectionKey, reactive, toRefs } from 'vue'
 import useChart, { newChart } from '../charts/chart'

--- a/frontend/src2/workbook/workbook.ts
+++ b/frontend/src2/workbook/workbook.ts
@@ -1,7 +1,7 @@
 import { call } from 'frappe-ui'
 import { __ } from '../translation'
 // @ts-ignore
-import { useTelemetry } from 'frappe-ui/frappe'
+import { useTelemetry } from '../telemetry'
 import { computed, InjectionKey, reactive, toRefs } from 'vue'
 import useChart, { newChart } from '../charts/chart'
 import useDashboard, { newDashboard } from '../dashboard/dashboard'

--- a/insights/insights/doctype/insights_workbook/insights_workbook.py
+++ b/insights/insights/doctype/insights_workbook/insights_workbook.py
@@ -2,6 +2,8 @@
 # For license information, please see license.txt
 
 
+from contextlib import suppress
+
 import frappe
 import frappe.utils
 from frappe.model.document import Document
@@ -250,6 +252,16 @@ class InsightsWorkbook(Document):
         )
         if not last_viewed_recently:
             self.add_viewed(force=True)
+
+        # adoption signal for library workbooks; interval dedupes to once/user/site/day
+        if self.from_template:
+            with suppress(Exception):
+                capture(
+                    "workbook_template_used",
+                    "insights",
+                    properties={"template": self.from_template},
+                    interval="1d",
+                )
 
     @frappe.whitelist()
     def export(self):


### PR DESCRIPTION
### Why

Telemetry is currently dead in v3. Frappe dropped the whitelist on `frappe.utils.telemetry.pulse.client.is_enabled` and replaced the browser surface with the whitelisted `boot_config` + a direct CDN pulse client. The telemetry shipped in frappe-ui `0.1.x` still calls the now-unreachable `is_enabled`, so it silently disables itself. The proper fix rides along with the frappe-ui v1 migration, which is still WIP — this unblocks telemetry now, independent of that bump.

### What

- **`src2/telemetry/`** — vendors beta.24's `boot_config` + direct-pulse-client implementation into insights so it works on any frappe-ui version. Only depends on `call` (stable). Temp stopgap: delete it and revert the imports to `frappe-ui/frappe` once the v1 migration lands (noted in the file headers).
- **Library / standard-workbook adoption events**, to measure uptake of prebuilt workbooks:
  - `workbook_library_opened`
  - `workbook_template_imported` `{ template, app, module }`
  - `workbook_template_used` `{ template }` — emitted server-side from the existing `track_view` (no extra request), `interval="1d"` so it dedupes to once per user/site/day.

### Notes for reviewers

- No new frontend→backend calls; the usage event piggybacks on `track_view`.
- All events no-op when telemetry is disabled.
- `interval`'s dedup key is `event*user*team*site*app` (not properties), so `workbook_template_used` is per-user-per-day, not per-template-per-day — the `template` prop still rides along for distribution.
