### PR TITLE
fix: lower default query timeout to 60s

### DIFF
--- a/insights/insights/doctype/insights_data_source_v3/ibis_utils.py
+++ b/insights/insights/doctype/insights_data_source_v3/ibis_utils.py
@@ -586,10 +586,9 @@ class IbisQueryBuilder:
         raw_sql = sqlparse.format(sql=raw_sql, strip_comments=True)
         raw_sql = self._validate_native_sql(raw_sql, use_live_connection=self.use_live_connection)
 
-        check_permissions = (
-            frappe.db.get_single_value("Insights Settings", "enable_permissions")
-            or frappe.db.get_single_value("Insights Settings", "apply_user_permissions")
-        )
+        check_permissions = frappe.db.get_single_value(
+            "Insights Settings", "enable_permissions"
+        ) or frappe.db.get_single_value("Insights Settings", "apply_user_permissions")
 
         if check_permissions or not self.use_live_connection:
             tables = self._get_sql_table_names(
@@ -956,7 +955,11 @@ def execute_ibis_query(
                 title="Query execution time exceeded the limit.",
                 message=f"Query: {sql}",
             )
-            max_time = frappe.db.get_single_value("Insights Settings", "max_execution_time") or 180
+            from insights.insights.doctype.insights_settings.insights_settings import (
+                get_max_execution_time,
+            )
+
+            max_time = get_max_execution_time()
             frappe.throw(
                 title="Query Timeout",
                 msg=f"Query execution time exceeded the limit of {max_time} seconds. Please try again with a smaller timespan or a more specific filter.",

--- a/insights/insights/doctype/insights_data_source_v3/insights_data_source_v3.py
+++ b/insights/insights/doctype/insights_data_source_v3/insights_data_source_v3.py
@@ -262,12 +262,13 @@ class InsightsDataSourcev3(InsightsDataSourceDocument, Document):
             except Exception:
                 db.raw_sql("SET SESSION TRANSACTION_READ_ONLY = 1")
 
-            MAX_STATEMENT_TIMEOUT = (
-                frappe.db.get_single_value("Insights Settings", "max_execution_time", cache=True) or 180
+            from insights.insights.doctype.insights_settings.insights_settings import (
+                get_max_execution_time,
             )
+
             ## Todo: Permanent fix for this
             try:
-                db.raw_sql(f"SET MAX_STATEMENT_TIME={MAX_STATEMENT_TIMEOUT}")
+                db.raw_sql(f"SET MAX_STATEMENT_TIME={get_max_execution_time()}")
             except Exception:
                 pass
 

--- a/insights/insights/doctype/insights_settings/insights_settings.json
+++ b/insights/insights/doctype/insights_settings/insights_settings.json
@@ -144,6 +144,8 @@
    "label": "Apply User Permissions"
   },
   {
+   "default": "60",
+   "description": "Interactive queries are cancelled after this many seconds. Applies to new connections and to live (non-data-store) queries; background imports are exempt.",
    "fieldname": "max_execution_time",
    "fieldtype": "Int",
    "label": "Max Execution Time (Seconds)"

--- a/insights/insights/doctype/insights_settings/insights_settings.py
+++ b/insights/insights/doctype/insights_settings/insights_settings.py
@@ -7,6 +7,17 @@ import os
 import frappe
 from frappe.model.document import Document
 
+# Interactive queries block a web worker and hold a connection on the source DB,
+# so the cap is tuned for a viewer waiting on a dashboard, not for long analytics.
+# Background imports bypass this (see _disable_statement_timeout).
+DEFAULT_MAX_EXECUTION_TIME = 60
+
+
+def get_max_execution_time() -> int:
+    return frappe.db.get_single_value("Insights Settings", "max_execution_time", cache=True) or (
+        DEFAULT_MAX_EXECUTION_TIME
+    )
+
 
 class InsightsSettings(Document):
     # begin: auto-generated types


### PR DESCRIPTION
Interactive queries hold a web worker and a live connection to the source DB for as long as they run. The old default fallback was **180s**, so a single heavy dashboard query could stall a worker and keep load on the OLTP database for three minutes before being cancelled.

This drops the default to **60s** and routes both call sites (the `SET MAX_STATEMENT_TIME` on new connections and the timeout error message) through a single `get_max_execution_time()` helper so the default lives in one place. The setting field also gains a default and a description.

Sites that set `max_execution_time` explicitly are unaffected; only those on the implicit fallback change (180 → 60). Background imports already bypass this via `_disable_statement_timeout`, so syncs are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)