### PR TITLE
feat: weekly data store cleanup

### DIFF
--- a/insights/hooks.py
+++ b/insights/hooks.py
@@ -169,6 +169,9 @@ scheduler_events = {
     "daily": [
         "insights.api.data_store.sync_tables",
     ],
+    "weekly": [
+        "insights.insights.doctype.insights_data_source_v3.data_warehouse.cleanup_data_store",
+    ],
     "hourly": [
         "insights.api.data_store.update_failed_sync_status",
         "insights.insights.doctype.insights_table_import_job.insights_table_import_job.run_scheduled_imports",

--- a/insights/insights/doctype/insights_data_source_v3/connectors/duckdb.py
+++ b/insights/insights/doctype/insights_data_source_v3/connectors/duckdb.py
@@ -58,6 +58,38 @@ def open_local_duckdb(
 
 
 @contextmanager
+def local_duckdb_write_lock(
+    path: str,
+    cache_key: str,
+    timeout: int = 30,
+) -> Generator[None, None, None]:
+    """Serialize write access to a local DuckDB file.
+
+    Holds a file-level lock and evicts the cached read-only connection for
+    cache_key, so the caller is free to open the file for writing — or to
+    replace the file altogether, as the warehouse compaction does.
+
+    Args:
+        path: Absolute path to the .duckdb file.
+        cache_key: The key under which the read connection is cached in
+            insights.db_connections (typically the data source name).
+        timeout: Seconds to wait for the file lock before giving up.
+    """
+    from frappe.utils.synchronization import filelock
+
+    import insights
+
+    lock_name = f"insights_duckdb_write_{frappe.scrub(os.path.basename(path))}"
+    with filelock(lock_name, timeout=timeout):
+        with suppress(Exception):
+            cached = insights.db_connections.pop(cache_key, None)
+            if cached:
+                cached.disconnect()
+
+        yield
+
+
+@contextmanager
 def local_duckdb_write_connection(
     path: str,
     cache_key: str,
@@ -81,17 +113,7 @@ def local_duckdb_write_connection(
         allowed_dir: Directory to allow external file access from.
         timeout: Seconds to wait for the file lock before giving up.
     """
-    from frappe.utils.synchronization import filelock
-
-    import insights
-
-    lock_name = f"insights_duckdb_write_{frappe.scrub(os.path.basename(path))}"
-    with filelock(lock_name, timeout=timeout):
-        with suppress(Exception):
-            cached = insights.db_connections.pop(cache_key, None)
-            if cached:
-                cached.disconnect()
-
+    with local_duckdb_write_lock(path, cache_key, timeout=timeout):
         db = open_local_duckdb(
             path,
             read_only=False,

--- a/insights/insights/doctype/insights_data_source_v3/data_warehouse.py
+++ b/insights/insights/doctype/insights_data_source_v3/data_warehouse.py
@@ -11,8 +11,8 @@ import frappe.utils
 import ibis
 import pandas as pd
 from duckdb import CatalogException
-from frappe.query_builder.functions import IfNull
-from frappe.utils import get_files_path, now
+from frappe.query_builder.functions import IfNull, Max, Min
+from frappe.utils import add_days, get_datetime, get_files_path, now, now_datetime
 from frappe.utils.background_jobs import is_job_enqueued
 from ibis import _
 from ibis.backends.duckdb import Backend as DuckDBBackend
@@ -22,11 +22,21 @@ from ibis.expr.types import Expr, Table
 import insights
 from insights.insights.doctype.insights_data_source_v3.connectors.duckdb import (
     local_duckdb_write_connection,
+    local_duckdb_write_lock,
     open_local_duckdb,
 )
 from insights.utils import InsightsDataSourcev3, InsightsTablev3
 
 WAREHOUSE_DB_NAME = "insights"
+
+# A stored table unused for this long is un-stored; a table imported this
+# recently is never pruned, even if nothing has queried it yet.
+UNUSED_TABLE_DAYS = 30
+# Cleanup holds the warehouse write lock for much longer than an import commit.
+CLEANUP_LOCK_TIMEOUT = 15 * 60
+# Rebuilding the file is only worth the disk and time above these thresholds.
+COMPACT_MIN_FILE_SIZE = 100 * 1024 * 1024
+COMPACT_MIN_FREE_RATIO = 0.2
 
 
 class Warehouse:
@@ -740,6 +750,268 @@ def execute_warehouse_table_import(data_source: str, table_name: str):
 def get_warehouse_schema_name(data_source: str) -> str:
     """Return the DuckDB schema name for a given data source name."""
     return frappe.scrub(data_source).replace(".", "_")
+
+
+def cleanup_data_store():
+    """Weekly: un-store unused tables, drop orphans from DuckDB, compact the file.
+
+    Pruning is reversible by design — `get_ibis_table(import_if_not_exists=True)`
+    re-imports a dropped table the next time a query needs it.
+    """
+    logger = frappe.logger()
+    cutoff = add_days(now_datetime(), -UNUSED_TABLE_DAYS)
+
+    pruned = prune_unused_tables(cutoff)
+    orphans = drop_orphan_warehouse_tables()
+    compacted = compact_warehouse()
+
+    summary = {
+        "tables_pruned": len(pruned),
+        "orphans_dropped": len(orphans),
+        "size_before": compacted[0] if compacted else None,
+        "size_after": compacted[1] if compacted else None,
+    }
+    logger.info(f"Data store cleanup: {summary}")
+    return summary
+
+
+def prune_unused_tables(cutoff) -> list[str]:
+    """Flip `stored` off for tables no query has read since `cutoff`.
+
+    Incremental tables are never pruned: re-importing them restarts from
+    `sync_from` and history the source has purged since is unrecoverable.
+    """
+    logger = frappe.logger()
+
+    oldest_execution = frappe.db.get_value(
+        "Insights Query Execution Log", {}, "creation", order_by="creation asc"
+    )
+    if not oldest_execution or get_datetime(oldest_execution) > cutoff:
+        # New site, or the log was trimmed via Log Settings. Every table would
+        # look unused — skip rather than prune everything at once.
+        logger.info("Data store cleanup: execution log is shorter than the unused window, skipping prune")
+        return []
+
+    candidates = frappe.get_all(
+        "Insights Table v3",
+        filters={"stored": 1},
+        fields=["name", "data_source", "table", "sync_mode"],
+    )
+    candidates = [t for t in candidates if t.sync_mode != "Incremental"]
+    if not candidates:
+        return []
+
+    last_used = get_last_execution_per_table()
+    first_imported = get_first_import_per_table()
+
+    pruned = []
+    for table in candidates:
+        key = (table.data_source, table.table)
+
+        used_on = last_used.get(key)
+        if used_on and used_on > cutoff:
+            continue
+
+        imported_on = first_imported.get(key)
+        if imported_on and imported_on > cutoff:
+            # Stored recently but not queried yet — give it time to be used.
+            continue
+
+        frappe.db.set_value(
+            "Insights Table v3",
+            table.name,
+            {"stored": 0, "last_synced_on": None, "last_sync_bookmark": None},
+            update_modified=False,
+        )
+        pruned.append(table.name)
+
+        reason = f"last execution {(now_datetime() - used_on).days}d ago" if used_on else "never executed"
+        logger.info(f"Data store cleanup: pruned '{table.name}' ({reason})")
+
+    return pruned
+
+
+def get_last_execution_per_table() -> dict[tuple[str, str], object]:
+    """Map (data_source, table) to when a query last read it.
+
+    A query execution counts as usage of every table its dependency chain
+    reads, not just the tables it names directly — nested queries are not
+    logged separately.
+    """
+    ExecutionLog = frappe.qb.DocType("Insights Query Execution Log")
+    executions = (
+        frappe.qb.from_(ExecutionLog)
+        .select(ExecutionLog.query, Max(ExecutionLog.creation).as_("last_executed_on"))
+        .groupby(ExecutionLog.query)
+        .run(as_dict=True)
+    )
+    executions = {r.query: get_datetime(r.last_executed_on) for r in executions if r.query}
+    if not executions:
+        return {}
+
+    references = frappe.get_all(
+        "Insights Query Reference",
+        fields=["query", "ref_type", "data_source", "table_name", "ref_query"],
+    )
+    query_deps: dict[str, list[str]] = {}
+    table_deps: dict[str, list[tuple[str, str]]] = {}
+    for ref in references:
+        if ref.ref_type == "Query" and ref.ref_query:
+            query_deps.setdefault(ref.query, []).append(ref.ref_query)
+        elif ref.ref_type == "Table" and ref.table_name:
+            table_deps.setdefault(ref.query, []).append((ref.data_source, ref.table_name))
+
+    last_used: dict[tuple[str, str], object] = {}
+    for query, executed_on in executions.items():
+        visited = set()
+        stack = [query]
+        while stack:
+            node = stack.pop()
+            if node in visited:
+                continue
+            visited.add(node)
+            for key in table_deps.get(node, []):
+                if key not in last_used or last_used[key] < executed_on:
+                    last_used[key] = executed_on
+            stack.extend(query_deps.get(node, []))
+
+    return last_used
+
+
+def get_first_import_per_table() -> dict[tuple[str, str], object]:
+    ImportLog = frappe.qb.DocType("Insights Table Import Log")
+    imports = (
+        frappe.qb.from_(ImportLog)
+        .select(
+            ImportLog.data_source,
+            ImportLog.table_name,
+            Min(ImportLog.creation).as_("first_imported_on"),
+        )
+        .where(ImportLog.status == "Completed")
+        .groupby(ImportLog.data_source, ImportLog.table_name)
+        .run(as_dict=True)
+    )
+    return {(r.data_source, r.table_name): get_datetime(r.first_imported_on) for r in imports}
+
+
+def drop_orphan_warehouse_tables() -> list[str]:
+    """Drop warehouse tables that no longer have a `stored` doc behind them.
+
+    Covers deleted data sources (their whole schema), deleted table docs,
+    tables just pruned, and legacy flat `source.table` tables left in `main`.
+    An orphan has no doc left to hold a bookmark or sync config, so the
+    "never touch incremental" rule does not apply to it.
+    """
+    logger = frappe.logger()
+
+    expected = {
+        (get_warehouse_schema_name(t.data_source), frappe.scrub(t.table))
+        for t in frappe.get_all("Insights Table v3", filters={"stored": 1}, fields=["data_source", "table"])
+    }
+
+    dropped = []
+    with insights.warehouse.get_write_connection(timeout=CLEANUP_LOCK_TIMEOUT) as db:
+        tables = db.raw_sql(
+            "select schema_name, table_name from duckdb_tables() where database_name = current_database()"
+        ).fetchall()
+
+        for schema, table in tables:
+            if (schema, table) in expected:
+                continue
+            db.raw_sql(f"DROP TABLE IF EXISTS {quote_identifier(schema)}.{quote_identifier(table)}")
+            dropped.append(f"{schema}.{table}")
+            logger.info(f"Data store cleanup: dropped '{schema}.{table}' (orphan: no matching doc)")
+
+        occupied = {schema for schema, table in tables if (schema, table) in expected}
+        schemas = db.raw_sql(
+            "select schema_name from duckdb_schemas() "
+            "where database_name = current_database() and not internal"
+        ).fetchall()
+        for (schema,) in schemas:
+            if schema == "main" or schema in occupied:
+                continue
+            # Anything else still in the schema (a view, a sequence) keeps it.
+            with suppress(Exception):
+                db.raw_sql(f"DROP SCHEMA IF EXISTS {quote_identifier(schema)}")
+                logger.info(f"Data store cleanup: dropped empty schema '{schema}'")
+
+    return dropped
+
+
+def compact_warehouse() -> tuple[int, int] | None:
+    """Rebuild the warehouse file to reclaim disk, if it is worth doing.
+
+    `DROP TABLE` reuses freed blocks but never shrinks the file, so the only
+    way down from the high-water mark is copying the live data into a fresh
+    file and swapping it in. Returns (size before, size after), or None when
+    the rebuild was skipped or failed.
+    """
+    logger = frappe.logger()
+
+    path = insights.warehouse.get_db_path()
+    if not os.path.exists(path):
+        return None
+
+    size_before = os.path.getsize(path)
+    if size_before < COMPACT_MIN_FILE_SIZE:
+        return None
+
+    folder = os.path.dirname(path)
+    new_path = f"{path}.compact"
+
+    with local_duckdb_write_lock(path, cache_key=WAREHOUSE_DB_NAME, timeout=CLEANUP_LOCK_TIMEOUT):
+        # ATTACH-ing the new file needs the warehouse folder allowed, not tmp.
+        db = open_local_duckdb(path, read_only=False, allowed_dir=folder)
+        try:
+            if get_free_block_ratio(db) < COMPACT_MIN_FREE_RATIO:
+                return None
+            copy_database_to(db, new_path)
+        except Exception:
+            logger.exception("Data store cleanup: failed to compact the warehouse, keeping the old file")
+            with suppress(OSError):
+                os.remove(new_path)
+            return None
+        finally:
+            db.disconnect()
+
+        # Still under the lock: no one can open the old file mid-swap.
+        with suppress(OSError):
+            os.remove(f"{path}.wal")
+        os.rename(new_path, path)
+
+    size_after = os.path.getsize(path)
+    logger.info(f"Data store cleanup: compacted warehouse {size_before} → {size_after} bytes")
+    return size_before, size_after
+
+
+def copy_database_to(db: DuckDBBackend, new_path: str) -> None:
+    with suppress(OSError):
+        os.remove(new_path)
+
+    database = db.raw_sql("select current_database()").fetchone()[0]
+    db.raw_sql(f"ATTACH '{escape_sql_string(new_path)}' AS compacted")
+    try:
+        db.raw_sql(f"COPY FROM DATABASE {quote_identifier(database)} TO compacted")
+    finally:
+        db.raw_sql("DETACH compacted")
+
+
+def get_free_block_ratio(db: DuckDBBackend) -> float:
+    # Free block accounting only reflects earlier drops after a checkpoint.
+    db.raw_sql("CHECKPOINT")
+    total_blocks, free_blocks = db.raw_sql(
+        "select total_blocks, free_blocks from pragma_database_size() "
+        "where database_name = current_database()"
+    ).fetchone()
+    return free_blocks / total_blocks if total_blocks else 0.0
+
+
+def quote_identifier(name: str) -> str:
+    return '"' + name.replace('"', '""') + '"'
+
+
+def escape_sql_string(value: str) -> str:
+    return value.replace("'", "''")
 
 
 def is_warehouse(backend: DuckDBBackend):

--- a/insights/insights/doctype/insights_data_source_v3/data_warehouse.py
+++ b/insights/insights/doctype/insights_data_source_v3/data_warehouse.py
@@ -765,7 +765,7 @@ def cleanup_data_store():
     # DuckDB work is not part of this transaction: commit the docs first so a
     # later failure leaves an orphan for next week, not a `stored` table whose
     # warehouse table has already been dropped.
-    frappe.db.commit()
+    frappe.db.commit()  # nosemgrep
 
     orphans = drop_orphan_warehouse_tables()
     compacted = compact_warehouse()

--- a/insights/insights/doctype/insights_data_source_v3/data_warehouse.py
+++ b/insights/insights/doctype/insights_data_source_v3/data_warehouse.py
@@ -762,6 +762,11 @@ def cleanup_data_store():
     cutoff = add_days(now_datetime(), -UNUSED_TABLE_DAYS)
 
     pruned = prune_unused_tables(cutoff)
+    # DuckDB work is not part of this transaction: commit the docs first so a
+    # later failure leaves an orphan for next week, not a `stored` table whose
+    # warehouse table has already been dropped.
+    frappe.db.commit()
+
     orphans = drop_orphan_warehouse_tables()
     compacted = compact_warehouse()
 

--- a/insights/tests/test_data_store_cleanup.py
+++ b/insights/tests/test_data_store_cleanup.py
@@ -1,0 +1,264 @@
+import os
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+from unittest.mock import patch
+
+import frappe
+from frappe.utils import add_days, now_datetime
+
+import insights
+from insights.insights.doctype.insights_data_source_v3 import data_warehouse
+from insights.insights.doctype.insights_data_source_v3.connectors.duckdb import open_local_duckdb
+from insights.insights.doctype.insights_data_source_v3.data_warehouse import (
+    compact_warehouse,
+    drop_orphan_warehouse_tables,
+    prune_unused_tables,
+)
+from insights.insights.doctype.insights_table_v3.insights_table_v3 import get_table_name
+from insights.tests.base import InsightsIntegrationTestCase
+
+DATA_SOURCE = "Site DB"
+
+
+class TestDataStoreCleanup(InsightsIntegrationTestCase):
+    def before_test(self):
+        frappe.db.delete("Insights Query Execution Log")
+        frappe.db.delete("Insights Query Reference")
+        frappe.db.delete("Insights Table Import Log")
+        self.cutoff = add_days(now_datetime(), -data_warehouse.UNUSED_TABLE_DAYS)
+
+    # helpers
+
+    def create_table(self, table_name, stored=1, sync_mode="Full"):
+        name = get_table_name(DATA_SOURCE, table_name)
+        if frappe.db.exists("Insights Table v3", name):
+            frappe.delete_doc("Insights Table v3", name, force=True)
+
+        doc = frappe.get_doc(
+            {
+                "doctype": "Insights Table v3",
+                "data_source": DATA_SOURCE,
+                "table": table_name,
+                "label": table_name,
+                "stored": stored,
+                "sync_mode": sync_mode,
+                "last_synced_on": now_datetime(),
+            }
+        )
+        doc.flags.ignore_links = True
+        doc.insert(ignore_permissions=True)
+        return doc
+
+    def log_execution(self, query, days_ago):
+        log = frappe.get_doc({"doctype": "Insights Query Execution Log", "query": query, "sql": "select 1"})
+        log.flags.ignore_links = True
+        log.insert(ignore_permissions=True)
+        self.backdate("Insights Query Execution Log", log.name, days_ago)
+
+    def log_import(self, table_name, days_ago):
+        log = frappe.get_doc(
+            {
+                "doctype": "Insights Table Import Log",
+                "data_source": DATA_SOURCE,
+                "table_name": table_name,
+                "status": "Completed",
+            }
+        )
+        log.flags.ignore_links = True
+        log.insert(ignore_permissions=True)
+        self.backdate("Insights Table Import Log", log.name, days_ago)
+
+    def backdate(self, doctype, name, days_ago):
+        frappe.db.set_value(
+            doctype, name, "creation", add_days(now_datetime(), -days_ago), update_modified=False
+        )
+
+    def reference_table(self, query, table_name):
+        ref = frappe.get_doc(
+            {
+                "doctype": "Insights Query Reference",
+                "query": query,
+                "ref_type": "Table",
+                "data_source": DATA_SOURCE,
+                "table_name": table_name,
+            }
+        )
+        ref.flags.ignore_links = True
+        ref.insert(ignore_permissions=True)
+
+    def reference_query(self, query, ref_query):
+        ref = frappe.get_doc(
+            {
+                "doctype": "Insights Query Reference",
+                "query": query,
+                "ref_type": "Query",
+                "ref_query": ref_query,
+            }
+        )
+        ref.flags.ignore_links = True
+        ref.insert(ignore_permissions=True)
+
+    def is_stored(self, table_name):
+        return frappe.db.get_value("Insights Table v3", get_table_name(DATA_SOURCE, table_name), "stored")
+
+    # prune
+
+    def test_prunes_table_whose_queries_are_stale(self):
+        table = self.create_table("tabCleanupStale")
+        self.log_import("tabCleanupStale", days_ago=90)
+        self.reference_table("q_stale", "tabCleanupStale")
+        self.log_execution("q_stale", days_ago=60)
+
+        pruned = prune_unused_tables(self.cutoff)
+
+        self.assertIn(table.name, pruned)
+        self.assertFalse(self.is_stored("tabCleanupStale"))
+        self.assertFalse(
+            frappe.db.get_value("Insights Table v3", table.name, "last_synced_on"),
+            "pruned tables must forget where the last sync stopped",
+        )
+
+    def test_keeps_recently_used_table(self):
+        self.create_table("tabCleanupUsed")
+        self.log_import("tabCleanupUsed", days_ago=90)
+        self.reference_table("q_used", "tabCleanupUsed")
+        self.log_execution("q_used", days_ago=60)
+        self.log_execution("q_used", days_ago=2)
+
+        prune_unused_tables(self.cutoff)
+
+        self.assertTrue(self.is_stored("tabCleanupUsed"))
+
+    def test_keeps_table_used_through_a_nested_query(self):
+        self.create_table("tabCleanupNested")
+        self.log_import("tabCleanupNested", days_ago=90)
+        # only the child query names the table; the parent is what gets executed
+        self.reference_table("q_child", "tabCleanupNested")
+        self.reference_query("q_parent", "q_child")
+        self.log_execution("q_parent", days_ago=2)
+        # the site's execution log must reach past the cutoff for pruning to run at all
+        self.log_execution("q_other", days_ago=90)
+
+        prune_unused_tables(self.cutoff)
+
+        self.assertTrue(self.is_stored("tabCleanupNested"))
+
+    def test_keeps_freshly_imported_table_nobody_has_queried(self):
+        self.create_table("tabCleanupFresh")
+        self.log_import("tabCleanupFresh", days_ago=3)
+        self.log_execution("q_other", days_ago=90)
+
+        prune_unused_tables(self.cutoff)
+
+        self.assertTrue(self.is_stored("tabCleanupFresh"))
+
+    def test_keeps_incremental_table(self):
+        self.create_table("tabCleanupIncremental", sync_mode="Incremental")
+        self.log_import("tabCleanupIncremental", days_ago=90)
+        self.log_execution("q_other", days_ago=90)
+
+        prune_unused_tables(self.cutoff)
+
+        self.assertTrue(self.is_stored("tabCleanupIncremental"))
+
+    def test_skips_pruning_when_execution_log_was_trimmed(self):
+        self.create_table("tabCleanupUnknown")
+        self.log_import("tabCleanupUnknown", days_ago=90)
+        self.log_execution("q_recent", days_ago=1)
+
+        pruned = prune_unused_tables(self.cutoff)
+
+        self.assertEqual(pruned, [])
+        self.assertTrue(self.is_stored("tabCleanupUnknown"))
+
+    # orphan sweep
+
+    @contextmanager
+    def warehouse_file(self):
+        with tempfile.TemporaryDirectory(prefix="insights_cleanup_test_") as tmpdir:
+            path = str(Path(tmpdir) / "insights.duckdb")
+            db = open_local_duckdb(path, read_only=False, allowed_dir=tmpdir)
+            try:
+                yield db, path
+            finally:
+                try:
+                    db.disconnect()
+                except Exception:
+                    pass
+
+    @contextmanager
+    def patched_write_connection(self, db):
+        @contextmanager
+        def get_write_connection(database=None, timeout=30):
+            if database:
+                db.raw_sql(f"USE '{database}'")
+            yield db
+
+        with patch.object(insights.warehouse, "get_write_connection", get_write_connection):
+            yield
+
+    def warehouse_tables(self, db):
+        return set(
+            db.raw_sql(
+                "select schema_name, table_name from duckdb_tables() "
+                "where database_name = current_database()"
+            ).fetchall()
+        )
+
+    def test_orphan_sweep_keeps_stored_tables_and_drops_the_rest(self):
+        self.create_table("tabCleanupKept")
+        schema = data_warehouse.get_warehouse_schema_name(DATA_SOURCE)
+
+        with self.warehouse_file() as (db, _):
+            db.raw_sql(f'create schema "{schema}"')
+            db.raw_sql(f'create table "{schema}".tabcleanupkept as select 1 as a')
+            db.raw_sql(f'create table "{schema}".tabcleanupdeleted as select 1 as a')
+            db.raw_sql('create schema "gone_data_source"')
+            db.raw_sql('create table "gone_data_source".t as select 1 as a')
+            db.raw_sql("create table main.site_db_tabcleanuplegacy as select 1 as a")
+
+            with self.patched_write_connection(db):
+                dropped = drop_orphan_warehouse_tables()
+
+            self.assertEqual(self.warehouse_tables(db), {(schema, "tabcleanupkept")})
+            self.assertIn(f"{schema}.tabcleanupdeleted", dropped)
+            self.assertIn("gone_data_source.t", dropped)
+            self.assertIn("main.site_db_tabcleanuplegacy", dropped)
+
+            schemas = {row[0] for row in db.raw_sql("select schema_name from duckdb_schemas()").fetchall()}
+            self.assertNotIn("gone_data_source", schemas)
+
+    # compaction
+
+    def test_compaction_skipped_for_small_files(self):
+        with self.warehouse_file() as (db, path):
+            db.raw_sql("create table t as select 1 as a")
+            with patch.object(insights.warehouse, "get_db_path", lambda: path):
+                self.assertIsNone(compact_warehouse())
+
+    def test_compaction_rebuilds_the_file_and_keeps_data(self):
+        with self.warehouse_file() as (db, path):
+            db.raw_sql('create schema "s"')
+            db.raw_sql('create table "s".keep as select i from range(1000) t(i)')
+            # md5 of a random value — incompressible, so the file actually grows
+            db.raw_sql('create table "s".dropped as select md5(random()::varchar) as pad from range(200000)')
+            db.raw_sql('drop table "s".dropped')
+            db.raw_sql("CHECKPOINT")
+            db.disconnect()
+
+            with (
+                patch.object(insights.warehouse, "get_db_path", lambda: path),
+                patch.object(data_warehouse, "COMPACT_MIN_FILE_SIZE", 0),
+                patch.object(data_warehouse, "COMPACT_MIN_FREE_RATIO", 0),
+            ):
+                size_before, size_after = compact_warehouse()
+
+            self.assertEqual(size_after, os.path.getsize(path))
+            self.assertLess(size_after, size_before)
+
+            rebuilt = open_local_duckdb(path, read_only=True)
+            try:
+                self.assertEqual(int(rebuilt.table("keep", database="s").count().execute()), 1000)
+            finally:
+                rebuilt.disconnect()


### PR DESCRIPTION
Weekly scheduled job that keeps `insights.duckdb` from growing unbounded. Design doc: `docs/data_store_cleanup.md`.

Three passes in `cleanup_data_store()`:

1. **Prune** — un-stores Full-sync tables no query has read in 30 days. Reversible: `get_ibis_table(import_if_not_exists=True)` re-imports on next use. Incremental tables are never pruned (re-import restarts from `sync_from` and purged history is gone).
2. **Orphan sweep** — drops warehouse tables with no `stored=1` doc behind them: deleted data sources' schemas, deleted table docs, just-pruned tables, and the legacy flat `source.table` tables the schema-migration patch left in `main`.
3. **Compact** — `DROP TABLE` never shrinks a duckdb file, so above 100 MB and 20% free blocks the file is rebuilt via `ATTACH` + `COPY FROM DATABASE` and renamed into place.

Two points reviewers may want to check:

- Usage is measured **transitively** across `Insights Query Reference` — only the top-level query gets an execution log, so a table read through a nested query would otherwise look unused.
- The compaction swap happens **inside** the write lock. `local_duckdb_write_connection` is split so the lock half (`local_duckdb_write_lock`) can be held across disconnect *and* rename.

Guards against a mass prune: tables first imported in the last 30 days are skipped, and if the execution log itself doesn't reach back 30 days (trimmed via Log Settings, or a new site) the prune pass is skipped entirely that week.

No new doctypes, no settings — thresholds are hardcoded, audit trail is `frappe.logger` plus the summary counts in the Scheduled Job Log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)