### PR TITLE
fix(templates): re-base accounting AR/AP on Payment Ledger Entry

### DIFF
--- a/insights/workbook_templates/accounting/manifest.json
+++ b/insights/workbook_templates/accounting/manifest.json
@@ -1,8 +1,8 @@
 {
-	"version": 1,
+	"version": 2,
 	"title": "Receivables, Payables & Cash",
 	"description": "AR/AP ageing, a collections worklist and a cash-flow view for receivables, payables and cash.",
-	"notes": "Built from submitted Sales/Purchase Invoices, Payment Entries and GL (docstatus=1). Outstanding is reconstructed from GL Entry (is_cancelled=0) so payment-rounding residuals don't inflate receivables/payables. Snapshot figures are as-of-today in the company's base currency; the date filter drives the cash-flow trends.",
+	"notes": "Built from submitted Sales/Purchase Invoices, Payment Entries and the Payment Ledger (delinked=0), so payment-rounding residuals don't inflate receivables/payables. AR/AP outstanding is read from the Payment Ledger Entry rather than reconstructed from GL, which is far cheaper on large sites. Snapshot figures are as-of-today in the company's base currency; the date filter drives the cash-flow trends.",
 	"module": "Accounts",
 	"required_apps": [
 		"erpnext"
@@ -11,6 +11,6 @@
 		"Sales Invoice",
 		"Purchase Invoice",
 		"Payment Entry",
-		"GL Entry"
+		"Payment Ledger Entry"
 	]
 }

--- a/insights/workbook_templates/accounting/workbook.json
+++ b/insights/workbook_templates/accounting/workbook.json
@@ -25,7 +25,7 @@
 						"table": {
 							"type": "table",
 							"data_source": "Site DB",
-							"table_name": "tabGL Entry"
+							"table_name": "tabPayment Ledger Entry"
 						}
 					},
 					{
@@ -35,7 +35,7 @@
 							{
 								"column": {
 									"type": "column",
-									"column_name": "is_cancelled"
+									"column_name": "delinked"
 								},
 								"operator": "=",
 								"value": 0
@@ -65,7 +65,7 @@
 								"measure_name": "outstanding",
 								"expression": {
 									"type": "expression",
-									"expression": "sum(debit) - sum(credit)"
+									"expression": "sum(amount)"
 								},
 								"data_type": "Decimal"
 							}
@@ -73,7 +73,7 @@
 						"dimensions": [
 							{
 								"dimension_name": "against_voucher",
-								"column_name": "against_voucher",
+								"column_name": "against_voucher_no",
 								"data_type": "String"
 							}
 						]
@@ -179,7 +179,7 @@
 						"table": {
 							"type": "table",
 							"data_source": "Site DB",
-							"table_name": "tabGL Entry"
+							"table_name": "tabPayment Ledger Entry"
 						}
 					},
 					{
@@ -189,7 +189,7 @@
 							{
 								"column": {
 									"type": "column",
-									"column_name": "is_cancelled"
+									"column_name": "delinked"
 								},
 								"operator": "=",
 								"value": 0
@@ -219,7 +219,7 @@
 								"measure_name": "outstanding",
 								"expression": {
 									"type": "expression",
-									"expression": "sum(credit) - sum(debit)"
+									"expression": "sum(amount)"
 								},
 								"data_type": "Decimal"
 							}
@@ -227,7 +227,7 @@
 						"dimensions": [
 							{
 								"dimension_name": "against_voucher",
-								"column_name": "against_voucher",
+								"column_name": "against_voucher_no",
 								"data_type": "String"
 							}
 						]
@@ -978,6 +978,8 @@
 							"template-acc-c-cash-in-out": "`template-acc-cashflow`.`posting_date`",
 							"template-acc-c-inv-coll": "`template-acc-invcoll`.`posting_date`"
 						},
+						"default_operator": "within",
+						"default_value": "Last 12 months",
 						"layout": {
 							"i": "filter-date",
 							"x": 4,


### PR DESCRIPTION
The accounting template's **AR/AP Open Invoices** queries scanned `tabGL Entry` with no date bound. On a mature site that's a full scan of tens of millions of rows against the live OLTP database — the heaviest thing the shipped templates do.

Payment Ledger Entry holds only receivable/payable rows (~10x smaller than GL Entry) and carries `party`, `against_voucher_no`, `amount` and `due_date` directly, so outstanding is `sum(amount)` grouped by invoice. Same figures, far cheaper. AP amounts are positive for open payables, so the old credit−debit inversion is gone too.

Output columns are preserved exactly, so the charts and dashboard filter links are untouched.

Verified on a demo ERPNext site: AR/AP totals reconcile **exactly** against both the old GL-based logic and ERPNext's native `outstanding_amount` on Sales/Purchase Invoice.

Also gives the dashboard Date filter a default (`Last 12 months`), matching the other templates, so the cash-flow charts don't load unbounded. Manifest `version` bumped to 2 and `source_doctypes` updated (GL Entry → Payment Ledger Entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)