### PR TITLE
fix: dashboard charts fail with "server is busy"

### DIFF
--- a/frontend/src2/dashboard/dashboard.ts
+++ b/frontend/src2/dashboard/dashboard.ts
@@ -215,7 +215,18 @@ function makeDashboard(name: string) {
 	function refreshChart(chart_name: string, force = false) {
 		const chart = useChart(chart_name)
 		chart.dataQuery.adhocFilters = getAdhocFilters(chart_name)
+		chart.dataQuery.executionPriority = getLayoutRank(chart_name)
 		chart.refresh(force)
+	}
+
+	// charts reach the queue in whatever order their docs finish loading, so rank
+	// them by grid position instead: top row first, left to right within a row
+	function getLayoutRank(chart_name: string) {
+		const item = dashboard.doc.items.find(
+			(item) => item.type === 'chart' && item.chart === chart_name
+		)
+		if (!item) return undefined
+		return item.layout.y * grid_cols + item.layout.x
 	}
 
 	function getAdhocFilters(chart_name: string, exclude_filter_name?: string) {

--- a/frontend/src2/query/execution_queue.ts
+++ b/frontend/src2/query/execution_queue.ts
@@ -1,0 +1,70 @@
+// Only live source queries are capped server-side; cached and data store results
+// come back without ever reaching the limiter. The client can't tell which path a
+// query will take, so it doesn't try to stay under the server's limit - it fires up
+// to a browser-friendly number at once and treats a rejection as "come back later".
+
+const MAX_IN_FLIGHT = 6
+const MAX_ATTEMPTS = 8
+const RETRY_BASE_DELAY = 1000
+// a rejected request still builds the query before the limiter turns it away, so it
+// isn't free - back off to a steady interval instead of polling ever faster
+const MAX_RETRY_DELAY = 8000
+
+let inFlight = 0
+const waiting: Array<() => void> = []
+
+class StaleExecutionError extends Error {}
+
+function acquireSlot(): Promise<void> {
+	if (inFlight < MAX_IN_FLIGHT) {
+		inFlight++
+		return Promise.resolve()
+	}
+	return new Promise((resolve) => waiting.push(resolve))
+}
+
+function releaseSlot() {
+	// hand the slot straight to the next in line, so it can't be taken by a
+	// caller that arrives in between
+	const next = waiting.shift()
+	if (next) return next()
+	inFlight--
+}
+
+export function isServerBusyError(err: any) {
+	return err?.status === 503 && err?.exc_type === 'ServiceUnavailableError'
+}
+
+function retryDelay(attempt: number) {
+	const delay = Math.min(RETRY_BASE_DELAY * 2 ** (attempt - 1), MAX_RETRY_DELAY)
+	// jittered, so a batch of charts doesn't retry in lockstep
+	return delay * (0.5 + Math.random())
+}
+
+/**
+ * Run a server call once a slot is free, retrying while the server reports it is busy.
+ *
+ * The server rejects a busy query immediately, so the attempts below are what give a
+ * chart time to wait its turn - together they keep trying for roughly 20-60s before
+ * giving up and surfacing the error.
+ *
+ * `isStale` lets a superseded execution drop out instead of spending a slot on a
+ * result nobody is waiting for.
+ */
+export async function scheduleQueryExecution<T>(
+	run: () => Promise<T>,
+	isStale?: () => boolean,
+): Promise<T> {
+	for (let attempt = 1; ; attempt++) {
+		await acquireSlot()
+		try {
+			if (isStale?.()) throw new StaleExecutionError()
+			return await run()
+		} catch (err) {
+			if (attempt >= MAX_ATTEMPTS || !isServerBusyError(err)) throw err
+		} finally {
+			releaseSlot()
+		}
+		await new Promise((resolve) => setTimeout(resolve, retryDelay(attempt)))
+	}
+}

--- a/frontend/src2/query/execution_queue.ts
+++ b/frontend/src2/query/execution_queue.ts
@@ -10,25 +10,35 @@ const RETRY_BASE_DELAY = 1000
 // isn't free - back off to a steady interval instead of polling ever faster
 const MAX_RETRY_DELAY = 8000
 
+type Waiter = { priority: number; resume: () => void }
+
 let inFlight = 0
-const waiting: Array<() => void> = []
+const waiting: Waiter[] = []
 
 class StaleExecutionError extends Error {}
 
-function acquireSlot(): Promise<void> {
+function acquireSlot(priority: number): Promise<void> {
 	if (inFlight < MAX_IN_FLIGHT) {
 		inFlight++
 		return Promise.resolve()
 	}
-	return new Promise((resolve) => waiting.push(resolve))
+	return new Promise((resume) => waiting.push({ priority, resume }))
 }
 
 function releaseSlot() {
-	// hand the slot straight to the next in line, so it can't be taken by a
-	// caller that arrives in between
-	const next = waiting.shift()
-	if (next) return next()
-	inFlight--
+	if (!waiting.length) {
+		inFlight--
+		return
+	}
+
+	let next = 0
+	for (let i = 1; i < waiting.length; i++) {
+		// strictly lower, so equal priorities keep their arrival order
+		if (waiting[i].priority < waiting[next].priority) next = i
+	}
+	// hand the slot straight over, so it can't be taken by a caller that
+	// arrives in between
+	waiting.splice(next, 1)[0].resume()
 }
 
 export function isServerBusyError(err: any) {
@@ -49,14 +59,18 @@ function retryDelay(attempt: number) {
  * giving up and surfacing the error.
  *
  * `isStale` lets a superseded execution drop out instead of spending a slot on a
- * result nobody is waiting for.
+ * result nobody is waiting for. `priority` orders the waiting calls, lowest first -
+ * dashboard charts pass their position so the top of the page loads before the
+ * bottom. Calls that are already running are not preempted.
  */
 export async function scheduleQueryExecution<T>(
 	run: () => Promise<T>,
-	isStale?: () => boolean,
+	options: { isStale?: () => boolean; priority?: number } = {},
 ): Promise<T> {
+	const { isStale, priority = 0 } = options
+
 	for (let attempt = 1; ; attempt++) {
-		await acquireSlot()
+		await acquireSlot(priority)
 		try {
 			if (isStale?.()) throw new StaleExecutionError()
 			return await run()

--- a/frontend/src2/query/query.ts
+++ b/frontend/src2/query/query.ts
@@ -164,6 +164,9 @@ export function makeQuery(name: string) {
 	let currentExecutionToken = 0
 
 	const adhocFilters = ref<AdhocFilters>()
+	// set by whoever owns the layout, so a screenful of queries runs in a sensible
+	// order once they outnumber the free slots
+	const executionPriority = ref<number>()
 	async function execute(force: boolean = false, page_size?: number) {
 		if (!query.islocal) {
 			await waitUntil(() => query.isloaded)
@@ -207,7 +210,7 @@ export function makeQuery(name: string) {
 					page: currentPage.value,
 					page_size: pageSize.value,
 				}),
-			isStale
+			{ isStale, priority: executionPriority.value }
 		)
 		.then((response: any) => {
 			if (isStale()) return
@@ -1139,6 +1142,7 @@ export function makeQuery(name: string) {
 		currentOperations,
 		activeEditOperation,
 		adhocFilters,
+		executionPriority,
 
 		autoExecute,
 		executing,

--- a/frontend/src2/query/query.ts
+++ b/frontend/src2/query/query.ts
@@ -19,6 +19,7 @@ import { createToast } from '../helpers/toasts'
 import { __ } from '../translation'
 import router from '../router'
 import session from '../session'
+import { isServerBusyError, scheduleQueryExecution } from './execution_queue'
 import {
 	AdhocFilters,
 	CodeArgs,
@@ -195,17 +196,21 @@ export function makeQuery(name: string) {
 
 		executing.value = true
 		const token = ++currentExecutionToken
-		return query
-			.call('execute', {
-				active_operation_idx: activeOperationIdx.value,
-				adhoc_filters: adhocFilters.value,
-				force: Boolean(force),
-				page: currentPage.value,
-				page_size: pageSize.value,
-			})
+		// discard the result if a newer execution has superseded this one
+		const isStale = () => token !== currentExecutionToken
+		return scheduleQueryExecution(
+			() =>
+				query.call('execute', {
+					active_operation_idx: activeOperationIdx.value,
+					adhoc_filters: adhocFilters.value,
+					force: Boolean(force),
+					page: currentPage.value,
+					page_size: pageSize.value,
+				}),
+			isStale
+		)
 		.then((response: any) => {
-			// Discard stale responses — a newer execution has superseded this one
-			if (token !== currentExecutionToken) return
+			if (isStale()) return
 			if (!response) return
 
 			result.value.executedSQL = response.sql
@@ -235,14 +240,12 @@ export function makeQuery(name: string) {
 			result.value.lastExecutedAt = new Date()
 		})
 			.catch((err) => {
-				if (err.status === 503 && err.message && err.message.includes('ServiceUnavailableError')) {
-					isServerBusy.value = true
-				}
-				if (token !== currentExecutionToken) return
+				if (isStale()) return
+				isServerBusy.value = isServerBusyError(err)
 				result.value = { ...EMPTY_RESULT }
 			})
 			.finally(() => {
-				if (token !== currentExecutionToken) return
+				if (isStale()) return
 				executing.value = false
 				lastExecutionArgs = {
 					operations: currentOperations.value,
@@ -271,11 +274,12 @@ export function makeQuery(name: string) {
 		}
 
 		fetchingCount.value = true
-		return query
-			.call('get_count', {
+		return scheduleQueryExecution(() =>
+			query.call('get_count', {
 				active_operation_idx: activeOperationIdx.value,
 				adhoc_filters: adhocFilters.value,
 			})
+		)
 			.then((count: number) => {
 				result.value.totalRowCount = count || 0
 			})

--- a/insights/insights/doctype/insights_data_source_v3/ibis_utils.py
+++ b/insights/insights/doctype/insights_data_source_v3/ibis_utils.py
@@ -981,7 +981,10 @@ def execute_ibis_query(
     return result, time_taken
 
 
-@concurrent_limit()
+# reject immediately instead of waiting for a slot: a blocked request holds on to a
+# web thread, so waiting here is what starves the pool when a dashboard executes all
+# of its charts at once. The frontend retries on the 503.
+@concurrent_limit(wait_timeout=0)
 def _execute_live_query(query: IbisQuery):
     start = time.monotonic()
     result = query.execute()


### PR DESCRIPTION
Dashboards with 10+ charts fail with "server is busy" on benches that have few gunicorn threads.

The cause is not the concurrency limit itself. Frappe's limiter waits up to 10s for a free slot, and it waits inside the web thread. The charts queued behind the limit are what starve the pool.

`_execute_live_query` now sets `wait_timeout=0`, so the limiter rejects an over-limit query at once and the thread goes back to serving requests. The frontend absorbs the wait instead: it caps in-flight query calls and retries the 503 with jittered backoff.

Worth knowing while reviewing: cache hits and data store queries return before the limiter, so they never hit it. The client queue therefore does not try to match the server limit. It only prevents a burst.

Admins on small benches should still raise the worker count. This stops the failure, it does not add capacity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)