### PR TITLE
fix: only qualify postgres table names when schemas can collide

### DIFF
--- a/insights/insights/doctype/insights_data_source_v3/connectors/frappe_db.py
+++ b/insights/insights/doctype/insights_data_source_v3/connectors/frappe_db.py
@@ -126,13 +126,9 @@ def get_frappedb_table_links(data_source):
     standard_links = standard_links.to_dict(orient="records")
     custom_links = custom_links.to_dict(orient="records")
 
-    # links must name tables exactly as `Insights Table v3` stores them, which on a postgres
-    # source spanning several schemas means qualifying them with the schema holding the
-    # frappe tables (the first one configured).
-    prefix = f"{data_source.get_postgres_schemas()[0]}." if data_source.qualify_table_names() else ""
-
+    # links must name tables exactly as `Insights Table v3` stores them, or they never match
     def table_name(doctype):
-        return f"{prefix}tab{doctype}"
+        return data_source.format_table_name(f"tab{doctype}")
 
     all_links = []
     for link_row in standard_links + custom_links:

--- a/insights/insights/doctype/insights_data_source_v3/connectors/frappe_db.py
+++ b/insights/insights/doctype/insights_data_source_v3/connectors/frappe_db.py
@@ -126,6 +126,14 @@ def get_frappedb_table_links(data_source):
     standard_links = standard_links.to_dict(orient="records")
     custom_links = custom_links.to_dict(orient="records")
 
+    # links must name tables exactly as `Insights Table v3` stores them, which on a postgres
+    # source spanning several schemas means qualifying them with the schema holding the
+    # frappe tables (the first one configured).
+    prefix = f"{data_source.get_postgres_schemas()[0]}." if data_source.qualify_table_names() else ""
+
+    def table_name(doctype):
+        return f"{prefix}tab{doctype}"
+
     all_links = []
     for link_row in standard_links + custom_links:
         link = _dict(link_row)
@@ -133,9 +141,9 @@ def get_frappedb_table_links(data_source):
             all_links.append(
                 _dict(
                     {
-                        "left_table": "tab" + link.options,
+                        "left_table": table_name(link.options),
                         "left_column": "name",
-                        "right_table": "tab" + link.parent,
+                        "right_table": table_name(link.parent),
                         "right_column": link.fieldname,
                     }
                 )
@@ -144,9 +152,9 @@ def get_frappedb_table_links(data_source):
             all_links.append(
                 _dict(
                     {
-                        "left_table": "tab" + link.parent,
+                        "left_table": table_name(link.parent),
                         "left_column": "name",
-                        "right_table": "tab" + link.options,
+                        "right_table": table_name(link.options),
                         "right_column": "parent",
                     }
                 )

--- a/insights/insights/doctype/insights_data_source_v3/insights_data_source_v3.py
+++ b/insights/insights/doctype/insights_data_source_v3/insights_data_source_v3.py
@@ -330,6 +330,32 @@ class InsightsDataSourcev3(InsightsDataSourceDocument, Document):
 
         frappe.throw(f"Unsupported database type: {self.database_type}")
 
+    def get_postgres_schemas(self) -> list[str]:
+        """Schemas this data source reads from, as a comma separated list in `schema`."""
+        schemas = [s.strip() for s in (self.schema or "").split(",") if s.strip()]
+        return schemas or ["public"]
+
+    def qualify_table_names(self) -> bool:
+        """Whether table names should carry a `<schema>.` prefix.
+
+        Only useful when the data source spans more than one schema — with a single schema
+        there is nothing to disambiguate and the prefix just leaks into the UI and breaks the
+        table -> doctype mapping for frappe databases (frappe/insights#1195).
+        """
+        return self.database_type == "PostgreSQL" and len(self.get_postgres_schemas()) > 1
+
+    def split_table_name(self, table_name: str) -> tuple[str, str]:
+        """Resolve `(schema, table)` for a postgres table name.
+
+        Names are only qualified when the data source spans multiple schemas, but names
+        stored before that was the case may still carry the prefix — so accept both.
+        """
+        schemas = self.get_postgres_schemas()
+        schema, separator, table = table_name.partition(".")
+        if separator and schema in schemas:
+            return schema, table
+        return schemas[0], table_name
+
     def get_table_list(self):
         db = self._get_ibis_backend()
 
@@ -344,12 +370,12 @@ class InsightsDataSourcev3(InsightsDataSourceDocument, Document):
             return db.list_tables(database=self.schema)
 
         if self.database_type == "PostgreSQL":
-            schema = self.schema or "public"
-            schemas = schema.split(",")
+            qualify = self.qualify_table_names()
             tables = []
-            for schema in schemas:
+            for schema in self.get_postgres_schemas():
                 schema_tables = db.list_tables(database=(database_name, schema))
-                schema_tables = [f"{schema}.{table}" for table in schema_tables]
+                if qualify:
+                    schema_tables = [f"{schema}.{table}" for table in schema_tables]
                 tables.extend(schema_tables)
             return tables
 
@@ -440,8 +466,8 @@ class InsightsDataSourcev3(InsightsDataSourceDocument, Document):
 
     def get_ibis_table(self, table_name):
         remote_db = self._get_ibis_backend()
-        if self.database_type == "PostgreSQL" and "." in table_name:
-            schema, table = table_name.split(".")
+        if self.database_type == "PostgreSQL":
+            schema, table = self.split_table_name(table_name)
             return remote_db.table(table, database=schema)
         if self.type == "REST API":
             return remote_db.table(table_name, database=self.schema)

--- a/insights/insights/doctype/insights_data_source_v3/insights_data_source_v3.py
+++ b/insights/insights/doctype/insights_data_source_v3/insights_data_source_v3.py
@@ -344,8 +344,18 @@ class InsightsDataSourcev3(InsightsDataSourceDocument, Document):
         """
         return self.database_type == "PostgreSQL" and len(self.get_postgres_schemas()) > 1
 
+    def format_table_name(self, table: str, schema: str | None = None) -> str:
+        """Name `table` the way `get_table_list` does, so it matches `Insights Table v3`.
+
+        `schema` defaults to the first one configured, which is where a frappe database
+        keeps its tables.
+        """
+        if not self.qualify_table_names():
+            return table
+        return f"{schema or self.get_postgres_schemas()[0]}.{table}"
+
     def split_table_name(self, table_name: str) -> tuple[str, str]:
-        """Resolve `(schema, table)` for a postgres table name.
+        """Resolve `(schema, table)` for a postgres table name — inverse of `format_table_name`.
 
         Names are only qualified when the data source spans multiple schemas, but names
         stored before that was the case may still carry the prefix — so accept both.
@@ -370,13 +380,10 @@ class InsightsDataSourcev3(InsightsDataSourceDocument, Document):
             return db.list_tables(database=self.schema)
 
         if self.database_type == "PostgreSQL":
-            qualify = self.qualify_table_names()
             tables = []
             for schema in self.get_postgres_schemas():
                 schema_tables = db.list_tables(database=(database_name, schema))
-                if qualify:
-                    schema_tables = [f"{schema}.{table}" for table in schema_tables]
-                tables.extend(schema_tables)
+                tables.extend(self.format_table_name(table, schema) for table in schema_tables)
             return tables
 
         contains_special_chars = re.search(r"[^a-zA-Z0-9_]", database_name)

--- a/insights/insights/doctype/insights_table_v3/insights_table_v3.py
+++ b/insights/insights/doctype/insights_table_v3/insights_table_v3.py
@@ -284,6 +284,16 @@ def _get_referencing_queries(data_source: str, table_name: str) -> list[dict]:
     )
 
 
+def strip_schema_prefix(table_name: str) -> str:
+    """Drop the `<schema>.` prefix a postgres data source adds when it spans several schemas.
+
+    The frappe table -> doctype mapping below needs the bare `tab`-prefixed name, so
+    `public.tabUser` has to resolve to the `User` doctype and not blow up in `get_meta`.
+    """
+    _schema, separator, table = table_name.partition(".")
+    return table if separator and table.startswith("tab") else table_name
+
+
 def apply_user_permissions(t: Table, data_source, table_name):
     if frappe.flags.get("insights_for_public_access"):
         return t
@@ -293,6 +303,8 @@ def apply_user_permissions(t: Table, data_source, table_name):
 
     if not frappe.db.get_single_value("Insights Settings", "apply_user_permissions", cache=True):
         return t
+
+    table_name = strip_schema_prefix(table_name)
 
     if table_name == "tabSingles":
         single_doctypes = frappe.get_all("DocType", filters={"issingle": 1}, pluck="name")

--- a/insights/insights/doctype/insights_table_v3/insights_table_v3.py
+++ b/insights/insights/doctype/insights_table_v3/insights_table_v3.py
@@ -285,10 +285,12 @@ def _get_referencing_queries(data_source: str, table_name: str) -> list[dict]:
 
 
 def strip_schema_prefix(table_name: str) -> str:
-    """Drop the `<schema>.` prefix a postgres data source adds when it spans several schemas.
+    """Drop the `<schema>.` prefix postgres table names used to always carry.
 
     The frappe table -> doctype mapping below needs the bare `tab`-prefixed name, so
     `public.tabUser` has to resolve to the `User` doctype and not blow up in `get_meta`.
+    Names are unqualified since frappe/insights#1195, but a source the patch couldn't
+    migrate still has to work.
     """
     _schema, separator, table = table_name.partition(".")
     return table if separator and table.startswith("tab") else table_name

--- a/insights/patches.txt
+++ b/insights/patches.txt
@@ -56,3 +56,4 @@ insights.patches.fix_table_link_names
 insights.patches.backfill_query_references
 execute:frappe.db.set_single_value("Insights Settings", "allow_download", 1)
 insights.patches.requalify_workbook_templates
+insights.patches.strip_default_schema_from_table_names

--- a/insights/patches/strip_default_schema_from_table_names.py
+++ b/insights/patches/strip_default_schema_from_table_names.py
@@ -1,5 +1,3 @@
-from contextlib import suppress
-
 import frappe
 
 import insights
@@ -23,7 +21,7 @@ def execute():
     sources = frappe.get_all(
         "Insights Data Source v3",
         filters={"database_type": "PostgreSQL"},
-        fields=["name", "schema", "is_frappe_db", "is_site_db"],
+        fields=["name", "schema"],
     )
 
     for source in sources:
@@ -47,10 +45,7 @@ def unqualify_source(source, prefix):
 
     update_queries(source.name, renames)
     update_query_references(source.name, renames)
-
-    if source.is_frappe_db or source.is_site_db:
-        with suppress(Exception):
-            frappe.get_doc("Insights Data Source v3", source.name).update_table_links(force=True)
+    update_table_links(source.name, renames)
 
 
 def rename_tables(data_source, prefix) -> dict[str, str]:
@@ -167,3 +162,24 @@ def update_query_references(data_source, renames):
             new_table,
             update_modified=False,
         )
+
+
+def update_table_links(data_source, renames):
+    """Rename the tables a link points at.
+
+    Links have always been generated from the bare doctype name ("tabUser"), which is why
+    they never matched a qualified table in the first place — renaming the tables is what
+    makes them line up again. This only has anything to do for links written while the
+    source still spanned several schemas. Rewriting them in place (rather than rebuilding
+    from the remote) keeps the migration offline: the database this source points at is
+    routinely unreachable while `bench migrate` runs.
+    """
+    for old_table, new_table in renames.items():
+        for field in ("left_table", "right_table"):
+            frappe.db.set_value(
+                "Insights Table Link v3",
+                {"data_source": data_source, field: old_table},
+                field,
+                new_table,
+                update_modified=False,
+            )

--- a/insights/patches/strip_default_schema_from_table_names.py
+++ b/insights/patches/strip_default_schema_from_table_names.py
@@ -63,10 +63,13 @@ def rename_tables(data_source, prefix) -> dict[str, str]:
 
         if frappe.db.exists("Insights Table v3", new_name):
             # an unqualified record already exists — drop the duplicate
-            frappe.delete_doc("Insights Table v3", row.name, force=True, ignore_permissions=True)
+            discard_table(data_source, row)
             renames[row.table] = new_table
             continue
 
+        # renaming by hand rather than through `frappe.rename_doc`: every referrer is
+        # rewritten below anyway, and this keeps the migration from touching the remote
+        # database, which is routinely unreachable while `bench migrate` runs.
         frappe.db.set_value(
             "Insights Table v3",
             row.name,
@@ -92,6 +95,22 @@ def rename_tables(data_source, prefix) -> dict[str, str]:
         renames[row.table] = new_table
 
     return renames
+
+
+def discard_table(data_source, row):
+    """Delete a qualified record whose unqualified counterpart already exists.
+
+    Deleting an `Insights Table v3` doesn't clean up after itself, so drop the imported
+    data and the permissions pointing at it here — the surviving record has its own.
+    """
+    if row.stored:
+        insights.warehouse.get_table(data_source, row.table).drop()
+
+    frappe.db.delete(
+        "Insights Resource Permission",
+        {"resource_type": "Insights Table v3", "resource_name": row.name},
+    )
+    frappe.delete_doc("Insights Table v3", row.name, force=True, ignore_permissions=True)
 
 
 def rename_warehouse_table(data_source, old_table, new_table) -> bool:
@@ -167,12 +186,9 @@ def update_query_references(data_source, renames):
 def update_table_links(data_source, renames):
     """Rename the tables a link points at.
 
-    Links have always been generated from the bare doctype name ("tabUser"), which is why
-    they never matched a qualified table in the first place — renaming the tables is what
-    makes them line up again. This only has anything to do for links written while the
-    source still spanned several schemas. Rewriting them in place (rather than rebuilding
-    from the remote) keeps the migration offline: the database this source points at is
-    routinely unreachable while `bench migrate` runs.
+    Links were always generated from the bare doctype name ("tabUser"), which is why they
+    never matched a qualified table to begin with — so this only has anything to do for
+    links written after the source stopped spanning several schemas.
     """
     for old_table, new_table in renames.items():
         for field in ("left_table", "right_table"):

--- a/insights/patches/strip_default_schema_from_table_names.py
+++ b/insights/patches/strip_default_schema_from_table_names.py
@@ -1,0 +1,169 @@
+from contextlib import suppress
+
+import frappe
+
+import insights
+from insights.insights.doctype.insights_data_source_v3.data_warehouse import (
+    get_warehouse_schema_name,
+)
+from insights.insights.doctype.insights_table_v3.insights_table_v3 import get_table_name
+
+
+def execute():
+    """
+    Postgres data sources used to qualify every table name with its schema
+    ("public.tabSales Invoice") even when only one schema was configured. The prefix
+    leaked into the UI and broke the table -> doctype mapping for frappe databases, so
+    executing any query against a postgres Site DB failed with a `DoesNotExistError`
+    (frappe/insights#1195).
+
+    Table names are now only qualified when the data source spans several schemas. This
+    patch strips the redundant prefix from everything that stored it.
+    """
+    sources = frappe.get_all(
+        "Insights Data Source v3",
+        filters={"database_type": "PostgreSQL"},
+        fields=["name", "schema", "is_frappe_db", "is_site_db"],
+    )
+
+    for source in sources:
+        schemas = [s.strip() for s in (source.schema or "").split(",") if s.strip()] or ["public"]
+        if len(schemas) > 1:
+            # names are still qualified for multi schema sources
+            continue
+
+        try:
+            unqualify_source(source, f"{schemas[0]}.")
+            frappe.db.commit()
+        except Exception:
+            frappe.db.rollback()
+            frappe.log_error(title=f"Failed to strip schema prefix for {source.name}")
+
+
+def unqualify_source(source, prefix):
+    renames = rename_tables(source.name, prefix)
+    if not renames:
+        return
+
+    update_queries(source.name, renames)
+    update_query_references(source.name, renames)
+
+    if source.is_frappe_db or source.is_site_db:
+        with suppress(Exception):
+            frappe.get_doc("Insights Data Source v3", source.name).update_table_links(force=True)
+
+
+def rename_tables(data_source, prefix) -> dict[str, str]:
+    """Strip `prefix` from the stored `Insights Table v3` records. Returns {old: new}."""
+    rows = frappe.get_all(
+        "Insights Table v3",
+        filters={"data_source": data_source, "table": ["like", f"{prefix}%"]},
+        fields=["name", "table", "label", "stored"],
+    )
+
+    renames = {}
+    for row in rows:
+        new_table = row.table[len(prefix) :]
+        new_name = get_table_name(data_source, new_table)
+
+        if frappe.db.exists("Insights Table v3", new_name):
+            # an unqualified record already exists — drop the duplicate
+            frappe.delete_doc("Insights Table v3", row.name, force=True, ignore_permissions=True)
+            renames[row.table] = new_table
+            continue
+
+        frappe.db.set_value(
+            "Insights Table v3",
+            row.name,
+            {
+                "name": new_name,
+                "table": new_table,
+                "label": row.label[len(prefix) :] if row.label.startswith(prefix) else row.label,
+            },
+            update_modified=False,
+        )
+        frappe.db.set_value(
+            "Insights Resource Permission",
+            {"resource_type": "Insights Table v3", "resource_name": row.name},
+            "resource_name",
+            new_name,
+            update_modified=False,
+        )
+
+        if row.stored and not rename_warehouse_table(data_source, row.table, new_table):
+            # the imported data can no longer be found under the new name — let it re-import
+            frappe.db.set_value("Insights Table v3", new_name, "stored", 0, update_modified=False)
+
+        renames[row.table] = new_table
+
+    return renames
+
+
+def rename_warehouse_table(data_source, old_table, new_table) -> bool:
+    old_name = frappe.scrub(old_table)
+    new_name = frappe.scrub(new_table)
+    schema = get_warehouse_schema_name(data_source)
+    try:
+        with insights.warehouse.get_write_connection(schema) as db:
+            db.raw_sql(f'ALTER TABLE "{old_name}" RENAME TO "{new_name}"')
+        return True
+    except Exception:
+        return False
+
+
+def update_queries(data_source, renames):
+    """Rewrite the table names referenced by the source/join/union operations of every query."""
+    queries = frappe.get_all(
+        "Insights Query v3",
+        filters={"operations": ["like", "%table_name%"]},
+        fields=["name", "operations"],
+    )
+
+    for query in queries:
+        operations = frappe.parse_json(query.operations)
+        if not operations:
+            continue
+
+        if not rewrite_table_names(operations, data_source, renames):
+            continue
+
+        frappe.db.set_value(
+            "Insights Query v3",
+            query.name,
+            "operations",
+            frappe.as_json(operations),
+            update_modified=False,
+        )
+
+
+def rewrite_table_names(node, data_source, renames) -> bool:
+    """Recursively rename every `{data_source, table_name}` reference. Returns True if changed."""
+    changed = False
+
+    if isinstance(node, list):
+        for item in node:
+            changed = rewrite_table_names(item, data_source, renames) or changed
+        return changed
+
+    if not isinstance(node, dict):
+        return False
+
+    if node.get("data_source") == data_source and node.get("table_name") in renames:
+        node["table_name"] = renames[node["table_name"]]
+        changed = True
+
+    for value in node.values():
+        changed = rewrite_table_names(value, data_source, renames) or changed
+
+    return changed
+
+
+def update_query_references(data_source, renames):
+    for old_table, new_table in renames.items():
+        frappe.db.set_value(
+            "Insights Query Reference",
+            {"data_source": data_source, "table_name": old_table},
+            "table_name",
+            new_table,
+            update_modified=False,
+        )

--- a/insights/tests/test_postgres_schema_prefix.py
+++ b/insights/tests/test_postgres_schema_prefix.py
@@ -12,8 +12,12 @@ stored before that must still resolve, which is what these tests pin down.
 from unittest.mock import patch
 
 import frappe
+import pandas as pd
 from frappe.tests.utils import FrappeTestCase
 
+from insights.insights.doctype.insights_data_source_v3.connectors.frappe_db import (
+    get_frappedb_table_links,
+)
 from insights.insights.doctype.insights_data_source_v3.insights_data_source_v3 import (
     InsightsDataSourcev3,
 )
@@ -39,6 +43,35 @@ class FakeBackend:
     def table(self, name, database=None):
         self.requested.append((name, database))
         return f"{database}.{name}"
+
+
+class FakeFieldTable:
+    """Stands in for an ibis table of docfields — every expression yields the same rows."""
+
+    def __init__(self, rows):
+        self.rows = rows
+
+    def select(self, *args, **kwargs):
+        return self
+
+    def filter(self, *args):
+        return self
+
+    def execute(self):
+        return pd.DataFrame(self.rows)
+
+
+class FakeFrappeBackend:
+    """Serves the two field tables `get_frappedb_table_links` reads."""
+
+    def __init__(self, docfields=(), custom_fields=()):
+        self.rows = {
+            "tabDocField": list(docfields),
+            "tabCustom Field": list(custom_fields),
+        }
+
+    def table(self, name, database=None):
+        return FakeFieldTable(self.rows[name])
 
 
 def make_data_source(schema=None):
@@ -125,3 +158,84 @@ class TestSchemaQualifiedDoctypeMapping(FrappeTestCase):
 
         self.assertIn("name", allowed)
         self.assertIn("email", allowed)
+
+
+DOCFIELDS = [
+    {
+        "fieldname": "customer",
+        "fieldtype": "Link",
+        "options": "Customer",
+        "parent": "Sales Invoice",
+    },
+    {
+        "fieldname": "items",
+        "fieldtype": "Table",
+        "options": "Sales Invoice Item",
+        "parent": "Sales Invoice",
+    },
+]
+CUSTOM_FIELDS = [
+    {
+        "fieldname": "sales_person",
+        "fieldtype": "Link",
+        "options": "Sales Person",
+        "parent": "Sales Invoice",
+    },
+]
+
+
+class TestFrappeDbTableLinks(FrappeTestCase):
+    """Links have to name their tables exactly as `Insights Table v3` stores them."""
+
+    def get_links(self, data_source):
+        backend = FakeFrappeBackend(DOCFIELDS, CUSTOM_FIELDS)
+        with patch.object(InsightsDataSourcev3, "_get_ibis_backend", return_value=backend):
+            return get_frappedb_table_links(data_source)
+
+    def test_links_are_unqualified_for_a_single_schema(self):
+        links = self.get_links(make_data_source())
+
+        self.assertEqual(
+            links,
+            [
+                {
+                    "left_table": "tabCustomer",
+                    "left_column": "name",
+                    "right_table": "tabSales Invoice",
+                    "right_column": "customer",
+                },
+                {
+                    "left_table": "tabSales Invoice",
+                    "left_column": "name",
+                    "right_table": "tabSales Invoice Item",
+                    "right_column": "parent",
+                },
+                {
+                    "left_table": "tabSales Person",
+                    "left_column": "name",
+                    "right_table": "tabSales Invoice",
+                    "right_column": "sales_person",
+                },
+            ],
+        )
+
+    def test_links_are_qualified_when_schemas_can_collide(self):
+        # tables are stored qualified here, so links that named `tabX` would never match
+        links = self.get_links(make_data_source(schema="public, sales"))
+
+        self.assertTrue(
+            all(
+                link[side].startswith("public.tab")
+                for link in links
+                for side in ("left_table", "right_table")
+            ),
+            links,
+        )
+
+    def test_mariadb_links_are_never_qualified(self):
+        data_source = make_data_source()
+        data_source.database_type = "MariaDB"
+
+        links = self.get_links(data_source)
+
+        self.assertEqual(links[0]["left_table"], "tabCustomer")

--- a/insights/tests/test_postgres_schema_prefix.py
+++ b/insights/tests/test_postgres_schema_prefix.py
@@ -1,0 +1,127 @@
+"""Guards against regressing frappe/insights#1195.
+
+Postgres table names used to be qualified with their schema unconditionally, so a Site DB
+running on postgres listed `public.tabSales Invoice` instead of `tabSales Invoice`. Besides
+leaking the prefix into every label, it broke the table -> doctype mapping used by user
+permissions, and executing any query failed with `DoesNotExistError`.
+
+Names are now only qualified when a data source actually spans several schemas — but names
+stored before that must still resolve, which is what these tests pin down.
+"""
+
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from insights.insights.doctype.insights_data_source_v3.insights_data_source_v3 import (
+    InsightsDataSourcev3,
+)
+from insights.insights.doctype.insights_table_v3.insights_table_v3 import (
+    get_permitted_columns_for_table,
+    strip_schema_prefix,
+)
+
+
+class FakeBackend:
+    """Stands in for the ibis backend, recording what it was asked for."""
+
+    def __init__(self, tables_by_schema=None):
+        self.tables_by_schema = tables_by_schema or {}
+        self.listed = []
+        self.requested = []
+
+    def list_tables(self, database=None, **kwargs):
+        self.listed.append(database)
+        _catalog, schema = database
+        return list(self.tables_by_schema.get(schema, []))
+
+    def table(self, name, database=None):
+        self.requested.append((name, database))
+        return f"{database}.{name}"
+
+
+def make_data_source(schema=None):
+    return frappe.get_doc(
+        {
+            "doctype": "Insights Data Source v3",
+            "title": "Postgres Prefix Test",
+            "database_type": "PostgreSQL",
+            "database_name": "test_db",
+            "schema": schema,
+        }
+    )
+
+
+class TestPostgresSchemaPrefix(FrappeTestCase):
+    def test_single_schema_tables_are_not_qualified(self):
+        backend = FakeBackend({"public": ["tabUser", "customers"]})
+        ds = make_data_source()
+
+        with patch.object(InsightsDataSourcev3, "_get_ibis_backend", return_value=backend):
+            tables = ds.get_table_list()
+
+        self.assertEqual(tables, ["tabUser", "customers"])
+        # the schema is still the one we read from, it just isn't part of the name
+        self.assertEqual(backend.listed, [("test_db", "public")])
+
+    def test_named_single_schema_tables_are_not_qualified(self):
+        backend = FakeBackend({"sales": ["orders"]})
+        ds = make_data_source(schema="sales")
+
+        with patch.object(InsightsDataSourcev3, "_get_ibis_backend", return_value=backend):
+            tables = ds.get_table_list()
+
+        self.assertEqual(tables, ["orders"])
+
+    def test_multiple_schemas_keep_the_prefix(self):
+        backend = FakeBackend({"public": ["customers"], "sales": ["customers", "orders"]})
+        ds = make_data_source(schema="public, sales")
+
+        with patch.object(InsightsDataSourcev3, "_get_ibis_backend", return_value=backend):
+            tables = ds.get_table_list()
+
+        # without the prefix the two `customers` tables would collide
+        self.assertEqual(tables, ["public.customers", "sales.customers", "sales.orders"])
+
+    def test_unqualified_names_resolve_against_the_configured_schema(self):
+        backend = FakeBackend()
+        ds = make_data_source(schema="sales")
+
+        with patch.object(InsightsDataSourcev3, "_get_ibis_backend", return_value=backend):
+            ds.get_ibis_table("orders")
+
+        self.assertEqual(backend.requested, [("orders", "sales")])
+
+    def test_previously_stored_qualified_names_still_resolve(self):
+        backend = FakeBackend()
+        ds = make_data_source()
+
+        with patch.object(InsightsDataSourcev3, "_get_ibis_backend", return_value=backend):
+            ds.get_ibis_table("public.tabSales Invoice")
+
+        self.assertEqual(backend.requested, [("tabSales Invoice", "public")])
+
+    def test_a_dot_in_the_table_name_is_not_mistaken_for_a_schema(self):
+        backend = FakeBackend()
+        ds = make_data_source()
+
+        with patch.object(InsightsDataSourcev3, "_get_ibis_backend", return_value=backend):
+            ds.get_ibis_table("v1.2 metrics")
+
+        self.assertEqual(backend.requested, [("v1.2 metrics", "public")])
+
+
+class TestSchemaQualifiedDoctypeMapping(FrappeTestCase):
+    def test_strip_schema_prefix(self):
+        self.assertEqual(strip_schema_prefix("public.tabUser"), "tabUser")
+        self.assertEqual(strip_schema_prefix("tabUser"), "tabUser")
+        # not a frappe table — leave it alone, the prefix is part of the name we were given
+        self.assertEqual(strip_schema_prefix("public.customers"), "public.customers")
+
+    def test_qualified_frappe_table_maps_to_its_doctype(self):
+        # this used to raise DoesNotExistError from `get_meta("public.tabUser")`
+        allowed = get_permitted_columns_for_table(strip_schema_prefix("public.tabUser"))
+
+        self.assertIn("name", allowed)
+        self.assertIn("email", allowed)

--- a/insights/tests/test_postgres_schema_prefix.py
+++ b/insights/tests/test_postgres_schema_prefix.py
@@ -144,6 +144,17 @@ class TestPostgresSchemaPrefix(FrappeTestCase):
 
         self.assertEqual(backend.requested, [("v1.2 metrics", "public")])
 
+    def test_formatting_a_name_is_the_inverse_of_splitting_it(self):
+        for ds in (make_data_source(), make_data_source(schema="sales")):
+            self.assertEqual(ds.format_table_name("orders"), "orders")
+            self.assertEqual(ds.split_table_name(ds.format_table_name("orders"))[1], "orders")
+
+        multi = make_data_source(schema="public, sales")
+        self.assertEqual(multi.format_table_name("orders", "sales"), "sales.orders")
+        self.assertEqual(multi.split_table_name("sales.orders"), ("sales", "orders"))
+        # no schema given — frappe tables live in the first one configured
+        self.assertEqual(multi.format_table_name("tabUser"), "public.tabUser")
+
 
 class TestSchemaQualifiedDoctypeMapping(FrappeTestCase):
     def test_strip_schema_prefix(self):


### PR DESCRIPTION
Postgres table names always carried a schema prefix. A Site DB on postgres listed `public.tabSales Invoice` instead of `tabSales Invoice`.

The prefix leaked into every label. It also broke the table to doctype mapping in `apply_user_permissions`, which passes `table_name.removeprefix("tab")` to `get_meta()`. Any query on a postgres site failed with a `DoesNotExistError`. Native SQL queries failed the same way, because the parser extracts only the bare table name.

The prefix only matters when a data source spans more than one schema. Names are now qualified only in that case. `format_table_name()` builds a name and `split_table_name()` reads one back. `get_ibis_table()` accepts both forms, so names stored before this change keep working. Table links build their names the same way. Before, they always emitted `tabX` and never matched on postgres.

The patch rewrites the stored table records, the warehouse tables, and every reference to them. When both forms of a name exist, it keeps the unqualified record. It then drops the other record, its warehouse table, and its permissions.

Fixes #1195
