### PR TITLE
fix: dashboard filters applied but not shown after reopen

### DIFF
--- a/frontend/src2/dashboard/DashboardFilter.vue
+++ b/frontend/src2/dashboard/DashboardFilter.vue
@@ -50,15 +50,16 @@ function stringValuesProvider(search: string) {
 
 const filterState = reactive(copy(dashboard.filterStates[filter.filter_name] || {}))
 
+// no `immediate` — on mount, filterState must keep the restored state from dashboard.filterStates
 watch(
 	() => [filter.default_operator, filter.default_value],
 	([op, val]) => {
-		if (op !== null && val !== null) {
+		if (op != null && val != null) {
 			filterState.operator = op as FilterOperator
 			filterState.value = val
 		}
 	},
-	{ immediate: true, deep: true },
+	{ deep: true },
 )
 
 wheneverChanges(


### PR DESCRIPTION
Since #1191, a dashboard filter with no default value looks empty on reopen while the persisted filter state still filters the charts. There is no way to clear it from the UI.

Cause: the watch on the default filter config ran with `immediate: true` on mount. Unset defaults are `undefined`, not `null`, so the guard passed and reset the local filter state that was just restored from localStorage. The reset ran before the sync watcher was registered, so the persisted state kept the old value.

Fix: run the watch only when the default config changes, and use `!= null` so both `null` and `undefined` count as unset. Affected users self-heal on the next filter change.