### PR TITLE
feat(query): add json_value and null_if, fix json_extract

### DIFF
--- a/insights/insights/doctype/insights_data_source_v3/ibis/functions.py
+++ b/insights/insights/doctype/insights_data_source_v3/ibis/functions.py
@@ -566,6 +566,81 @@ def textsplit(column: ir.StringColumn, delimiter: str, max_splits: int):
     return query
 
 
+JSON_VALUE_TYPES = {
+    "string": "string",
+    "text": "string",
+    "int": "int64",
+    "integer": "int64",
+    "float": "float64",
+    "decimal": "float64",
+    "number": "float64",
+    "bool": "boolean",
+    "boolean": "boolean",
+    "date": "date",
+    "datetime": "timestamp",
+    "timestamp": "timestamp",
+}
+
+
+def _json_text(column: ir.StringColumn, path: str):
+    """Walk a dotted `path` into a JSON string column and return it as text.
+
+    Returns SQL NULL for both a missing key and an explicit JSON ``null`` — casting
+    JSON to string otherwise yields the literal text ``'null'``, which silently
+    poisons comparisons and type inference. Numeric path segments index arrays.
+    """
+    value = normalize_json(column).cast("json")
+    for segment in str(path).split("."):
+        if not segment:
+            continue
+        value = value[int(segment)] if segment.lstrip("-").isdigit() else value[segment]
+
+    text = value.cast("string")
+    # strip the quotes JSON puts around string values
+    text = ibis.cases(
+        (
+            text.startswith('"') & text.endswith('"'),
+            text.substr(1, text.length() - 2),
+        ),
+        (text.startswith('"'), text.substr(1)),
+        (text.endswith('"'), text.substr(0, text.length() - 1)),
+        else_=text,
+    )
+    return (text == "null").ifelse(ibis.null(), text)
+
+
+def json_value(column: ir.StringColumn, path: str, type: str = "string"):
+    """
+    def json_value(column, path, type='string')
+
+    Read a single value out of a JSON column as a regular column.
+
+    Unlike json_extract, this returns a value you can use anywhere — inside filters,
+    summaries or other expressions — and you say what the type is instead of it being
+    guessed. A missing key or a JSON null gives an empty value. Use dots to reach
+    nested keys, and numbers to pick out of a list.
+
+    Types: string, int, float, bool, date, timestamp
+
+    Examples:
+    - json_value(properties, 'product')
+    - json_value(properties, 'address.city')
+    - json_value(properties, 'items.0.name')
+    - json_value(payload, 'amount', 'float')
+    - json_value(payload, 'signed_up_at', 'timestamp')
+    """
+    text = _json_text(column, path)
+
+    target = JSON_VALUE_TYPES.get(str(type).lower())
+    if target is None:
+        frappe.throw(
+            f"Invalid type '{type}' for json_value. Valid types: {', '.join(sorted(set(JSON_VALUE_TYPES)))}"
+        )
+
+    # try_cast so a stray malformed value becomes empty instead of failing the query
+    return text if target == "string" else text.try_cast(target)
+
+
 def json_extract(column: ir.StringColumn, *field_names: str):
     """
     def json_extract(column, *field_names)
@@ -580,23 +655,7 @@ def json_extract(column: ir.StringColumn, *field_names: str):
     if query is None:
         return column  # return original column if query is not found
 
-    json_column = normalize_json(column).cast("json")
-
-    # cast JSON values to string and remove quotes
-    clean_columns = {}
-    for field in field_names:
-        clean_col = json_column[field].cast("string")
-        # manually remove quotes for better compatibility
-        clean_col = ibis.cases(
-            (
-                clean_col.startswith('"') & clean_col.endswith('"'),
-                clean_col.substr(1, clean_col.length() - 2),
-            ),
-            (clean_col.startswith('"'), clean_col.substr(1)),
-            (clean_col.endswith('"'), clean_col.substr(0, clean_col.length() - 1)),
-            else_=clean_col,
-        )
-        clean_columns[field] = clean_col
+    clean_columns = {field: _json_text(column, field) for field in field_names}
 
     data = query.select(**clean_columns).limit(50).execute()
 
@@ -605,8 +664,12 @@ def json_extract(column: ir.StringColumn, *field_names: str):
         values = data[field].tolist()
 
         if values:
+            # infer_type_from_list speaks Frappe's type names ("Integer"), which ibis
+            # cannot coerce — translate before casting
             inferred_type = infer_type_from_list(values)
-            clean_col = clean_col.try_cast(inferred_type)
+            target = JSON_VALUE_TYPES.get(str(inferred_type).lower(), "string")
+            if target != "string":
+                clean_col = clean_col.try_cast(target)
 
         query = query.mutate({field: clean_col})
 
@@ -995,6 +1058,23 @@ def if_null(column, value):
     - if_null(email, 'No Email')
     """
     return ibis.coalesce(column, value)
+
+
+def null_if(column, value):
+    """
+    def null_if(column, value)
+
+    Treat a placeholder value as empty.
+
+    Useful when a source writes something like an empty string or 'undefined'
+    instead of leaving the value blank, which would otherwise be counted as a
+    real value.
+
+    Examples:
+    - null_if(team, '')
+    - null_if(city, 'undefined')
+    """
+    return (column == value).ifelse(ibis.null(), column)
 
 
 def asc(column):

--- a/insights/insights/doctype/insights_data_source_v3/test_json_functions.py
+++ b/insights/insights/doctype/insights_data_source_v3/test_json_functions.py
@@ -1,0 +1,59 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
+# See license.txt
+
+import unittest
+
+import ibis
+
+from insights.insights.doctype.insights_data_source_v3.ibis.functions import (
+    json_value,
+    null_if,
+)
+
+ROWS = [
+    # pretty-printed, the shape Pulse writes
+    '{\n "product": "erpnext",\n "site": "a.frappe.cloud"\n}',
+    # an explicit null, and a nested object
+    '{"product": null, "amount": "12.5", "ok": true, "address": {"city": "Pune"}, "items": [{"n": "first"}]}',
+]
+
+
+class TestJsonFunctions(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.con = ibis.duckdb.connect()
+        cls.table = cls.con.create_table("json_fixture", ibis.memtable({"p": ROWS, "team": ["abc", ""]}))
+
+    def _values(self, expr):
+        return self.table.select(v=expr).to_pandas()["v"].tolist()
+
+    def test_reads_a_key_from_pretty_printed_json(self):
+        self.assertEqual(self._values(json_value(self.table.p, "product"))[0], "erpnext")
+
+    def test_explicit_json_null_becomes_empty_not_the_text_null(self):
+        # casting JSON to string otherwise yields the literal 'null', which then
+        # counts as a real value in filters and group-bys
+        self.assertIsNone(self._values(json_value(self.table.p, "product"))[1])
+
+    def test_missing_key_is_empty(self):
+        self.assertEqual(self._values(json_value(self.table.p, "nope")), [None, None])
+
+    def test_reads_nested_keys_and_list_positions(self):
+        self.assertEqual(self._values(json_value(self.table.p, "address.city"))[1], "Pune")
+        self.assertEqual(self._values(json_value(self.table.p, "items.0.n"))[1], "first")
+
+    def test_returns_a_typed_value(self):
+        self.assertEqual(self._values(json_value(self.table.p, "amount", "float"))[1], 12.5)
+        self.assertTrue(self._values(json_value(self.table.p, "ok", "bool"))[1])
+
+    def test_composes_inside_a_filter(self):
+        # the point of json_value over json_extract: it is a value, not a query
+        matched = self.table.filter(json_value(self.table.p, "product") == "erpnext")
+        self.assertEqual(matched.count().to_pandas(), 1)
+
+    def test_rejects_an_unknown_type(self):
+        with self.assertRaises(Exception):
+            json_value(self.table.p, "amount", "monetary")
+
+    def test_null_if_blanks_a_placeholder_value(self):
+        self.assertEqual(self._values(null_if(self.table.team, "")), ["abc", None])


### PR DESCRIPTION
Reading a value out of a JSON column was only possible with json_extract,
which is not a value at all — it rewrites the whole query, so it cannot be
used inside a filter, a summary, or another expression. It also guesses the
type by running a hidden 50-row query first.

`json_value(column, path, type)` is the plain version: it returns a column you
can use anywhere, you say what the type is, and dotted paths reach nested
keys and list positions.

Two fixes to json_extract along the way, both of which it shares with the new
function:

- A JSON null came back as the text 'null', so blank values counted as real
  ones in filters and group-bys. Now empty.
- The guessed type was never applied — infer_type_from_list returns Frappe's
  names ("Integer") and ibis rejects them, so any column that wasn't text
  failed to build. Numbers and dates now cast as intended.

`null_if(column, value)` is the counterpart to the existing if_null, for
sources that write '' or 'undefined' instead of leaving a value blank.
