### PR TITLE
refactor: generate dashboard preview in-process via framework util

### DIFF
--- a/insights/insights/doctype/insights_dashboard_v3/insights_dashboard_v3.py
+++ b/insights/insights/doctype/insights_dashboard_v3/insights_dashboard_v3.py
@@ -247,6 +247,18 @@ class InsightsDashboardv3(Document):
 
 
 def get_page_preview(url: str, headers: dict | None = None) -> bytes:
+    # Newer Frappe renders previews in-process via headless Chromium — no
+    # external service, and the site's own /assets and /files resolve locally.
+    # Older versions fall back to the preview_generator HTTP service.
+    try:
+        from frappe.utils.preview import get_preview_from_url
+    except ImportError:
+        return get_page_preview_via_service(url, headers)
+
+    return get_preview_from_url(url, wait_for=1000, headers=headers or {}, format="jpeg")
+
+
+def get_page_preview_via_service(url: str, headers: dict | None = None) -> bytes:
     PREVIEW_GENERATOR_URL = (
         frappe.conf.preview_generator_url
         or "https://preview.frappe.cloud/api/method/preview_generator.api.generate_preview_from_url"


### PR DESCRIPTION
Dashboard previews currently POST to the external `preview.frappe.cloud` (preview_generator) service. Newer Frappe ships `frappe.utils.preview.get_preview_from_url`, which renders in-process via the bundled headless Chromium — no external round-trip, and the site's own `/assets` and `/files` resolve locally.

`get_page_preview` now uses the framework util when importable and falls back to the HTTP service on older Frappe. Auth (the `X-Insights-Preview-Key` header) and the timing (`wait_for=1000`) are unchanged; the util forwards headers via CDP.

Mirrors the same switch done in Builder (frappe/builder#628).