### PR TITLE
feat: nudge Insights Admins to prebuilt module dashboards

### DIFF
--- a/frontend/src2/router.ts
+++ b/frontend/src2/router.ts
@@ -58,6 +58,13 @@ const routes = [
 		],
 	},
 	{
+		props: true,
+		name: 'OpenTemplate',
+		path: '/template/:app/:folder',
+		component: () => import('./workbook/OpenTemplate.vue'),
+		meta: { hideSidebar: true },
+	},
+	{
 		path: '/data-source',
 		name: 'DataSourceList',
 		component: () => import('./data_source/DataSourceList.vue'),

--- a/frontend/src2/workbook/OpenTemplate.vue
+++ b/frontend/src2/workbook/OpenTemplate.vue
@@ -1,0 +1,37 @@
+<script setup lang="ts">
+import { call, LoadingIndicator } from 'frappe-ui'
+import { onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import { createToast } from '../helpers/toasts'
+import { __ } from '../translation'
+
+// Resolves a shipped workbook template to its dashboard, lazily importing it on
+// first open (idempotent server-side). Entry point for the ERPNext workspace
+// nudge, so the desk banner links to a stable template id instead of a docname.
+const props = defineProps<{ app: string; folder: string }>()
+const router = useRouter()
+
+onMounted(() => {
+	call('insights.api.templates.create_workbook_from_template', {
+		template_name: `${props.app}/${props.folder}`,
+	})
+		.then((result: { workbook: number; dashboard: string | null }) => {
+			router.replace(
+				result.dashboard
+					? `/dashboards/${result.dashboard}`
+					: `/workbook/${result.workbook}`,
+			)
+		})
+		.catch(() => {
+			createToast({ message: __('Could not open the dashboard'), variant: 'error' })
+			router.replace('/workbook')
+		})
+})
+</script>
+
+<template>
+	<div class="flex h-full w-full flex-col items-center justify-center gap-2 text-ink-gray-5">
+		<LoadingIndicator class="w-7" />
+		<p class="text-sm">{{ __('Preparing dashboard…') }}</p>
+	</div>
+</template>

--- a/insights/hooks.py
+++ b/insights/hooks.py
@@ -35,7 +35,7 @@ insights_workbooks = "workbook_templates"
 
 # include js, css files in header of desk.html
 # app_include_css = "/assets/insights/css/insights.css"
-# app_include_js = "insights.bundle.js"
+app_include_js = "insights_nudge.bundle.js"
 
 # include js, css files in header of web template
 # web_include_css = "/assets/insights/css/insights.css"

--- a/insights/insights/doctype/insights_dashboard_v3/insights_dashboard_v3.py
+++ b/insights/insights/doctype/insights_dashboard_v3/insights_dashboard_v3.py
@@ -70,6 +70,19 @@ class InsightsDashboardv3(Document):
         d.has_workbook_access = frappe.has_permission("Insights Workbook", ptype="read", doc=self.workbook)
         return d
 
+    def after_insert(self):
+        # A dashboard created already populated (e.g. imported from a template) is
+        # never saved again, so before_save's diff-based preview never runs and it
+        # lands without a preview. Generate the initial one here when it has content.
+        if frappe.flags.in_patch or not frappe.parse_json(self.items):
+            return
+        frappe.enqueue_doc(
+            doctype=self.doctype,
+            name=self.name,
+            method="generate_dashboard_preview",
+            enqueue_after_commit=True,
+        )
+
     def before_save(self):
         self.set_linked_charts()
         self.enqueue_update_dashboard_preview()

--- a/insights/public/js/insights_nudge.bundle.js
+++ b/insights/public/js/insights_nudge.bundle.js
@@ -1,0 +1,165 @@
+/**
+ * Nudges ERPNext admins toward the prebuilt Insights dashboard for the module
+ * workspace they're viewing (Selling, Buying, Stock, Financial Reports).
+ *
+ * Loaded on every desk page via `app_include_js` (hooks.py). Client Scripts are
+ * DocType-scoped and never run on workspaces, so this app-level bundle is the
+ * only place the banner can hook in. Kept tiny and gated early — it renders
+ * nothing unless the route, role and dismissal checks all pass.
+ */
+(function () {
+	if (window.__insights_nudge_loaded) return;
+	window.__insights_nudge_loaded = true;
+
+	const BASE = "/insights"; // v3 frontend base route
+	const ALLOWED_ROLES = ["Insights Admin"];
+
+	// Workspace -> shipped workbook template. `template` is the folder under
+	// insights/workbook_templates/; the id is `insights/<template>`. The link opens
+	// it via the SPA resolver, which lazily imports it (idempotent) on first open.
+	const DASHBOARDS = {
+		Selling: { title: "Sales Performance", template: "sales" },
+		Buying: { title: "Purchasing Overview", template: "purchasing" },
+		Stock: { title: "Stock & Inventory", template: "stock" },
+		// "Accounts" module spans several workspaces — nudge from the reporting one.
+		"Financial Reports": {
+			title: "Receivables, Payables & Cash",
+			template: "accounting",
+		},
+	};
+
+	const templateId = (cfg) => `insights/${cfg.template}`;
+	const openUrl = (cfg) => `${BASE}/template/${templateId(cfg)}`;
+
+	const allowed = () =>
+		ALLOWED_ROLES.some((r) => (frappe.user_roles || []).includes(r));
+	// Site-wide opt-out for promotional banners — Frappe gates its own CRM/Helpdesk
+	// workspace nudges (setup_promotional_banners) on the same System Settings flag.
+	const suggestionsDisabled = () =>
+		cint(frappe.sys_defaults?.disable_product_suggestion);
+	const dismissKey = (ws) => `insights:nudge:${frappe.session.user}:${ws}`;
+	const dismissed = (ws) => localStorage.getItem(dismissKey(ws)) === "1";
+	const esc = (s) => frappe.utils.escape_html(s);
+
+	// Self-guards on frappe.boot.enable_telemetry; no-ops when telemetry is off.
+	const track = (event, ws, cfg) =>
+		frappe.telemetry?.capture(event, "insights", {
+			workspace: ws,
+			template: templateId(cfg),
+		});
+
+	function currentWorkspace() {
+		const route = frappe.get_route() || [];
+		return route[0] === "Workspaces" ? route[1] : null;
+	}
+
+	function removeBanner() {
+		document
+			.querySelectorAll(".insights-nudge")
+			.forEach((el) => el.remove());
+	}
+
+	// The visible workspace's main section. Workspaces share one reused body and
+	// rebuild the editorjs content on each nav, so anchor against the stable direct
+	// child `.editor-js-container` — a deep `.codex-editor` ref isn't a child of the
+	// section and throws on client-side nav (only firstChild-fallback works on refresh).
+	function findAnchor() {
+		const sections = document.querySelectorAll(".layout-main-section");
+		for (const s of sections) {
+			if (s.offsetParent === null) continue; // not the active page
+			return {
+				container: s,
+				before: s.querySelector(":scope > .editor-js-container"),
+			};
+		}
+		return null;
+	}
+
+	function render(ws, cfg, anchor) {
+		const el = document.createElement("div");
+		el.className = "insights-nudge";
+		el.setAttribute("role", "region");
+		el.setAttribute("aria-label", "Insights dashboard suggestion");
+		el.innerHTML = `
+			<span class="insights-nudge__text">${__(
+				"A prebuilt {0} dashboard is available in Insights",
+				[`<b>${esc(cfg.title)}</b>`],
+			)}</span>
+			<span class="insights-nudge__actions">
+				<a class="btn btn-default btn-sm insights-nudge__cta" href="${esc(
+					openUrl(cfg),
+				)}" target="_blank" rel="noopener">${frappe.utils.icon(
+					"external-link",
+					"sm",
+				)}${__("Open")}</a>
+				<button type="button" class="btn btn-default btn-sm icon-btn insights-nudge__x" aria-label="${__(
+					"Dismiss",
+				)}">${frappe.utils.icon("x", "sm")}</button>
+			</span>`;
+		el.querySelector(".insights-nudge__cta").addEventListener("click", () =>
+			track("workspace_dashboard_nudge_clicked", ws, cfg),
+		);
+		el.querySelector(".insights-nudge__x").addEventListener("click", () => {
+			localStorage.setItem(dismissKey(ws), "1");
+			el.remove();
+			track("workspace_dashboard_nudge_dismissed", ws, cfg);
+		});
+		anchor.container.insertBefore(
+			el,
+			anchor.before || anchor.container.firstChild,
+		);
+		track("workspace_dashboard_nudge_shown", ws, cfg);
+	}
+
+	function tryShow(attempt) {
+		attempt = attempt || 0;
+		const ws = currentWorkspace();
+		const cfg = ws && DASHBOARDS[ws];
+		if (!cfg || suggestionsDisabled() || !allowed() || dismissed(ws))
+			return removeBanner();
+
+		const anchor = findAnchor();
+		if (!anchor) {
+			if (attempt < 20) setTimeout(() => tryShow(attempt + 1), 100); // workspace renders async
+			return;
+		}
+		removeBanner();
+		render(ws, cfg, anchor);
+	}
+
+	function injectStyles() {
+		if (document.getElementById("insights-nudge-styles")) return;
+		const style = document.createElement("style");
+		style.id = "insights-nudge-styles";
+		style.textContent = `
+			.insights-nudge {
+				display: flex; align-items: center; gap: 16px;
+				margin: 4px 0 -3px 0px; padding: 11px 14px;
+				background: var(--surface-white);
+				border: 1px solid var(--outline-gray-1);
+				border-radius: var(--radius-lg, 10px);
+			}
+			.insights-nudge__text {
+				flex: 1; min-width: 0;
+				font-size: var(--text-base, 13px); line-height: 1.5;
+				color: var(--ink-gray-6);
+			}
+			.insights-nudge__text b { font-weight: 600; color: var(--ink-gray-8); }
+			.insights-nudge__actions { flex-shrink: 0; display: flex; align-items: center; gap: 6px; }
+			.insights-nudge__cta { display: inline-flex; align-items: center; gap: 5px; white-space: nowrap; }
+			.insights-nudge__cta svg { flex-shrink: 0; }
+		`;
+		document.head.appendChild(style);
+	}
+
+	function init() {
+		if (!window.frappe || !frappe.router || !frappe.get_route) {
+			return setTimeout(init, 300); // self-heal against load order
+		}
+		injectStyles();
+		frappe.router.on("change", () => tryShow());
+		tryShow();
+	}
+
+	init();
+})();

--- a/insights/public/js/insights_nudge.bundle.js
+++ b/insights/public/js/insights_nudge.bundle.js
@@ -111,8 +111,12 @@
 		track("workspace_dashboard_nudge_shown", ws, cfg);
 	}
 
+	let retryTimer = null;
 	function tryShow(attempt) {
 		attempt = attempt || 0;
+		// Supersede any pending retry: a fresh call (e.g. a fast navigation) owns the
+		// banner now, so stale chains can't double-render it or re-fire "shown".
+		clearTimeout(retryTimer);
 		const ws = currentWorkspace();
 		const cfg = ws && DASHBOARDS[ws];
 		if (!cfg || suggestionsDisabled() || !allowed() || dismissed(ws))
@@ -120,7 +124,8 @@
 
 		const anchor = findAnchor();
 		if (!anchor) {
-			if (attempt < 20) setTimeout(() => tryShow(attempt + 1), 100); // workspace renders async
+			if (attempt < 20)
+				retryTimer = setTimeout(() => tryShow(attempt + 1), 100); // workspace renders async
 			return;
 		}
 		removeBanner();


### PR DESCRIPTION
A dismissible banner in ERPNext module workspaces (Selling, Buying, Stock, Financial Reports) that points Insights Admins at the prebuilt dashboard for that module.

### How it works
- Injected on desk via `app_include_js`. Client Scripts are DocType-scoped and never run on workspaces, so an app-level bundle is the only hook point.
- **Open** links to a new SPA resolver route `/template/:app/:folder` that lazily imports the workbook template (idempotent, `create_workbook_from_template`) and lands on its dashboard. Nothing is imported until someone opens one.
- Gated: `Insights Admin` only, respects the `disable_product_suggestion` System Setting (the same opt-out Frappe uses for its own CRM/Helpdesk workspace promos), dismissible per user, and emits shown/clicked/dismissed telemetry.

<img width="2940" height="1124" alt="CleanShot 2026-07-15 at 13 46 33@2x" src="https://github.com/user-attachments/assets/a314a613-d258-447b-826b-507ff630295a" />


### Also
Fixes a general preview gap: `before_save`'s preview generation early-returns on `is_new()`, so any dashboard created *already populated* (template import, duplication) never got a preview. Now generated in `after_insert` when the dashboard lands with content.

### Notes for reviewers
- The desk bundle is intentionally dependency-free vanilla JS (no lucide runtime on desk) and gated early so it stays cheap on every desk page.
- `disable_product_suggestion` is an orthogonal site-wide off-switch; the role gate is separate.
