### PR TITLE
fix: name workbooks with strings instead of autoincrement

### DIFF
--- a/insights/api/workbooks.py
+++ b/insights/api/workbooks.py
@@ -51,15 +51,14 @@ def get_workbooks(
         fields=["reference_name", "name"],
     )
     for workbook in workbooks:
-        views = [view for view in workbook_views if str(view["reference_name"]) == str(workbook["name"])]
+        views = [view for view in workbook_views if view["reference_name"] == workbook["name"]]
         workbook["views"] = len(views)
 
     # batch the share lookups into two grouped queries instead of ~2 per
     # workbook (avoids an N+1 over the whole list)
     org_shared, shared_users = _workbook_shares(workbook_names)
     for workbook in workbooks:
-        # share_name is stored as a string; workbook name may be an int — cast to match
-        name = str(workbook["name"])
+        name = workbook["name"]
         if name in org_shared:
             workbook["shared_with_organization"] = True
             continue
@@ -72,14 +71,12 @@ def _workbook_shares(names: list[str]) -> tuple[set, dict]:
     """Return (org-shared workbook names, {workbook name -> [users it's read-shared with]}).
 
     Two queries for the whole list instead of an exists-check + fetch per workbook.
-    Keys are stringified since DocShare.share_name is stored as a string.
     """
     if not names:
         return set(), {}
 
-    org_shared = {
-        str(name)
-        for name in frappe.get_all(
+    org_shared = set(
+        frappe.get_all(
             "DocShare",
             filters={
                 "share_doctype": "Insights Workbook",
@@ -89,7 +86,7 @@ def _workbook_shares(names: list[str]) -> tuple[set, dict]:
             },
             pluck="share_name",
         )
-    }
+    )
 
     shared_users: dict[str, list] = {}
     rows = frappe.get_all(
@@ -102,7 +99,7 @@ def _workbook_shares(names: list[str]) -> tuple[set, dict]:
         fields=["share_name", "user"],
     )
     for row in rows:
-        shared_users.setdefault(str(row["share_name"]), []).append(row["user"])
+        shared_users.setdefault(row["share_name"], []).append(row["user"])
 
     return org_shared, shared_users
 

--- a/insights/insights/doctype/insights_chart_v3/insights_chart_v3.py
+++ b/insights/insights/doctype/insights_chart_v3/insights_chart_v3.py
@@ -131,7 +131,7 @@ def import_chart(chart, workbook):
         new_chart.sort_order = max_sort_order + 1
     new_chart.insert()
 
-    if str(workbook) == str(chart.doc.workbook) or not chart.dependencies.queries:
+    if workbook == chart.doc.workbook or not chart.dependencies.queries:
         return new_chart.name
 
     for _, exported_query in chart.dependencies.queries.items():

--- a/insights/insights/doctype/insights_query_v3/insights_query_v3.py
+++ b/insights/insights/doctype/insights_query_v3/insights_query_v3.py
@@ -426,7 +426,7 @@ def import_query(query, workbook):
         new_query.sort_order = max_sort_order + 1
     new_query.insert()
 
-    if str(workbook) == str(query.doc.workbook) or not query.dependencies.queries:
+    if workbook == query.doc.workbook or not query.dependencies.queries:
         return new_query.name
 
     # if query is copied to a new workbook, all the dependencies will be copied as well

--- a/insights/insights/doctype/insights_workbook/insights_workbook.json
+++ b/insights/insights/doctype/insights_workbook/insights_workbook.json
@@ -1,6 +1,5 @@
 {
  "actions": [],
- "autoname": "autoincrement",
  "creation": "2024-05-28 11:49:18.335351",
  "doctype": "DocType",
  "engine": "InnoDB",
@@ -63,11 +62,10 @@
    "link_fieldname": "workbook"
   }
  ],
- "modified": "2025-04-11 17:26:45.109680",
+ "modified": "2026-08-06 10:12:33.482915",
  "modified_by": "Administrator",
  "module": "Insights",
  "name": "Insights Workbook",
- "naming_rule": "Autoincrement",
  "owner": "Administrator",
  "permissions": [
   {

--- a/insights/insights/doctype/insights_workbook/insights_workbook.py
+++ b/insights/insights/doctype/insights_workbook/insights_workbook.py
@@ -7,11 +7,16 @@ from contextlib import suppress
 import frappe
 import frappe.utils
 from frappe.model.document import Document
+from frappe.model.naming import getseries
 from frappe.query_builder import Interval
 from frappe.query_builder.functions import Now
 from frappe.utils.telemetry import capture
 
 from insights.utils import deep_convert_dict_to_dict
+
+# `tabSeries` key the workbook counter lives under. The patch that moved this doctype
+# off `autoincrement` seeds the same key, so the two must not drift.
+WORKBOOK_SERIES_KEY = "Insights Workbook"
 
 
 class InsightsWorkbook(Document):
@@ -27,12 +32,17 @@ class InsightsWorkbook(Document):
         from_template: DF.Data | None
         imported_checksum: DF.Data | None
         imported_version: DF.Int
-        name: DF.Int | None
         title: DF.Data
     # end: auto-generated types
 
+    def autoname(self):
+        # plain numbers, carrying on from where `autoincrement` left off. The name has to
+        # be a string: every column that references a workbook is varchar, and postgres
+        # refuses to compare those against an integer name.
+        self.name = getseries(WORKBOOK_SERIES_KEY, 1)
+
     def before_save(self):
-        self.title = self.title or f"Workbook {frappe.utils.cint(self.name)}"
+        self.title = self.title or f"Workbook {self.name}"
 
     def on_trash(self):
         try:

--- a/insights/insights/doctype/insights_workbook/insights_workbook.py
+++ b/insights/insights/doctype/insights_workbook/insights_workbook.py
@@ -14,8 +14,7 @@ from frappe.utils.telemetry import capture
 
 from insights.utils import deep_convert_dict_to_dict
 
-# `tabSeries` key the workbook counter lives under. The patch that moved this doctype
-# off `autoincrement` seeds the same key, so the two must not drift.
+# `tabSeries` key the workbook counter lives under.
 WORKBOOK_SERIES_KEY = "Insights Workbook"
 
 

--- a/insights/insights/doctype/insights_workbook/insights_workbook.py
+++ b/insights/insights/doctype/insights_workbook/insights_workbook.py
@@ -36,9 +36,8 @@ class InsightsWorkbook(Document):
     # end: auto-generated types
 
     def autoname(self):
-        # plain numbers, carrying on from where `autoincrement` left off. The name has to
-        # be a string: every column that references a workbook is varchar, and postgres
-        # refuses to compare those against an integer name.
+        # plain numbers, carrying on from where `autoincrement` left off — see
+        # insights/patches/name_workbooks_as_strings.py for why this needs to be a string.
         self.name = getseries(WORKBOOK_SERIES_KEY, 1)
 
     def before_save(self):

--- a/insights/patches.txt
+++ b/insights/patches.txt
@@ -1,5 +1,6 @@
 [pre_model_sync]
 insights.patches.check_legacy_v2_data_before_upgrade #2
+insights.patches.name_workbooks_as_strings
 insights.patches.normalize_workbook #6
 
 [post_model_sync]

--- a/insights/patches/name_workbooks_as_strings.py
+++ b/insights/patches/name_workbooks_as_strings.py
@@ -1,0 +1,78 @@
+import frappe
+from frappe.core.doctype.doctype.doctype import change_name_column_type
+from frappe.utils import cint
+
+from insights.insights.doctype.insights_workbook.insights_workbook import WORKBOOK_SERIES_KEY
+
+SEQUENCE_NAME = frappe.scrub(f"{WORKBOOK_SERIES_KEY}_id_seq")
+
+
+def execute():
+    """
+    `Insights Workbook` used to be named by `autoincrement`, which makes `name` a bigint.
+    Every column that references a workbook is varchar(140) though — the four `workbook`
+    Link fields, `View Log.reference_name` and `DocShare.share_name` — and postgres refuses
+    `character varying = integer`, so listing or sharing a workbook failed outright
+    (frappe/insights#1193).
+
+    The doctype now names itself from `tabSeries`, which keeps the plain numbers but stores
+    them as strings. This patch converts the column and hands the counter over.
+
+    It has to run pre-model-sync: `validate_autoincrement_autoname` refuses to move a
+    doctype that already holds data off `autoincrement`, so the DocType record must already
+    say so before the new JSON is imported.
+    """
+    if not frappe.db.table_exists("Insights Workbook"):
+        return
+
+    if "bigint" not in str(frappe.db.get_column_type("Insights Workbook", "name")).lower():
+        return
+
+    # read the counter while the column is still numeric
+    last_id = frappe.db.sql("select max(name) from `tabInsights Workbook`")[0][0]
+
+    # the JSON that lands right after this patch no longer carries `autoname`; the DocType
+    # record has to agree with it already, or the import throws
+    frappe.db.set_value(
+        "DocType",
+        "Insights Workbook",
+        {"autoname": "", "naming_rule": ""},
+        update_modified=False,
+    )
+    frappe.clear_cache(doctype="Insights Workbook")
+
+    change_name_column_type("Insights Workbook", f"varchar({frappe.db.VARCHAR_LEN})")
+    drop_sequence()
+    seed_series(last_id)
+
+
+def drop_sequence():
+    """The sequence the old naming rule drew from. Nothing recreates it: the framework only
+    maintains sequences for doctypes still marked `autoincrement`."""
+    if frappe.db.db_type == "sqlite":
+        # emulated in a bookkeeping table rather than a real sequence object
+        return
+
+    frappe.db.sql_ddl(f"drop sequence if exists {SEQUENCE_NAME}")
+
+
+def seed_series(last_id):
+    """Point `tabSeries` at the last id handed out, so the first name the new `autoname`
+    produces is the one the sequence would have produced.
+
+    Nothing to do for an empty table — a fresh series starts at 1 on its own.
+    """
+    if not last_id:
+        return
+
+    current = frappe.db.sql("select current from `tabSeries` where name = %s", (WORKBOOK_SERIES_KEY,))
+    if not current:
+        frappe.db.sql(
+            "insert into `tabSeries` (name, current) values (%s, %s)",
+            (WORKBOOK_SERIES_KEY, last_id),
+        )
+    elif cint(current[0][0]) < last_id:
+        frappe.db.sql(
+            "update `tabSeries` set current = %s where name = %s",
+            (last_id, WORKBOOK_SERIES_KEY),
+        )

--- a/insights/patches/name_workbooks_as_strings.py
+++ b/insights/patches/name_workbooks_as_strings.py
@@ -48,10 +48,6 @@ def execute():
 def drop_sequence():
     """The sequence the old naming rule drew from. Nothing recreates it: the framework only
     maintains sequences for doctypes still marked `autoincrement`."""
-    if frappe.db.db_type == "sqlite":
-        # emulated in a bookkeeping table rather than a real sequence object
-        return
-
     frappe.db.sql_ddl(f"drop sequence if exists {SEQUENCE_NAME}")
 
 

--- a/insights/patches/name_workbooks_as_strings.py
+++ b/insights/patches/name_workbooks_as_strings.py
@@ -1,5 +1,4 @@
 import frappe
-from frappe.core.doctype.doctype.doctype import change_name_column_type
 from frappe.utils import cint
 
 from insights.insights.doctype.insights_workbook.insights_workbook import WORKBOOK_SERIES_KEY
@@ -41,7 +40,7 @@ def execute():
     )
     frappe.clear_cache(doctype="Insights Workbook")
 
-    change_name_column_type("Insights Workbook", f"varchar({frappe.db.VARCHAR_LEN})")
+    frappe.get_doc("DocType", "Insights Workbook").setup_autoincrement_and_sequence()
     drop_sequence()
     seed_series(last_id)
 

--- a/insights/tests/test_workbook_templates.py
+++ b/insights/tests/test_workbook_templates.py
@@ -166,9 +166,7 @@ class TestWorkbookTemplates(InsightsIntegrationTestCase):
 
         self.assert_visible_to(USER_2, "Insights Workbook", workbook_name)
         with self.as_user(USER_2):
-            self.assertFalse(
-                frappe.has_permission("Insights Workbook", ptype="write", doc=workbook_name)
-            )
+            self.assertFalse(frappe.has_permission("Insights Workbook", ptype="write", doc=workbook_name))
 
     def test_double_import_returns_existing_without_duplicating(self):
         with self.as_user(ADMIN_USER), installed_apps(APPS_WITH_ERPNEXT):

--- a/insights/tests/test_workbook_templates.py
+++ b/insights/tests/test_workbook_templates.py
@@ -152,7 +152,7 @@ class TestWorkbookTemplates(InsightsIntegrationTestCase):
         # implicit organization: view share — everyone read, no write
         share = frappe.db.get_value(
             "DocShare",
-            {"share_doctype": "Insights Workbook", "share_name": str(workbook_name), "everyone": 1},
+            {"share_doctype": "Insights Workbook", "share_name": workbook_name, "everyone": 1},
             ["read", "write"],
             as_dict=True,
         )
@@ -167,7 +167,7 @@ class TestWorkbookTemplates(InsightsIntegrationTestCase):
         self.assert_visible_to(USER_2, "Insights Workbook", workbook_name)
         with self.as_user(USER_2):
             self.assertFalse(
-                frappe.has_permission("Insights Workbook", ptype="write", doc=str(workbook_name))
+                frappe.has_permission("Insights Workbook", ptype="write", doc=workbook_name)
             )
 
     def test_double_import_returns_existing_without_duplicating(self):

--- a/insights/tests/workbook/test_workbook_naming.py
+++ b/insights/tests/workbook/test_workbook_naming.py
@@ -1,9 +1,5 @@
-"""Guards frappe/insights#1193.
-
-`Insights Workbook` used to be named by `autoincrement`, which made `name` a bigint while
-every column referencing it stayed varchar(140). Postgres refuses to compare the two, so
-listing and sharing workbooks broke. The doctype now names itself from `tabSeries`: the
-names are still plain numbers, but they are strings, and nothing has to cast them.
+"""Guards frappe/insights#1193 — see insights/patches/name_workbooks_as_strings.py for
+why `Insights Workbook` now names itself as a string instead of via `autoincrement`.
 """
 
 import frappe

--- a/insights/tests/workbook/test_workbook_naming.py
+++ b/insights/tests/workbook/test_workbook_naming.py
@@ -1,0 +1,69 @@
+"""Guards frappe/insights#1193.
+
+`Insights Workbook` used to be named by `autoincrement`, which made `name` a bigint while
+every column referencing it stayed varchar(140). Postgres refuses to compare the two, so
+listing and sharing workbooks broke. The doctype now names itself from `tabSeries`: the
+names are still plain numbers, but they are strings, and nothing has to cast them.
+"""
+
+import frappe
+
+from insights.tests.base import InsightsIntegrationTestCase
+from insights.tests.factories import DT, USER_1, create_test_user, create_test_workbook, delete_users
+from insights.tests.workbook_utils import cleanup_test_workbooks
+
+
+class TestWorkbookNaming(InsightsIntegrationTestCase):
+    COMMIT_AFTER_TEST_SETUP = True
+    COMMIT_AFTER_TEST_TEARDOWN = True
+
+    @classmethod
+    def before_class(cls):
+        cleanup_test_workbooks(USER_1)
+        delete_users(USER_1)
+        create_test_user(USER_1)
+
+    @classmethod
+    def after_class(cls):
+        cleanup_test_workbooks(USER_1)
+        delete_users(USER_1)
+
+    def after_test(self):
+        cleanup_test_workbooks(USER_1)
+
+    def test_name_column_is_varchar(self):
+        # the migration this doctype went through; an unmigrated site fails here first.
+        # mariadb reports "varchar(140)", postgres "character varying"
+        column_type = str(frappe.db.get_column_type(DT.WORKBOOK, "name")).lower()
+        self.assertIn("char", column_type, f"expected a varchar name column, got {column_type!r}")
+
+    def test_workbook_is_named_with_a_number_as_a_string(self):
+        workbook = create_test_workbook(USER_1)
+
+        self.assertIsInstance(workbook.name, str)
+        self.assertTrue(workbook.name.isdigit(), f"expected a plain number, got {workbook.name!r}")
+
+    def test_names_keep_counting_up(self):
+        first = create_test_workbook(USER_1, title="Naming Test One")
+        second = create_test_workbook(USER_1, title="Naming Test Two")
+
+        self.assertEqual(int(second.name), int(first.name) + 1)
+
+    def test_children_are_found_without_casting_the_name(self):
+        workbook = create_test_workbook(USER_1)
+        folder = frappe.get_doc(
+            {
+                "doctype": "Insights Folder",
+                "workbook": workbook.name,
+                "title": "Naming Test Folder",
+                "type": "query",
+            }
+        ).insert()
+
+        # the link column and the name are both varchar now, so this needs no cast on
+        # either side — which is the whole point of the migration
+        self.assertEqual(
+            frappe.get_all("Insights Folder", filters={"workbook": workbook.name}, pluck="name"),
+            [folder.name],
+        )
+        self.assertEqual(folder.workbook, workbook.name)


### PR DESCRIPTION
`Insights Workbook` was named by `autoincrement`, making `name` a bigint, while every column that references it is varchar(140): `View Log.reference_name`, `DocShare.share_name` (Dynamic Link), and the four `workbook` Link fields. Postgres refuses `character varying = integer`, so listing or sharing a workbook failed outright.

The doctype now names itself from `tabSeries` (`autoname`), so `name` is a string from creation — no casting needed anywhere it's compared or joined. A `pre_model_sync` patch (`name_workbooks_as_strings`) converts the column on existing sites and hands the counter over from the old sequence.

Fixes #1193