### PR TITLE
fix(src2): funnel chart drill-down

### DIFF
--- a/frontend/src2/charts/helpers.ts
+++ b/frontend/src2/charts/helpers.ts
@@ -624,6 +624,7 @@ export function getFunnelChartOptions(config: FunnelChartConfig, result: QueryRe
 		series: [
 			{
 				type: 'custom',
+				name: valueColumn,
 				emphasis: { disabled: true },
 				data: dataValues.map((val, i) => ({
 					name: categories[i],


### PR DESCRIPTION
Clicking a funnel segment didn't open the drill-down dialog.

The click handler resolves the drill-down measure column from the clicked series' name (`params.seriesName`). Every other drill-down-capable chart sets a series `name` matching its measure column, but the funnel's custom series had none — so the lookup returned `undefined` and no drill-down query was built.

Fix: set the funnel series `name` to the value column, mirroring the donut chart. No funnel-specific branch needed — the existing generic drill-down path handles the rest.