### PR TITLE
fix: chart breaks when the chart type changes

### DIFF
--- a/frontend/src2/charts/chart.ts
+++ b/frontend/src2/charts/chart.ts
@@ -28,7 +28,12 @@ import {
 } from '../types/chart.types'
 import { InsightsChartv3 } from '../types/workbook.types'
 import useWorkbook, { getLinkedQueries } from '../workbook/workbook'
-import { handleOldXAxisConfig, handleOldYAxisConfig, setDimensionNames } from './helpers'
+import {
+	ensureConfigSlots,
+	handleOldXAxisConfig,
+	handleOldYAxisConfig,
+	setDimensionNames,
+} from './helpers'
 
 const charts = new Map<string, Chart>()
 
@@ -56,6 +61,8 @@ function makeChart(name: string) {
 		if (!chart.isloaded) return {} as Query
 		return useQuery(chart.doc.data_query)
 	})
+
+	const isConfigValid = computed(() => validateConfig())
 	async function refresh(force?: boolean, reload?: boolean) {
 		if (reload) {
 			await chart.load()
@@ -65,8 +72,7 @@ function makeChart(name: string) {
 			() => chart.isloaded && dataQuery.value.isloaded && useQuery(chart.doc.query).isloaded
 		)
 
-		const isValid = validateConfig()
-		if (!isValid) return
+		if (!isConfigValid.value) return
 
 		const query = makeAdhocQuery()
 		addSourceOperation(query)
@@ -122,7 +128,7 @@ function makeChart(name: string) {
 					message: __('X-axis is required'),
 				})
 			}
-			if (config.x_axis.dimension.column_name === config.split_by?.dimension.column_name) {
+			if (config.x_axis.dimension.column_name === config.split_by?.dimension?.column_name) {
 				messages.push({
 					variant: 'error',
 					message: __('X-axis and Split by cannot be the same'),
@@ -474,14 +480,13 @@ function makeChart(name: string) {
 	watch(
 		() => chart.doc.chart_type,
 		(newType: string, oldType: string) => {
-			if (newType === oldType) return
-			if (!newType || !oldType) return
-			if (
-				(AXIS_CHARTS.includes(newType) && !AXIS_CHARTS.includes(oldType)) ||
-				(!AXIS_CHARTS.includes(newType) && AXIS_CHARTS.includes(oldType))
-			) {
+			if (!newType || newType === oldType) return
+			const crossesAxisBoundary =
+				oldType && AXIS_CHARTS.includes(newType) !== AXIS_CHARTS.includes(oldType)
+			if (crossesAxisBoundary) {
 				resetConfig()
 			}
+			ensureConfigSlots(chart.doc.config, newType)
 		}
 	)
 
@@ -537,6 +542,7 @@ function makeChart(name: string) {
 		...toRefs(chart),
 
 		dataQuery,
+		isConfigValid,
 
 		refresh,
 		updateGranularity,
@@ -626,6 +632,7 @@ function transformChartDoc(doc: any) {
 	}
 
 	doc.config = setDimensionNames(doc.config)
+	doc.config = ensureConfigSlots(doc.config, doc.chart_type)
 
 	return doc
 }

--- a/frontend/src2/charts/components/ChartRenderer.vue
+++ b/frontend/src2/charts/components/ChartRenderer.vue
@@ -45,6 +45,9 @@ const loading = computed(
 )
 
 const eChartOptions = computed(() => {
+	// the result outlives a chart type switch, so without this the option builders
+	// would run against the incoming type's still-empty config
+	if (!props.chart.isConfigValid) return
 	if (!result.value.columns?.length) return
 	if (chart_type.value === 'Bar' || chart_type.value === 'Row') {
 		return getBarChartOptions(

--- a/frontend/src2/charts/helpers.ts
+++ b/frontend/src2/charts/helpers.ts
@@ -3,6 +3,7 @@ import { ellipsis, formatNumber, getShortNumber, toTitleCase } from '../helpers'
 import { FIELDTYPES, isCalendarDateType } from '../helpers/constants'
 import { getFormattedDate } from '../query/helpers'
 import {
+	AXIS_CHARTS,
 	AxisChartConfig,
 	BarChartConfig,
 	BubbleChartConfig,
@@ -1450,6 +1451,25 @@ export function handleOldYAxisConfig(old_y_axis: any): AxisChartConfig['y_axis']
 		}
 	}
 	return old_y_axis
+}
+
+// Every chart type reads a fixed set of slots off the config, and the validator and the
+// option builders reach into them without guarding. A type switch replaces the config
+// wholesale, so the incoming type's slots have to exist before anything reads them.
+export function ensureConfigSlots(config: any, chart_type: string) {
+	if (AXIS_CHARTS.includes(chart_type)) {
+		config.x_axis = config.x_axis || {}
+		config.x_axis.dimension = config.x_axis.dimension || {}
+		config.y_axis = config.y_axis || {}
+		config.y_axis.series = config.y_axis.series || []
+	}
+
+	if (chart_type === 'Map') {
+		config.location_column = config.location_column || {}
+		config.value_column = config.value_column || {}
+	}
+
+	return config
 }
 
 export function setDimensionNames(config: any) {


### PR DESCRIPTION
Switching a chart between an axis type and a non-axis type empties the config, and nothing seeded the incoming type's slots. `validateConfig` and the option builders read those slots without guarding, so a switch to Line threw during render and took the builder down with it. The chart could not recover, because no form writes `x_axis` back into the config once it is missing. Deleting the chart was the only way out.

Reproduce on develop: create a Bar chart, pick an x-axis, switch to Number, then switch to Line.

The fix seeds the type's slots in the two places a config is produced — a type change and a load, so charts already saved in a broken state heal on open. `ChartRenderer` also gates the option builders on a new `isConfigValid`, because the previous type's result outlives the switch and would otherwise be drawn against an empty config.

The redundant seeding in the per-type config forms is left alone. It goes away with the config refactor in ADR-0001.

🤖 Generated with [Claude Code](https://claude.com/claude-code)