### PR TITLE
feat: allow many-to-one region mapping and multi-territory drill-down

### DIFF
--- a/frontend/src2/charts/components/ChartRenderer.vue
+++ b/frontend/src2/charts/components/ChartRenderer.vue
@@ -144,6 +144,7 @@ async function handleMapChartClick(params: any) {
 	// If multiple territories map to this region, upgrade = to IN
 	const matchingList = Array.from(entry.rawValues)
 	if (matchingList.length > 1) {
+		let mutated = false
 		// Use the raw schema column name — this matches filter.column.column_name
 		// set by getFiltersForDimension(dim, value) via column(dim.column_name)
 		const schemaColName = mapConfig.value.location_column?.column_name
@@ -159,10 +160,14 @@ async function handleMapChartClick(params: any) {
 						) {
 							filter.operator = 'in'
 							filter.value = matchingList
+							mutated = true
 						}
 					}
 				}
 			}
+		}
+		if (!mutated) {
+			return null
 		}
 	}
 

--- a/frontend/src2/charts/components/ChartRenderer.vue
+++ b/frontend/src2/charts/components/ChartRenderer.vue
@@ -89,18 +89,13 @@ const locationColumn = computed(() => {
 
 // Runs only when data changes
 const locationRowIndex = computed(() => {
-	const index = new Map<string, any>()
+	const index = new Map<string, { firstRow: any; rawValues: Set<string> }>()
 	const col = locationColumn.value
 
-	if (!col) return { index, reverseMap: new Map<string, string>() }
+	if (!col) return index
 
 	// computed mappings for faster acess
 	const mappings = mapConfig.value.region_mappings?.[mapConfig.value.map_type || 'world'] || {}
-	const reverseMap = new Map<string, string>()
-
-	for (const [userValue, mappedRegion] of Object.entries(mappings)) {
-		reverseMap.set(titleCase(mappedRegion as string), userValue)
-	}
 
 	// Index the rows
 	result.value.formattedRows.forEach((row) => {
@@ -108,42 +103,70 @@ const locationRowIndex = computed(() => {
 		if (!rawValue) return
 
 		const normalizedRowValue = titleCase(rawValue)
-		//	case 1: Index by Direct Match (Auto-mapped)
-		// Key: "United States" -> Row(United States)
-		index.set(normalizedRowValue, row)
-
-		//case 2: Index by config mapping
-		// If this row is "usa" and config maps == "usa" -> "United States"
-		// we also want the key "United States" to point to this row
 		const mappedName = mappings[rawValue]
-		if (mappedName) {
-			index.set(titleCase(mappedName as string), row)
+		const normalizedMapped = mappedName ? titleCase(mappedName as string) : null
+
+		// Register under both the raw key and the mapped region key (if different)
+		const keysToUpdate = [normalizedRowValue]
+		if (normalizedMapped && normalizedMapped !== normalizedRowValue) {
+			keysToUpdate.push(normalizedMapped)
 		}
+
+		keysToUpdate.forEach((key) => {
+			let entry = index.get(key)
+			if (!entry) {
+				entry = { firstRow: row, rawValues: new Set<string>() }
+				index.set(key, entry)
+			}
+			entry.rawValues.add(rawValue)
+		})
 	})
 
-	return { index, reverseMap }
+	return index
 })
 
-function handleMapChartClick(params: any) {
+async function handleMapChartClick(params: any) {
 	if (!locationColumn.value) return null
 
 	const clickedLocation = params.name
 	const normalizedClick = titleCase(clickedLocation)
 
-	const { index, reverseMap } = locationRowIndex.value
-	// Lookup directly
-	let matchedRow = index.get(normalizedClick)
+	const entry = locationRowIndex.value.get(normalizedClick)
+	if (!entry || !entry.firstRow) return null
 
-	if (!matchedRow) {
-		const originalUserVal = reverseMap.get(normalizedClick)
-		if (originalUserVal) {
-			matchedRow = index.get(titleCase(originalUserVal))
+	// Build base drill-down query from firstRow (produces WHERE territory = 'territory')
+	const query = await props.chart.dataQuery.getDrillDownQuery(
+		locationColumn.value,
+		entry.firstRow,
+	)
+	if (!query) return null
+
+	// If multiple territories map to this region, upgrade = to IN
+	const matchingList = Array.from(entry.rawValues)
+	if (matchingList.length > 1) {
+		// Use the raw schema column name — this matches filter.column.column_name
+		// set by getFiltersForDimension(dim, value) via column(dim.column_name)
+		const schemaColName = mapConfig.value.location_column?.column_name
+		if (schemaColName) {
+			const operations = query.doc.operations || []
+			for (let i = operations.length - 1; i >= 0; i--) {
+				const op = operations[i]
+				if (op.type === 'filter_group' && op.filters) {
+					for (const filter of op.filters as any[]) {
+						if (
+							filter.column?.column_name === schemaColName &&
+							filter.operator === '='
+						) {
+							filter.operator = 'in'
+							filter.value = matchingList
+						}
+					}
+				}
+			}
 		}
 	}
 
-	if (!matchedRow) return null
-
-	return props.chart.dataQuery.getDrillDownQuery(locationColumn.value, matchedRow)
+	return query
 }
 
 function handleGeneralChartClick(params: any) {

--- a/frontend/src2/charts/components/RegionMappingDialog.vue
+++ b/frontend/src2/charts/components/RegionMappingDialog.vue
@@ -160,26 +160,22 @@ const manualMappings = computed(() => {
 	}))
 })
 
-const usedRegions = computed(() => new Set(Object.values(localMappings.value)))
-
 function getOptions(region: Region) {
 	const available = data.value?.available_regions || []
 	const options: Array<{ label: string; value: string }> = []
 
 	// Add suggestions first
 	region.suggestions?.forEach((s) => {
-		if (!usedRegions.value.has(s.region)) {
-			options.push({
-				label: `${s.region} (${Math.round(s.similarity * 100)}% match)`,
-				value: s.region,
-			})
-		}
+		options.push({
+			label: `${s.region} (${Math.round(s.similarity * 100)}% match)`,
+			value: s.region,
+		})
 	})
 
 	// Add remaining available regions
 	const suggested = new Set(region.suggestions?.map((s) => s.region) || [])
 	available.forEach((r) => {
-		if (!suggested.has(r) && !usedRegions.value.has(r)) {
+		if (!suggested.has(r)) {
 			options.push({ label: r, value: r })
 		}
 	})


### PR DESCRIPTION
## Overview

Resolves an issue where users could only map a single territory to a target region on Map charts (e.g., mapping `South India -> India` blocked mapping `North India -> India` or `West India -> India`). Previously, mapping multiple territories resulted in region selection disappearing from the UI, and the map click index overwritten previous mappings so drill-down only queried the last-mapped territory (`WHERE territory = 'West India'`). 

This PR removes the 1-to-1 UI restriction and updates the map chart indexing engine (`locationRowIndex`) to accumulate all matching raw values. When a map polygon with multiple mapped territories is clicked, the drill-down query dynamically upgrades the exact-match (`=`) filter to an `in` filter matching against the raw schema column name (`WHERE territory IN ('South India', 'North India', 'West India')`).

## Key Changes

- **CHARTS (`RegionMappingDialog.vue`)**: Removed `usedRegions` restriction in `getOptions()` so users can select and map multiple dataset locations/territories to the same target map region.
- **CHARTS (`ChartRenderer.vue`)**: Updated `locationRowIndex` from single-row overwriting to storing `{ firstRow, rawValues: Set<string> }` per map region. Updated `handleMapChartClick` to upgrade the drill-down query's dimension filter from `=` to `in` using the stable schema column (`mapConfig.location_column.column_name`) when multiple raw values resolve to the clicked map region.

Closes #1085