### PR TITLE
fix: keep throwaway queries out of the query cache

### DIFF
--- a/frontend/src2/charts/chart.ts
+++ b/frontend/src2/charts/chart.ts
@@ -12,7 +12,7 @@ import { GranularityType } from '../helpers/constants'
 import useDocumentResource from '../helpers/resource'
 import { createToast } from '../helpers/toasts'
 import { column, count, query_table } from '../query/helpers'
-import useQuery, { Query } from '../query/query'
+import useQuery, { makeAdhocQuery, Query } from '../query/query'
 import router from '../router'
 import { __ } from '../translation'
 import {
@@ -68,7 +68,7 @@ function makeChart(name: string) {
 		const isValid = validateConfig()
 		if (!isValid) return
 
-		const query = useQuery('new-query-' + getUniqueId())
+		const query = makeAdhocQuery()
 		addSourceOperation(query)
 		addFilterOperation(query)
 		addChartOperation(query)

--- a/frontend/src2/query/query.ts
+++ b/frontend/src2/query/query.ts
@@ -86,6 +86,12 @@ export default function useQuery(name: string) {
 	return query
 }
 
+// throwaway queries are never looked up by name, so keep them out of the shared
+// cache, otherwise every chart refresh/drill-down leaks an entry for the session
+export function makeAdhocQuery() {
+	return makeQuery('new-query-' + getUniqueId())
+}
+
 export function makeQuery(name: string) {
 	const query = getQueryResource(name)
 
@@ -796,7 +802,7 @@ export function makeQuery(name: string) {
 			drillDownFilters = getDrillDownFiltersForSummarize(ops, sliceIdx, col, currRow)
 		}
 
-		const drill_down_query = useQuery('new-query-' + getUniqueId())
+		const drill_down_query = makeAdhocQuery()
 		drill_down_query.doc.title = 'Drill Down'
 		drill_down_query.doc.use_live_connection = query.doc.use_live_connection
 		drill_down_query.autoExecute = true


### PR DESCRIPTION
Closes #1272

`useQuery` memoizes into a module-level map with no eviction. Chart refresh and drill-down each built a scratch query under a fresh `new-query-*` name, so every refresh left a permanent entry behind. Memory only, no extra requests.

Both now use a new `makeAdhocQuery()` helper, which builds the query without registering it. Persisted names still go through the cache.

I grepped every `useQuery` call site: nothing resolves these scratch names later. The chart path only copies `doc.operations` onto the persisted `data_query`, and the drill-down query is passed to `DrillDown.vue` by reference.