### PR TITLE
feat(charts): reference lines, funnel-from-measures, percent measures

### DIFF
--- a/frontend/src2/charts/chart.ts
+++ b/frontend/src2/charts/chart.ts
@@ -21,6 +21,7 @@ import {
 	BubbleChartConfig,
 	CHARTS,
 	DonutChartConfig,
+	FunnelChartConfig,
 	MapChartConfig,
 	NumberChartConfig,
 	TableChartConfig,
@@ -139,7 +140,7 @@ function makeChart(name: string) {
 			}
 		}
 
-		if (chart.doc.chart_type === 'Donut' || chart.doc.chart_type === 'Funnel') {
+		if (chart.doc.chart_type === 'Donut') {
 			const config = chart.doc.config as DonutChartConfig
 			if (!config.label_column?.column_name) {
 				messages.push({
@@ -151,6 +152,19 @@ function makeChart(name: string) {
 				messages.push({
 					variant: 'error',
 					message: __('Value column is required'),
+				})
+			}
+		}
+
+		if (chart.doc.chart_type === 'Funnel') {
+			const config = chart.doc.config as FunnelChartConfig
+			// Measures mode needs at least one measure; grouped mode needs label + value.
+			if (config.measures?.some((m) => m.measure_name)) {
+				// valid measures-mode config
+			} else if (!config.label_column?.column_name || !config.value_column?.measure_name) {
+				messages.push({
+					variant: 'error',
+					message: __('Add a measure, or set a label and value column'),
 				})
 			}
 		}
@@ -226,8 +240,12 @@ function makeChart(name: string) {
 			addNumberChartOperation(query)
 		}
 
-		if (chart.doc.chart_type === 'Donut' || chart.doc.chart_type === 'Funnel') {
+		if (chart.doc.chart_type === 'Donut') {
 			addDonutChartOperation(query)
+		}
+
+		if (chart.doc.chart_type === 'Funnel') {
+			addFunnelChartOperation(query)
 		}
 
 		if (chart.doc.chart_type === 'Table') {
@@ -277,6 +295,32 @@ function makeChart(name: string) {
 	function addDonutChartOperation(query: Query) {
 		const config = chart.doc.config as DonutChartConfig
 
+		query.addSummarize({
+			measures: [config.value_column],
+			dimensions: [config.label_column],
+		})
+		query.addOrderBy({
+			column: column(config.value_column.measure_name),
+			direction: 'desc',
+		})
+	}
+
+	function addFunnelChartOperation(query: Query) {
+		const config = chart.doc.config as FunnelChartConfig
+
+		// Measures mode: each measure is a stage, aggregated over the whole
+		// result with no group-by (mirrors the Number chart's data_query).
+		const measures = config.measures?.filter((m) => m.measure_name)
+		if (measures?.length) {
+			query.addSummarize({
+				measures,
+				dimensions: [],
+			})
+			return
+		}
+
+		// Grouped (long-format) mode: one row per stage, ordered by value.
+		if (!config.value_column?.measure_name || !config.label_column?.column_name) return
 		query.addSummarize({
 			measures: [config.value_column],
 			dimensions: [config.label_column],

--- a/frontend/src2/charts/components/FunnelChartConfigForm.vue
+++ b/frontend/src2/charts/components/FunnelChartConfigForm.vue
@@ -3,7 +3,14 @@ import { computed, watchEffect } from 'vue'
 import { __ } from '../../translation'
 import { FIELDTYPES } from '../../helpers/constants'
 import { FunnelChartConfig } from '../../types/chart.types'
-import { ColumnOption, Dimension, DimensionOption, Measure } from '../../types/query.types'
+import {
+	ColumnOption,
+	Dimension,
+	DimensionOption,
+	Measure,
+	MeasureOption,
+} from '../../types/query.types'
+import DraggableList from '../../components/DraggableList.vue'
 import CollapsibleSection from './CollapsibleSection.vue'
 import MeasurePicker from './MeasurePicker.vue'
 import DimensionPicker from './DimensionPicker.vue'
@@ -16,12 +23,16 @@ const props = defineProps<{
 const config = defineModel<FunnelChartConfig>({
 	required: true,
 	default: () => ({
+		measures: [],
 		label_column: {},
 		value_column: {},
 	}),
 })
 
 watchEffect(() => {
+	if (!config.value.measures) {
+		config.value.measures = []
+	}
 	if (!config.value.label_column) {
 		config.value.label_column = {} as Dimension
 	}
@@ -29,6 +40,18 @@ watchEffect(() => {
 		config.value.value_column = {} as Measure
 	}
 })
+
+// Measures mode is active once any stage has a picked measure. When it isn't,
+// we fall back to the grouped (label + value) controls so existing funnels and
+// long-format data stay configurable.
+const hasMeasures = computed(() => config.value.measures?.some((m) => m.measure_name))
+
+function addStage() {
+	if (!config.value.measures) {
+		config.value.measures = []
+	}
+	config.value.measures.push({} as MeasureOption)
+}
 
 const discrete_dimensions = computed(() =>
 	props.dimensions.filter((d) => FIELDTYPES.DISCRETE.includes(d.data_type)),
@@ -38,16 +61,43 @@ const discrete_dimensions = computed(() =>
 <template>
 	<CollapsibleSection title="Options">
 		<div class="flex flex-col gap-3 pt-1">
-			<DimensionPicker
-				label="Label"
-				v-model="config.label_column"
-				:options="discrete_dimensions"
-			/>
-			<MeasurePicker
-				label="Value"
-				v-model="config.value_column"
-				:column-options="props.columnOptions"
-			/>
+			<div>
+				<p class="mb-1.5 text-xs text-ink-gray-5">Stages</p>
+				<div>
+					<DraggableList v-model:items="config.measures" group="funnel-stages">
+						<template #item="{ item, index }">
+							<MeasurePicker
+								:model-value="item"
+								:column-options="props.columnOptions"
+								@update:model-value="Object.assign(item, $event || {})"
+								@remove="config.measures!.splice(index, 1)"
+							/>
+						</template>
+					</DraggableList>
+					<button
+						class="mt-1.5 text-left text-xs text-ink-gray-5 hover:underline"
+						@click="addStage"
+					>
+						+ Add stage
+					</button>
+				</div>
+			</div>
+
+			<template v-if="!hasMeasures">
+				<DimensionPicker
+					label="Label"
+					:options="discrete_dimensions"
+					:model-value="config.label_column as Dimension"
+					@update:model-value="config.label_column = $event || ({} as Dimension)"
+				/>
+				<MeasurePicker
+					label="Value"
+					:column-options="props.columnOptions"
+					:model-value="config.value_column as Measure"
+					@update:model-value="config.value_column = $event || ({} as Measure)"
+				/>
+			</template>
+
 			<Toggle v-model="config.show_percentage" :label="__('Show Percentage')" />
 		</div>
 	</CollapsibleSection>

--- a/frontend/src2/charts/components/MeasurePicker.vue
+++ b/frontend/src2/charts/components/MeasurePicker.vue
@@ -20,7 +20,13 @@ const emit = defineEmits({ remove: () => true })
 const props = defineProps<{
 	label?: string
 	columnOptions: ColumnOption[]
+	enableFormat?: boolean
 }>()
+
+const formatOptions = [
+	{ label: __('Normal'), value: '' },
+	{ label: __('Percent'), value: 'percent' },
+]
 
 // True when at least one available column is a pre-aggregated measure (i.e. it
 // came from a summarize/pivot_wider step in the source query). In this case we
@@ -128,6 +134,7 @@ function updateMeasure(measureExpression: ExpressionMeasure) {
 		expression: measureExpression.expression,
 		measure_name: measureExpression.measure_name,
 		data_type: measureExpression.data_type,
+		format: measure.value.format,
 	}
 	showMeasureDialog.value = false
 }
@@ -342,6 +349,15 @@ function handleRemove() {
 							@update:modelValue="label = $event"
 							@blur="measure.measure_name = label"
 							@keydown.enter="measure.measure_name = label"
+						/>
+					</InlineFormControlLabel>
+
+					<InlineFormControlLabel v-if="props.enableFormat" label="Format">
+						<FormControl
+							type="select"
+							:options="formatOptions"
+							:modelValue="measure.format || ''"
+							@update:modelValue="measure.format = $event || undefined"
 						/>
 					</InlineFormControlLabel>
 

--- a/frontend/src2/charts/components/NumberChart.vue
+++ b/frontend/src2/charts/components/NumberChart.vue
@@ -2,7 +2,7 @@
 import { computed } from 'vue'
 import { formatNumber, getShortNumber } from '../../helpers'
 import { NumberChartConfig, NumberColumnOptions } from '../../types/chart.types'
-import { QueryResult, QueryResultColumn, QueryResultRow } from '../../types/query.types'
+import { DataFormat, QueryResult, QueryResultColumn, QueryResultRow } from '../../types/query.types'
 import Sparkline from './Sparkline.vue'
 
 const props = defineProps<{
@@ -53,13 +53,16 @@ const cards = computed(() => {
 		const decimal = getNumberOption(idx, 'decimal')
 		const color = getNumberOption(idx, 'color')
 		const shorten_numbers = getNumberOption(idx, 'shorten_numbers')
+		const format = config.value.number_columns.find((c) => c.measure_name === measure_name)
+			?.format
 
 		return {
 			measure_name,
 			values: numberValues,
-			currentValue: getFormattedValue(currentValue, decimal, shorten_numbers),
-			previousValue: getFormattedValue(previousValue, decimal, shorten_numbers),
+			currentValue: getFormattedValue(currentValue, decimal, shorten_numbers, format),
+			previousValue: getFormattedValue(previousValue, decimal, shorten_numbers, format),
 			delta,
+			// percentDelta is already a percentage change, so it keeps the default format
 			percentDelta: getFormattedValue(percentDelta, decimal, shorten_numbers),
 			prefix,
 			suffix,
@@ -68,8 +71,16 @@ const cards = computed(() => {
 	})
 })
 
-const getFormattedValue = (value: number, decimal?: number, shorten_numbers?: boolean) => {
+const getFormattedValue = (
+	value: number,
+	decimal?: number,
+	shorten_numbers?: boolean,
+	format?: DataFormat,
+) => {
 	if (isNaN(value)) return 0
+	if (format === 'percent') {
+		return `${formatNumber(value * 100, decimal)}%`
+	}
 	if (shorten_numbers) {
 		return getShortNumber(value, decimal)
 	}

--- a/frontend/src2/charts/components/NumberChartConfigForm.vue
+++ b/frontend/src2/charts/components/NumberChartConfigForm.vue
@@ -75,6 +75,7 @@ function setNumberOption(index: number, option: keyof NumberColumnOptions, value
 							<MeasurePicker
 								:model-value="item"
 								:column-options="props.columnOptions"
+								:enable-format="true"
 								@update:model-value="Object.assign(item, $event || {})"
 								@remove="config.number_columns.splice(index, 1)"
 							>

--- a/frontend/src2/charts/components/TableChart.vue
+++ b/frontend/src2/charts/components/TableChart.vue
@@ -3,12 +3,24 @@ import { computed, watch } from 'vue'
 import QueryDataTable from '../../query/components/QueryDataTable.vue'
 import { column } from '../../query/helpers'
 import { TableChartConfig } from '../../types/chart.types'
-import { SortDirection } from '../../types/query.types'
+import { DataFormat, SortDirection } from '../../types/query.types'
 import { Chart } from '../chart'
 import ChartTitle from './ChartTitle.vue'
 
 const props = defineProps<{ chart: Chart }>()
 const tableConfig = computed(() => props.chart.doc.config as TableChartConfig)
+
+// Maps a value column to its display format (e.g. percent) so the table can
+// render a rate measure as `59%` instead of `0.59`.
+const columnFormats = computed(() => {
+	const formats: Record<string, DataFormat> = {}
+	tableConfig.value.values?.forEach((measure) => {
+		if (measure?.measure_name && measure.format) {
+			formats[measure.measure_name] = measure.format
+		}
+	})
+	return formats
+})
 
 function onSortChange(column_name: string, sort_order: SortDirection) {
 	const existingOrder = props.chart.doc.config.order_by.find(
@@ -51,6 +63,7 @@ function onSortChange(column_name: string, sort_order: SortDirection) {
 			:sticky-columns="tableConfig.sticky_columns"
 			:column-widths="tableConfig.column_widths"
 			:text-wrap="tableConfig.text_wrap"
+			:column-formats="columnFormats"
 			:replace-nulls-with-zeros="true"
 		></QueryDataTable>
 	</div>

--- a/frontend/src2/charts/components/TableChartConfigForm.vue
+++ b/frontend/src2/charts/components/TableChartConfigForm.vue
@@ -258,6 +258,7 @@ function updateTextWrap(column_name: string, wrap: boolean | undefined) {
 						<MeasurePicker
 							:model-value="item"
 							:column-options="props.columnOptions"
+							:enable-format="true"
 							@update:model-value="Object.assign(item, $event || {})"
 							@remove="config.values.splice(index, 1)"
 						/>

--- a/frontend/src2/charts/components/YAxisConfig.vue
+++ b/frontend/src2/charts/components/YAxisConfig.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
 import ColorInput from '../../components/ColorInput.vue'
 import { debounce } from 'frappe-ui'
+import { Settings, X as XIcon } from 'lucide-vue-next'
 import { watchEffect } from 'vue'
-import Checkbox from '../../components/Checkbox.vue'
 import DraggableList from '../../components/DraggableList.vue'
 import InlineFormControlLabel from '../../components/InlineFormControlLabel.vue'
 import { copy } from '../../helpers'
-import { AxisChartConfig } from '../../types/chart.types'
+import { AxisChartConfig, ReferenceLine } from '../../types/chart.types'
 import { ColumnOption, MeasureOption } from '../../types/query.types'
 import CollapsibleSection from './CollapsibleSection.vue'
 import MeasurePicker from './MeasurePicker.vue'
@@ -36,6 +36,17 @@ const updateColor = debounce((color: string, idx: number) => {
 	}
 	y_axis.value.series[idx].color = color ? [color] : []
 }, 500)
+
+function addReferenceLine() {
+	if (!y_axis.value.reference_lines) {
+		y_axis.value.reference_lines = []
+	}
+	y_axis.value.reference_lines.push({ axis: 'y' } as ReferenceLine)
+}
+
+function removeReferenceLine(index: number) {
+	y_axis.value.reference_lines?.splice(index, 1)
+}
 </script>
 
 <template>
@@ -113,6 +124,79 @@ const updateColor = debounce((color: string, idx: number) => {
 			<InlineFormControlLabel label="Y-Max" class="w-1/2">
 				<FormControl type="number" v-model="y_axis.max" placeholder="Max" />
 			</InlineFormControlLabel>
+
+			<div>
+				<p class="mb-1.5 text-xs text-ink-gray-5">Reference Lines</p>
+				<div class="flex flex-col gap-1.5">
+					<div
+						v-for="(line, index) in y_axis.reference_lines"
+						:key="index"
+						class="flex items-end gap-1"
+					>
+						<div class="flex-1 overflow-hidden">
+							<FormControl
+								type="text"
+								v-model="line.value"
+								:placeholder="
+									line.axis === 'x' ? 'Value (e.g. Jan)' : 'Value (e.g. 60)'
+								"
+							/>
+						</div>
+						<Popover side="bottom" align="end">
+							<template #trigger>
+								<Button>
+									<template #icon>
+										<Settings
+											class="h-4 w-4 text-ink-gray-6"
+											stroke-width="1.5"
+										/>
+									</template>
+								</Button>
+							</template>
+							<template #default>
+								<div class="flex w-[14rem] flex-col gap-2 p-2">
+									<InlineFormControlLabel label="Axis">
+										<FormControl
+											type="select"
+											v-model="line.axis"
+											:options="[
+												{ label: 'Y (horizontal)', value: 'y' },
+												{ label: 'X (vertical)', value: 'x' },
+											]"
+										/>
+									</InlineFormControlLabel>
+									<InlineFormControlLabel label="Label">
+										<FormControl
+											type="text"
+											v-model="line.label"
+											placeholder="e.g. Target"
+										/>
+									</InlineFormControlLabel>
+									<InlineFormControlLabel label="Color">
+										<ColorInput
+											:model-value="line.color"
+											@update:model-value="line.color = $event"
+											placement="left-start"
+										/>
+									</InlineFormControlLabel>
+									<Toggle label="Dashed" v-model="line.dashed" />
+								</div>
+							</template>
+						</Popover>
+						<Button @click="removeReferenceLine(index)">
+							<template #icon>
+								<XIcon class="h-4 w-4 text-ink-gray-6" stroke-width="1.5" />
+							</template>
+						</Button>
+					</div>
+				</div>
+				<button
+					class="mt-1.5 text-left text-xs text-ink-gray-5 hover:underline"
+					@click="addReferenceLine"
+				>
+					+ Add reference line
+				</button>
+			</div>
 		</div>
 	</CollapsibleSection>
 </template>

--- a/frontend/src2/charts/components/YAxisConfig.vue
+++ b/frontend/src2/charts/components/YAxisConfig.vue
@@ -165,6 +165,16 @@ function removeReferenceLine(index: number) {
 											]"
 										/>
 									</InlineFormControlLabel>
+									<InlineFormControlLabel
+										v-if="(line.axis || 'y') === 'y'"
+										label="Align"
+									>
+										<FormControl
+											type="select"
+											v-model="line.align"
+											:options="['Left', 'Right']"
+										/>
+									</InlineFormControlLabel>
 									<InlineFormControlLabel label="Label">
 										<FormControl
 											type="text"

--- a/frontend/src2/charts/helpers.ts
+++ b/frontend/src2/charts/helpers.ts
@@ -74,7 +74,12 @@ export function getLineChartOptions(config: LineChartConfig, result: QueryResult
 	const _columns = result.columns
 	const _rows = result.rows
 
-	const number_columns = _columns.filter((c) => FIELDTYPES.NUMBER.includes(c.type))
+	// The x-axis dimension is a result column too; when it is numeric (e.g. an Integer
+	// day offset) it must not be picked up as a plotted series alongside the measures.
+	const x_dimension_name = config.x_axis.dimension.dimension_name
+	const number_columns = _columns.filter(
+		(c) => FIELDTYPES.NUMBER.includes(c.type) && c.name !== x_dimension_name,
+	)
 	const show_scrollbar = config.y_axis.show_scrollbar || false
 
 	const xAxis = getXAxis(config.x_axis)
@@ -205,7 +210,12 @@ export function getBarChartOptions(config: BarChartConfig, result: QueryResult, 
 	const _columns = result.columns
 	const _rows = result.rows
 
-	const number_columns = _columns.filter((c) => FIELDTYPES.NUMBER.includes(c.type))
+	// The x-axis dimension is a result column too; when it is numeric (e.g. an Integer
+	// day offset) it must not be picked up as a plotted series alongside the measures.
+	const x_dimension_name = config.x_axis.dimension.dimension_name
+	const number_columns = _columns.filter(
+		(c) => FIELDTYPES.NUMBER.includes(c.type) && c.name !== x_dimension_name,
+	)
 	const show_scrollbar = config.y_axis.show_scrollbar || false
 
 	const xAxis = getXAxis(config.x_axis)

--- a/frontend/src2/charts/helpers.ts
+++ b/frontend/src2/charts/helpers.ts
@@ -105,7 +105,10 @@ export function getLineChartOptions(config: LineChartConfig, result: QueryResult
 
 	const colors = getColors()
 
-	const markLine = getReferenceMarkLine(config.y_axis.reference_lines)
+	const seriesAligns = number_columns.map((c) =>
+		getSerie(config, c.name).align === 'Right' ? 'Right' : 'Left',
+	) as ('Left' | 'Right')[]
+	const markLines = assignReferenceMarkLines(config.y_axis.reference_lines, seriesAligns, false)
 
 	const chartSeries = number_columns.map((c, idx) => {
 		const serie = getSerie(config, c.name) as SeriesLine
@@ -147,8 +150,8 @@ export function getLineChartOptions(config: LineChartConfig, result: QueryResult
 			labelLayout: { hideOverlap: true },
 			itemStyle: { color: color },
 			areaStyle: show_area ? getAreaStyle(color) : undefined,
-			// draw reference lines once, on the first series only
-			markLine: idx === 0 ? markLine : undefined,
+			// each reference line is hosted on a series bound to the axis it targets
+			markLine: markLines[idx],
 			...(hide_from_chart
 				? {
 						lineStyle: { opacity: 0 },
@@ -261,7 +264,10 @@ export function getBarChartOptions(config: BarChartConfig, result: QueryResult, 
 
 	const colors = getColors()
 
-	const markLine = getReferenceMarkLine(config.y_axis.reference_lines, swapAxes)
+	const seriesAligns = number_columns.map((c) =>
+		getSerie(config, c.name).align === 'Right' ? 'Right' : 'Left',
+	) as ('Left' | 'Right')[]
+	const markLines = assignReferenceMarkLines(config.y_axis.reference_lines, seriesAligns, swapAxes)
 
 	const chartSeries = number_columns.map((c, idx) => {
 		const serie = getSerie(config, c.name)
@@ -301,8 +307,8 @@ export function getBarChartOptions(config: BarChartConfig, result: QueryResult, 
 				fontSize: 11,
 			},
 			barGap: config.y_axis.overlap ? '-100%' : undefined,
-			// draw reference lines once, on the first series only
-			markLine: idx === 0 ? markLine : undefined,
+			// each reference line is hosted on a series bound to the axis it targets
+			markLine: markLines[idx],
 			labelLayout: { hideOverlap: true },
 			yAxisIndex: is_right_axis ? 1 : 0,
 			lineStyle: hide_from_chart ? { opacity: 0 } : undefined,
@@ -423,6 +429,36 @@ function getYAxis(options: YAxisCustomizeOptions = {}) {
 // attached to one series so the lines are drawn once, not once per series.
 // A 'y' line is horizontal (at a measure value); an 'x' line is vertical (at a
 // category/date value). `swapAxes` (Row chart) flips which ECharts axis each maps to.
+// A markLine inherits the axis of the series it is attached to. So on a dual-axis chart,
+// host each reference line on a series bound to the axis it targets — a 'y' line defaults
+// to the primary (left) axis, or the right axis when align === 'Right'; 'x' (category)
+// lines have no left/right and ride with the primary group. Returns, per series index, the
+// markLine to attach (or undefined). Single-axis charts host everything on the first series.
+function assignReferenceMarkLines(
+	reference_lines: ReferenceLine[] | undefined,
+	seriesAligns: ('Left' | 'Right')[],
+	swapAxes: boolean,
+) {
+	const perSeries: (ReturnType<typeof getReferenceMarkLine>)[] = seriesAligns.map(() => undefined)
+	if (!reference_lines?.length) return perSeries
+
+	const rightHost = seriesAligns.findIndex((a) => a === 'Right')
+	const primaryHost = Math.max(
+		seriesAligns.findIndex((a) => a !== 'Right'),
+		0,
+	)
+
+	const rightLines =
+		rightHost !== -1
+			? reference_lines.filter((l) => (l.axis || 'y') === 'y' && l.align === 'Right')
+			: []
+	const primaryLines = reference_lines.filter((l) => !rightLines.includes(l))
+
+	perSeries[primaryHost] = getReferenceMarkLine(primaryLines, swapAxes)
+	if (rightHost !== -1) perSeries[rightHost] = getReferenceMarkLine(rightLines, swapAxes)
+	return perSeries
+}
+
 function getReferenceMarkLine(reference_lines?: ReferenceLine[], swapAxes = false) {
 	if (!reference_lines?.length) return undefined
 

--- a/frontend/src2/charts/helpers.ts
+++ b/frontend/src2/charts/helpers.ts
@@ -11,6 +11,7 @@ import {
 	FunnelChartConfig,
 	LineChartConfig,
 	MapChartConfig,
+	ReferenceLine,
 	SankeyChartConfig,
 	Series,
 	SeriesLine,
@@ -99,6 +100,8 @@ export function getLineChartOptions(config: LineChartConfig, result: QueryResult
 
 	const colors = getColors()
 
+	const markLine = getReferenceMarkLine(config.y_axis.reference_lines)
+
 	const chartSeries = number_columns.map((c, idx) => {
 		const serie = getSerie(config, c.name) as SeriesLine
 
@@ -139,6 +142,8 @@ export function getLineChartOptions(config: LineChartConfig, result: QueryResult
 			labelLayout: { hideOverlap: true },
 			itemStyle: { color: color },
 			areaStyle: show_area ? getAreaStyle(color) : undefined,
+			// draw reference lines once, on the first series only
+			markLine: idx === 0 ? markLine : undefined,
 			...(hide_from_chart
 				? {
 						lineStyle: { opacity: 0 },
@@ -246,6 +251,8 @@ export function getBarChartOptions(config: BarChartConfig, result: QueryResult, 
 
 	const colors = getColors()
 
+	const markLine = getReferenceMarkLine(config.y_axis.reference_lines, swapAxes)
+
 	const chartSeries = number_columns.map((c, idx) => {
 		const serie = getSerie(config, c.name)
 		const is_right_axis = serie.align === 'Right'
@@ -284,6 +291,8 @@ export function getBarChartOptions(config: BarChartConfig, result: QueryResult, 
 				fontSize: 11,
 			},
 			barGap: config.y_axis.overlap ? '-100%' : undefined,
+			// draw reference lines once, on the first series only
+			markLine: idx === 0 ? markLine : undefined,
 			labelLayout: { hideOverlap: true },
 			yAxisIndex: is_right_axis ? 1 : 0,
 			lineStyle: hide_from_chart ? { opacity: 0 } : undefined,
@@ -397,6 +406,49 @@ function getYAxis(options: YAxisCustomizeOptions = {}) {
 		},
 		min: options.normalized ? 0 : options.min || undefined,
 		max: options.normalized ? 100 : options.max || undefined,
+	}
+}
+
+// Builds a single ECharts `markLine` from the configured reference lines. It is
+// attached to one series so the lines are drawn once, not once per series.
+// A 'y' line is horizontal (at a measure value); an 'x' line is vertical (at a
+// category/date value). `swapAxes` (Row chart) flips which ECharts axis each maps to.
+function getReferenceMarkLine(reference_lines?: ReferenceLine[], swapAxes = false) {
+	if (!reference_lines?.length) return undefined
+
+	const data = reference_lines
+		.filter((line) => line.value !== undefined && line.value !== null && line.value !== '')
+		.map((line) => {
+			const onValueAxis = (line.axis || 'y') === 'y'
+			// the value axis is yAxis normally, but becomes xAxis when axes are swapped
+			const axisKey = onValueAxis === !swapAxes ? 'yAxis' : 'xAxis'
+			const rawValue = onValueAxis ? Number(line.value) : line.value
+
+			const entry: any = {
+				[axisKey]: rawValue,
+				lineStyle: {
+					type: line.dashed ? 'dashed' : 'solid',
+					width: 1.5,
+					...(line.color ? { color: line.color } : {}),
+				},
+			}
+			if (line.label) {
+				entry.label = {
+					show: true,
+					position: 'insideEndTop',
+					formatter: line.label,
+					...(line.color ? { color: line.color } : {}),
+				}
+			}
+			return entry
+		})
+
+	if (!data.length) return undefined
+
+	return {
+		silent: true,
+		symbol: 'none',
+		data,
 	}
 }
 

--- a/frontend/src2/charts/helpers.ts
+++ b/frontend/src2/charts/helpers.ts
@@ -105,11 +105,6 @@ export function getLineChartOptions(config: LineChartConfig, result: QueryResult
 
 	const colors = getColors()
 
-	const seriesAligns = number_columns.map((c) =>
-		getSerie(config, c.name).align === 'Right' ? 'Right' : 'Left',
-	) as ('Left' | 'Right')[]
-	const markLines = assignReferenceMarkLines(config.y_axis.reference_lines, seriesAligns, false)
-
 	const chartSeries = number_columns.map((c, idx) => {
 		const serie = getSerie(config, c.name) as SeriesLine
 
@@ -150,8 +145,6 @@ export function getLineChartOptions(config: LineChartConfig, result: QueryResult
 			labelLayout: { hideOverlap: true },
 			itemStyle: { color: color },
 			areaStyle: show_area ? getAreaStyle(color) : undefined,
-			// each reference line is hosted on a series bound to the axis it targets
-			markLine: markLines[idx],
 			...(hide_from_chart
 				? {
 						lineStyle: { opacity: 0 },
@@ -175,7 +168,10 @@ export function getLineChartOptions(config: LineChartConfig, result: QueryResult
 		color: colors,
 		xAxis,
 		yAxis,
-		series: chartSeries,
+		series: [
+			...chartSeries,
+			...getReferenceLineSeries(config.y_axis.reference_lines, hasRightAxis),
+		],
 		tooltip: getTooltip({
 			xAxisIsDate,
 			granularity,
@@ -264,11 +260,6 @@ export function getBarChartOptions(config: BarChartConfig, result: QueryResult, 
 
 	const colors = getColors()
 
-	const seriesAligns = number_columns.map((c) =>
-		getSerie(config, c.name).align === 'Right' ? 'Right' : 'Left',
-	) as ('Left' | 'Right')[]
-	const markLines = assignReferenceMarkLines(config.y_axis.reference_lines, seriesAligns, swapAxes)
-
 	const chartSeries = number_columns.map((c, idx) => {
 		const serie = getSerie(config, c.name)
 		const is_right_axis = serie.align === 'Right'
@@ -307,8 +298,6 @@ export function getBarChartOptions(config: BarChartConfig, result: QueryResult, 
 				fontSize: 11,
 			},
 			barGap: config.y_axis.overlap ? '-100%' : undefined,
-			// each reference line is hosted on a series bound to the axis it targets
-			markLine: markLines[idx],
 			labelLayout: { hideOverlap: true },
 			yAxisIndex: is_right_axis ? 1 : 0,
 			lineStyle: hide_from_chart ? { opacity: 0 } : undefined,
@@ -333,7 +322,10 @@ export function getBarChartOptions(config: BarChartConfig, result: QueryResult, 
 		xAxis: swapAxes ? yAxis : xAxis,
 		yAxis: swapAxes ? xAxis : yAxis,
 		dataZoom: getDataZoom(show_scrollbar, swapAxes),
-		series: chartSeries,
+		series: [
+			...chartSeries,
+			...getReferenceLineSeries(config.y_axis.reference_lines, hasRightAxis, swapAxes),
+		],
 		tooltip: getTooltip({
 			xAxisIsDate,
 			granularity,
@@ -425,44 +417,48 @@ function getYAxis(options: YAxisCustomizeOptions = {}) {
 	}
 }
 
-// Builds a single ECharts `markLine` from the configured reference lines. It is
-// attached to one series so the lines are drawn once, not once per series.
-// A 'y' line is horizontal (at a measure value); an 'x' line is vertical (at a
-// category/date value). `swapAxes` (Row chart) flips which ECharts axis each maps to.
-// A markLine inherits the axis of the series it is attached to. So on a dual-axis chart,
-// host each reference line on a series bound to the axis it targets — a 'y' line defaults
-// to the primary (left) axis, or the right axis when align === 'Right'; 'x' (category)
-// lines have no left/right and ride with the primary group. Returns, per series index, the
-// markLine to attach (or undefined). Single-axis charts host everything on the first series.
-function assignReferenceMarkLines(
+// Reference lines are drawn as markLines on their own empty series, one per value axis
+// they target, instead of on a plotted series. A markLine inherits the axis and the
+// visibility of its host, so hosting on real data would put a line on the wrong scale and
+// let a legend toggle take it away with the series. A 'y' line targets the left axis, or
+// the right one when align === 'Right'; 'x' (category) lines have no left/right and ride
+// with the left group. Append the result to `series` after the legend is built so these
+// hosts stay out of it.
+function getReferenceLineSeries(
 	reference_lines: ReferenceLine[] | undefined,
-	seriesAligns: ('Left' | 'Right')[],
-	swapAxes: boolean,
+	hasRightAxis: boolean,
+	swapAxes = false,
 ) {
-	const perSeries: (ReturnType<typeof getReferenceMarkLine>)[] = seriesAligns.map(() => undefined)
-	if (!reference_lines?.length) return perSeries
+	if (!reference_lines?.length) return []
 
-	const rightHost = seriesAligns.findIndex((a) => a === 'Right')
-	const leftHost = seriesAligns.findIndex((a) => a !== 'Right')
-	const primaryHost = leftHost !== -1 ? leftHost : 0
+	const targetsRight = (line: ReferenceLine) =>
+		hasRightAxis && (line.axis || 'y') === 'y' && line.align === 'Right'
 
-	// Group lines by the series index that hosts their target axis, then build one
-	// markLine per host. Grouping (rather than one assignment per axis) keeps every line
-	// even when both hosts collapse to the same series — e.g. when every series is
-	// right-aligned, primary and right host are both index 0.
-	const linesByHost = new Map<number, ReferenceLine[]>()
-	for (const line of reference_lines) {
-		const wantsRight = (line.axis || 'y') === 'y' && line.align === 'Right'
-		const host = wantsRight && rightHost !== -1 ? rightHost : primaryHost
-		if (!linesByHost.has(host)) linesByHost.set(host, [])
-		linesByHost.get(host)!.push(line)
-	}
-	for (const [host, lines] of linesByHost) {
-		perSeries[host] = getReferenceMarkLine(lines, swapAxes)
-	}
-	return perSeries
+	// the value axis is the yAxis normally, but becomes the xAxis when axes are swapped
+	const axisIndexKey = swapAxes ? 'xAxisIndex' : 'yAxisIndex'
+
+	return [
+		{ axisIndex: 0, lines: reference_lines.filter((l) => !targetsRight(l)) },
+		{ axisIndex: 1, lines: reference_lines.filter(targetsRight) },
+	]
+		.map(({ axisIndex, lines }) => {
+			const markLine = getReferenceMarkLine(lines, swapAxes)
+			return markLine
+				? {
+						type: 'line',
+						name: `_reference_lines_${axisIndex}`,
+						data: [],
+						silent: true,
+						[axisIndexKey]: axisIndex,
+						markLine,
+				  }
+				: undefined
+		})
+		.filter(Boolean)
 }
 
+// A 'y' line is horizontal (at a measure value); an 'x' line is vertical (at a
+// category/date value). `swapAxes` (Row chart) flips which ECharts axis each maps to.
 function getReferenceMarkLine(reference_lines?: ReferenceLine[], swapAxes = false) {
 	if (!reference_lines?.length) return undefined
 
@@ -473,13 +469,15 @@ function getReferenceMarkLine(reference_lines?: ReferenceLine[], swapAxes = fals
 			// the value axis is yAxis normally, but becomes xAxis when axes are swapped
 			const axisKey = onValueAxis === !swapAxes ? 'yAxis' : 'xAxis'
 			const rawValue = onValueAxis ? Number(line.value) : line.value
+			// a neutral gray by default, so a reference line doesn't read as another measure
+			const color = line.color || '#6b7280'
 
 			const entry: any = {
 				[axisKey]: rawValue,
 				lineStyle: {
 					type: line.dashed ? 'dashed' : 'solid',
 					width: 1.5,
-					...(line.color ? { color: line.color } : {}),
+					color,
 				},
 			}
 			if (line.label) {
@@ -487,7 +485,7 @@ function getReferenceMarkLine(reference_lines?: ReferenceLine[], swapAxes = fals
 					show: true,
 					position: 'insideEndTop',
 					formatter: line.label,
-					...(line.color ? { color: line.color } : {}),
+					color,
 				}
 			}
 			return entry

--- a/frontend/src2/charts/helpers.ts
+++ b/frontend/src2/charts/helpers.ts
@@ -602,13 +602,28 @@ function getDonutChartData(
 
 export function getFunnelChartOptions(config: FunnelChartConfig, result: QueryResult) {
 	const rows = result.rows
-
-	const labelColumn = config.label_column.dimension_name
-	const valueColumn = config.value_column.measure_name
 	const show_percentage = config.show_percentage ?? true
 
-	const categories = rows.map((r) => r[labelColumn] as string)
-	const dataValues = rows.map((r) => r[valueColumn] as number)
+	// Measures mode: each measure is a stage. The data_query aggregates them with
+	// no group-by, so the result is a single row with one column per measure.
+	const measures = config.measures?.filter((m) => m.measure_name)
+
+	let categories: string[]
+	let dataValues: number[]
+	let seriesName: string
+
+	if (measures?.length) {
+		const row = rows[0] || {}
+		categories = measures.map((m) => m.measure_name)
+		dataValues = measures.map((m) => Number(row[m.measure_name]) || 0)
+		seriesName = 'Funnel'
+	} else {
+		const labelColumn = config.label_column?.dimension_name as string
+		const valueColumn = config.value_column?.measure_name as string
+		categories = rows.map((r) => r[labelColumn] as string)
+		dataValues = rows.map((r) => r[valueColumn] as number)
+		seriesName = valueColumn
+	}
 
 	const count = dataValues.length
 	const colors = Array.from({ length: count }, (_, i) => {
@@ -676,7 +691,7 @@ export function getFunnelChartOptions(config: FunnelChartConfig, result: QueryRe
 		series: [
 			{
 				type: 'custom',
-				name: valueColumn,
+				name: seriesName,
 				emphasis: { disabled: true },
 				data: dataValues.map((val, i) => ({
 					name: categories[i],

--- a/frontend/src2/charts/helpers.ts
+++ b/frontend/src2/charts/helpers.ts
@@ -443,19 +443,23 @@ function assignReferenceMarkLines(
 	if (!reference_lines?.length) return perSeries
 
 	const rightHost = seriesAligns.findIndex((a) => a === 'Right')
-	const primaryHost = Math.max(
-		seriesAligns.findIndex((a) => a !== 'Right'),
-		0,
-	)
+	const leftHost = seriesAligns.findIndex((a) => a !== 'Right')
+	const primaryHost = leftHost !== -1 ? leftHost : 0
 
-	const rightLines =
-		rightHost !== -1
-			? reference_lines.filter((l) => (l.axis || 'y') === 'y' && l.align === 'Right')
-			: []
-	const primaryLines = reference_lines.filter((l) => !rightLines.includes(l))
-
-	perSeries[primaryHost] = getReferenceMarkLine(primaryLines, swapAxes)
-	if (rightHost !== -1) perSeries[rightHost] = getReferenceMarkLine(rightLines, swapAxes)
+	// Group lines by the series index that hosts their target axis, then build one
+	// markLine per host. Grouping (rather than one assignment per axis) keeps every line
+	// even when both hosts collapse to the same series — e.g. when every series is
+	// right-aligned, primary and right host are both index 0.
+	const linesByHost = new Map<number, ReferenceLine[]>()
+	for (const line of reference_lines) {
+		const wantsRight = (line.axis || 'y') === 'y' && line.align === 'Right'
+		const host = wantsRight && rightHost !== -1 ? rightHost : primaryHost
+		if (!linesByHost.has(host)) linesByHost.set(host, [])
+		linesByHost.get(host)!.push(line)
+	}
+	for (const [host, lines] of linesByHost) {
+		perSeries[host] = getReferenceMarkLine(lines, swapAxes)
+	}
 	return perSeries
 }
 

--- a/frontend/src2/components/DataTable.vue
+++ b/frontend/src2/components/DataTable.vue
@@ -21,7 +21,13 @@ import {
 	text_rules,
 } from '../query/components/formatting_utils'
 import { matchesFilter, parseFilterString } from '../query/helpers'
-import { QueryResultColumn, QueryResultRow, SortDirection, SortOrder } from '../types/query.types'
+import {
+	DataFormat,
+	QueryResultColumn,
+	QueryResultRow,
+	SortDirection,
+	SortOrder,
+} from '../types/query.types'
 import DataTableColumn from './DataTableColumn.vue'
 import DataTableFooter from './DataTableFooter.vue'
 import LazyTextInput from './LazyTextInput.vue'
@@ -49,6 +55,7 @@ const props = defineProps<{
 	stickyColumns?: string[]
 	columnWidths?: Record<string, number>
 	textWrap?: Record<string, boolean>
+	columnFormats?: Record<string, DataFormat>
 	pageSize?: number
 	displayPageSize?: number
 	totalRowCount?: number
@@ -517,10 +524,13 @@ function getCellStyleClass(colName: string, val: any): string {
 	return ''
 }
 
-function _formatNumber(value: any) {
+function _formatNumber(value: any, columnName?: string) {
 	const isNull = value === null || value === undefined
 	if (isNull) {
 		return props.replaceNullsWithZeros ? 0 : 'null'
+	}
+	if (columnName && props.columnFormats?.[columnName] === 'percent') {
+		return `${formatNumber(value * 100)}%`
 	}
 	return props.compactNumbers ? getShortNumber(value) : formatNumber(value)
 }
@@ -715,7 +725,7 @@ function toggleNewColumn() {
 							@dblclick="isNumberColumn(col.name) && props.onDrilldown?.(col, row)"
 						>
 							<template v-if="isNumberColumn(col.name)">
-								{{ _formatNumber(row[col.name]) }}
+								{{ _formatNumber(row[col.name], col.name) }}
 							</template>
 							<template v-else-if="isUrl(row[col.name])">
 								<a :href="row[col.name]" target="_blank" class="underline">
@@ -757,7 +767,7 @@ function toggleNewColumn() {
 						>
 							{{
 								isNumberColumn(col.name)
-									? _formatNumber(totalPerColumn[col.name])
+									? _formatNumber(totalPerColumn[col.name], col.name)
 									: ''
 							}}
 						</td>

--- a/frontend/src2/types/chart.types.ts
+++ b/frontend/src2/types/chart.types.ts
@@ -112,8 +112,12 @@ export type DonutChartConfig = {
 	show_inline_labels?: boolean
 }
 export type FunnelChartConfig = {
-	label_column: Dimension
-	value_column: Measure
+	// Measures mode: each measure is one funnel stage, aggregated over the whole
+	// result with no group-by (stage label = measure name). Takes precedence when set.
+	measures?: Measure[]
+	// Grouped (long-format) mode: group `label_column` and read `value_column` per row.
+	label_column?: Dimension
+	value_column?: Measure
 	show_percentage?: boolean
 }
 

--- a/frontend/src2/types/chart.types.ts
+++ b/frontend/src2/types/chart.types.ts
@@ -31,6 +31,15 @@ export type YAxis = {
 	show_axis_label?: boolean
 	show_data_labels?: boolean
 	show_scrollbar?: boolean
+	reference_lines?: ReferenceLine[]
+}
+export type ReferenceLine = {
+	// 'y' draws a horizontal line at a measure value, 'x' a vertical line at a category/date value
+	axis?: 'x' | 'y'
+	value?: number | string
+	label?: string
+	color?: string
+	dashed?: boolean
 }
 export type Series = {
 	name?: string

--- a/frontend/src2/types/chart.types.ts
+++ b/frontend/src2/types/chart.types.ts
@@ -36,6 +36,8 @@ export type YAxis = {
 export type ReferenceLine = {
 	// 'y' draws a horizontal line at a measure value, 'x' a vertical line at a category/date value
 	axis?: 'x' | 'y'
+	// which value axis a 'y' line targets on a dual-axis chart; defaults to the primary (left)
+	align?: 'Left' | 'Right'
 	value?: number | string
 	label?: string
 	color?: string

--- a/frontend/src2/types/query.types.ts
+++ b/frontend/src2/types/query.types.ts
@@ -18,11 +18,13 @@ export type ColumnMeasure = {
 	column_name: string
 	data_type: MeasureDataType
 	aggregation: AggregationType
+	format?: DataFormat
 }
 export type ExpressionMeasure = {
 	measure_name: string
 	expression: Expression
 	data_type: MeasureDataType
+	format?: DataFormat
 }
 export type MeasureOption = Measure & { label: string; value: string }
 export type Dimension = {


### PR DESCRIPTION
Four small chart-engine improvements, each independent:

- **Reference/target lines** on line & bar charts (`y_axis.reference_lines`) — horizontal value lines or vertical markers, with label, color, dashed.
- **Funnel from multiple measures** — a funnel can be built from one-measure-per-stage, no union/unpivot query needed. Legacy label+value mode still works.
- **Percent-formatted measures** (`format: "percent"`) on number cards and tables — renders a ratio ×100 with `%`. Wires up the previously-dead `DataFormat` type; also fixes `json_extract` (a JSON null returned the text `'null'`, and the inferred type was never applied).
- **Fix**: a numeric x-axis dimension was plotted as a stray series on line/bar/row — now excluded.

All additive/backward-compatible; existing charts render unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)