### PR TITLE
feat: allow serving the app from a custom path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,8 +173,7 @@ node_modules
 *debug.log
 insights/docs/current
 insights/public/frontend
-insights/www/insights.html
-insights/www/insights_v2.html
+insights/www/_insights.html
 .nyc_output
 coverage/
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,7 @@
 		"dev": "vite",
 		"serve": "vite preview",
 		"build": "vite build -l warn --base=/assets/insights/frontend/ && yarn copy-html-entry",
-		"copy-html-entry": "cp ../insights/public/frontend/index.html ../insights/www/insights.html"
+		"copy-html-entry": "cp ../insights/public/frontend/index.html ../insights/www/_insights.html"
 	},
 	"dependencies": {
 		"@codemirror/lang-javascript": "^6.0.2",

--- a/frontend/src2/app_path.ts
+++ b/frontend/src2/app_path.ts
@@ -1,0 +1,10 @@
+declare global {
+	interface Window {
+		insights_path?: string
+	}
+}
+
+// Sites can serve the app from a path other than /insights (site config
+// `insights_path`); the server sends the effective one in boot data. Only the
+// router base needs it — build links via router.resolve() so they pick this up.
+export const APP_PATH = window.insights_path || '/insights'

--- a/frontend/src2/charts/chart.ts
+++ b/frontend/src2/charts/chart.ts
@@ -430,7 +430,11 @@ function makeChart(name: string) {
 	}
 
 	function getShareLink() {
-		return `${window.location.origin}/insights/shared/chart/${chart.doc.name}`
+		const { href } = router.resolve({
+			name: 'SharedChart',
+			params: { chart_name: chart.doc.name },
+		})
+		return `${window.location.origin}${href}`
 	}
 
 	function getDependentQueries() {

--- a/frontend/src2/dashboard/dashboard.ts
+++ b/frontend/src2/dashboard/dashboard.ts
@@ -2,6 +2,7 @@ import { reactive, ref, toRefs } from 'vue'
 // @ts-ignore
 import { useTelemetry } from 'frappe-ui/frappe'
 import useChart from '../charts/chart'
+import router from '../router'
 import {
 	getUniqueId,
 	safeJSONParse,
@@ -319,10 +320,11 @@ function makeDashboard(name: string) {
 	}
 
 	function getShareLink() {
-		return (
-			dashboard.doc.share_link ||
-			`${window.location.origin}/insights/shared/dashboard/${dashboard.doc.name}`
-		)
+		const { href } = router.resolve({
+			name: 'SharedDashboard',
+			params: { dashboard_name: dashboard.doc.name },
+		})
+		return dashboard.doc.share_link || `${window.location.origin}${href}`
 	}
 
 	function updateAccess(data: {

--- a/frontend/src2/router.ts
+++ b/frontend/src2/router.ts
@@ -1,4 +1,5 @@
 import { createRouter, createWebHistory, RouteLocation } from 'vue-router'
+import { APP_PATH } from './app_path.ts'
 import session from './session.ts'
 
 const routes = [
@@ -114,7 +115,7 @@ const routes = [
 ]
 
 let router = createRouter({
-	history: createWebHistory('/insights'),
+	history: createWebHistory(APP_PATH),
 	// @ts-ignore
 	routes,
 })

--- a/frontend/src2/workbook/workbook.ts
+++ b/frontend/src2/workbook/workbook.ts
@@ -242,7 +242,10 @@ function makeWorkbook(name: string) {
 							message: __('Workbook duplicated successfully'),
 							variant: 'success',
 						})
-						window.location.href = `/insights/workbook/${name}`
+						window.location.href = router.resolve({
+							name: 'Workbook',
+							params: { workbook_name: name },
+						}).href
 					})
 					.catch(showErrorToast)
 			},

--- a/insights/api/user.py
+++ b/insights/api/user.py
@@ -10,6 +10,7 @@ from insights.insights.doctype.insights_team.insights_team import (
     get_teams as get_user_teams,
 )
 from insights.insights.doctype.insights_team.insights_team import is_admin
+from insights.utils import get_app_url
 
 
 @insights_whitelist()
@@ -213,7 +214,7 @@ def accept_invitation(key: str):
     if invitation.status == "Accepted":
         frappe.local.login_manager.login_as(invitation.email)
         frappe.local.response["type"] = "redirect"
-        frappe.local.response["location"] = "/insights"
+        frappe.local.response["location"] = get_app_url()
 
 
 @insights_whitelist(role="Insights Admin")

--- a/insights/hooks.py
+++ b/insights/hooks.py
@@ -13,8 +13,9 @@ export_python_type_annotations = True
 require_type_annotated_api_methods = True
 
 # Sites that already serve something at /insights (e.g. a website page) can move
-# the app elsewhere by setting `insights_path` in site config.
-insights_path = frappe.conf.insights_path or "insights"
+# the app elsewhere by setting `insights_path` in site config. Stored without
+# slashes so everything below can build paths as f"/{insights_path}".
+insights_path = (frappe.conf.insights_path or "insights").strip("/") or "insights"
 
 add_to_apps_screen = [
     {

--- a/insights/hooks.py
+++ b/insights/hooks.py
@@ -1,3 +1,5 @@
+import frappe
+
 app_name = "insights"
 app_title = "Insights"
 app_publisher = "Frappe Technologies Pvt. Ltd."
@@ -10,13 +12,16 @@ app_license = "GNU GPLv3"
 export_python_type_annotations = True
 require_type_annotated_api_methods = True
 
+# Sites that already serve something at /insights (e.g. a website page) can move
+# the app elsewhere by setting `insights_path` in site config.
+insights_path = frappe.conf.insights_path or "insights"
 
 add_to_apps_screen = [
     {
         "name": "insights",
         "logo": "/assets/insights/frontend/insights-logo.png",
         "title": "Insights",
-        "route": "/insights",
+        "route": f"/{insights_path}",
         "has_permission": "insights.permissions.check_app_permission",
     }
 ]
@@ -232,5 +237,6 @@ before_tests = "insights.tests.utils.before_tests"
 page_renderer = "insights.utils.InsightsPageRenderer"
 
 website_route_rules = [
-    {"from_route": "/insights/<path:app_path>", "to_route": "insights"},
+    {"from_route": f"/{insights_path}/<path:app_path>", "to_route": "_insights"},
+    {"from_route": f"/{insights_path}", "to_route": "_insights"},
 ]

--- a/insights/insights/doctype/insights_dashboard_v3/insights_dashboard_v3.py
+++ b/insights/insights/doctype/insights_dashboard_v3/insights_dashboard_v3.py
@@ -11,7 +11,7 @@ from frappe.query_builder import Interval
 from frappe.query_builder.functions import Now
 from frappe.utils.telemetry import capture
 
-from insights.utils import DocShare, File
+from insights.utils import DocShare, File, get_app_url
 
 
 class InsightsDashboardv3(Document):
@@ -151,7 +151,7 @@ class InsightsDashboardv3(Document):
     def generate_dashboard_preview(self):
         with generate_preview_key() as key:
             preview = get_page_preview(
-                frappe.utils.get_url(f"/insights/shared/dashboard/{self.name}"),
+                frappe.utils.get_url(get_app_url(f"/shared/dashboard/{self.name}")),
                 headers={
                     "X-Insights-Preview-Key": key,
                 },

--- a/insights/insights/page/insights/insights.js
+++ b/insights/insights/page/insights/insights.js
@@ -1,3 +1,7 @@
-frappe.pages['insights'].on_page_load = function (wrapper) {
-	window.location.href = '/insights'
-}
+frappe.pages["insights"].on_page_load = function (wrapper) {
+	// site config can move the app off /insights; boot carries the effective route
+	const app = (frappe.boot.app_data || []).find(
+		(a) => a.app_name === "insights",
+	);
+	window.location.href = app?.app_route || "/insights";
+};

--- a/insights/public/js/insights_nudge.bundle.js
+++ b/insights/public/js/insights_nudge.bundle.js
@@ -11,7 +11,11 @@
 	if (window.__insights_nudge_loaded) return;
 	window.__insights_nudge_loaded = true;
 
-	const BASE = "/insights"; // v3 frontend base route
+	// v3 frontend base route — site config can move the app off /insights, so read
+	// the effective route from boot instead of hardcoding it.
+	const BASE =
+		(frappe.boot.app_data || []).find((a) => a.app_name === "insights")
+			?.app_route || "/insights";
 	const ALLOWED_ROLES = ["Insights Admin"];
 
 	// Workspace -> shipped workbook template. `template` is the folder under

--- a/insights/utils.py
+++ b/insights/utils.py
@@ -9,6 +9,12 @@ import pandas as pd
 from frappe.model.base_document import BaseDocument
 from frappe.website.page_renderers.template_page import TemplatePage
 
+from insights.hooks import insights_path
+
+
+def get_app_url(path: str = "") -> str:
+    return f"/{insights_path}{path}"
+
 
 class DoctypeBase(BaseDocument):
     doctype: str
@@ -164,8 +170,8 @@ class InsightsPageRenderer(TemplatePage):
             path = self.path
 
         embed_urls = [
-            "/insights/public",
-            "/insights/shared",
+            get_app_url("/public"),
+            get_app_url("/shared"),
         ]
         if not any(path.startswith(url) for url in embed_urls):
             return False

--- a/insights/www/_insights.py
+++ b/insights/www/_insights.py
@@ -4,6 +4,8 @@
 
 import frappe
 
+from insights.hooks import insights_path
+
 no_cache = 1
 
 
@@ -22,4 +24,5 @@ def get_context(context):
         "site_name": frappe.local.site,
         "is_fc_site": is_fc_site(),
         "socketio_port": frappe.conf.get("socketio_port"),
+        "insights_path": f"/{insights_path}",
     }


### PR DESCRIPTION
On sites that already use `/insights` for something else — frappe.io serves a Builder page there — the app frontend is unreachable: Builder's `website_path_resolver` and `page_renderer` hooks both run ahead of the app's www page, so the route never reaches us. Same problem Builder solved for itself with `builder_path`.

Such sites can now set `insights_path` in site config to move the app.

- `insights/www/insights.py` → `_insights.py`, so the page is reachable only through the route rules and no longer claims `/insights` by virtue of its filename. **This means `/insights` 404s until the frontend is rebuilt** (`_insights.html` is a build artifact).
- The effective path reaches the SPA through boot data and is used only as the router base — the share/duplicate links now go through `router.resolve()` so they inherit it.
- Desk-side scripts read the app route from `frappe.boot.app_data`, which already carries it from `add_to_apps_screen`.
- Server-side absolute paths (embed renderer, dashboard preview, invitation redirect) go through `get_app_url()`.

Default behaviour is unchanged.

Untested on a relocated site so far — verified only that hooks resolve and the default path is unaffected.