### PR TITLE
chore: track the project docs on develop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -186,5 +186,12 @@ todo
 frontend/package-lock.json
 .opencode/package-lock.json
 frontend/components.d.ts
-docs/
 scripts/
+
+# Effort docs under docs/projects/ are branch-scoped: they live on the feature
+# branch and are removed when it merges. See docs/agents/issue-tracker.md.
+# These paths are local-only and are never committed.
+docs/archive/
+docs/research/
+docs/projects/workbook_agent/
+docs/projects/gemstaging-doctype-drift/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,43 @@
+# Insights — agent instructions
+
+Frappe BI app. Backend: Python (Frappe framework) in `insights/`. Frontend: Vue 3 +
+frappe-ui in `frontend/src2/`, built with Vite.
+
+## Orientation
+
+- `insights/api/` — whitelisted API endpoints (thin; logic lives in doctype classes)
+- `insights/insights/doctype/` — doctypes; the `_v3` suffix on most of them is
+  historical, not a variant marker (`Insights Workbook` and a few others have none)
+- `insights/workbook_templates/` — shipped workbook templates
+  (`insights_workbook_templates` hook, open to other apps)
+- `frontend/src2/` — the whole UI, one folder per area (`workbook/`, `query/`,
+  `charts/`, `dashboard/`, `data_source/`, `data_store/`)
+- `frontend/src2/types/` — the domain types; read `query.types.ts` before touching
+  query logic
+- Query engine: operations JSON → ibis → SQL, against the source or the DuckDB data
+  store (`insights_data_source_v3/data_warehouse.py`, `ibis_utils.py`)
+- `CONTEXT.md` — the glossary; use its terms in code, tickets, and commits
+
+## Working here
+
+- Bench: run `bench` commands from the bench root, not from this app directory
+- Sites: test against a local development site with Insights installed
+- Branches: `develop` is the default branch; pull requests target
+  `frappe/insights`
+- Frontend dev server: `cd frontend && yarn dev`. Build UI on frappe-ui components
+  and semantic tokens (`text-ink-*`, `bg-surface-*`, `border-outline-*`); no raw
+  buttons or hardcoded colors
+- Run the bench's pre-commit hooks before committing
+
+## Agent skills
+
+### Issue tracker
+
+Markdown under `docs/projects/<effort>/` — a decision map plus one ticket per
+question. Effort docs are branch-scoped: they are removed when the branch merges,
+and the ADR is what survives. GitHub Issues on `frappe/insights` is the public
+queue, not this tracker. See `docs/agents/issue-tracker.md`.
+
+### Domain docs
+
+Single-context: `CONTEXT.md` at the root + `docs/adr/`. See `docs/agents/domain.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,107 @@
+# Insights
+
+Frappe's BI/analytics app. Users connect data sources, build queries as operation
+pipelines, and assemble charts into dashboards — all inside a Workbook.
+
+## Language
+
+### Analysis
+
+**Workbook**:
+The document where analysis happens — a named collection of queries, charts, and
+dashboards, saved and shared as one unit.
+_Avoid_: notebook, report
+
+**Query**:
+An ordered pipeline of Operations producing tabular, per-row results. Queries return
+rows; aggregation for presentation belongs to Charts.
+_Avoid_: dataset
+
+**Operation**:
+One step in a query pipeline — `source`, `join`, `union`, `filter_group`, `select`,
+`mutate`, `summarize`, `order_by`, `limit`, `pivot_wider`, …. Stored as JSON on the
+query, compiled to SQL through ibis.
+_Avoid_: transform, step
+
+**Chart**:
+An aggregated visualization over a query, configured with dimensions and measures.
+Charts aggregate; a mid-pipeline `summarize` in a query is a grain change, not
+presentation.
+_Avoid_: visual, graph
+
+**Dashboard**:
+A grid of charts, filters, and text blocks; each item carries a Layout.
+
+**Dashboard filter**:
+A dashboard-level control that routes filter conditions into the queries behind its
+linked charts.
+
+**Measure**:
+A column or expression aggregated with an aggregation type (sum, count, …).
+_Avoid_: metric
+
+**Dimension**:
+A column that results are grouped or split by, optionally with a date granularity.
+_Avoid_: group-by column
+
+**Expression**:
+An inline calculated column, measure, or filter written in the ibis-based expression
+syntax.
+_Avoid_: formula
+
+### Data
+
+**Data Source**:
+A configured connection to one database (Frappe site, MariaDB, Postgres, DuckDB, …).
+_Avoid_: connection
+
+**Table**:
+A table exposed by a data source, selectable as a query's source.
+
+**Table Link**:
+A stored join relationship between two tables, used to suggest joins.
+
+**Data Store**:
+The site-local DuckDB warehouse holding imported copies of source tables so queries
+run without hitting the source live.
+_Avoid_: warehouse (implementation file name only)
+
+**Table Import**:
+The sync job that copies a source table into the Data Store.
+
+### Framework integration
+
+**Island**:
+An app-provided, self-contained UI unit that the framework mounts into a host page
+(desk or a Vue-frontend app) — shadow-root isolated, linked to the framework-provided
+shared runtime. Declared via the `ui_islands` hook; Insights ships `insights.dashboard`
+and `insights.chart`.
+_Avoid_: widget, block, embed (embed = the public iframe-sharing feature)
+
+### Sharing & governance
+
+**Visibility**:
+A chart's or dashboard's declared audience — who may view it, on any surface.
+A strict ladder: `Private | Specific Roles | Everyone | Public`, declared as
+fields on the content. View-only; editing is governed separately.
+_Avoid_: sharing (person-level DocShare is the `Private` rung, not a separate axis)
+
+**Data Authority**:
+Whose permissions filter a chart's rows at execution: `Viewer` (default — the
+engine applies the viewer's role and user permissions) or `Author` (whole
+numbers, audience-curated). Declared on the content, enforced by the engine.
+_Avoid_: permission mode, run-as
+
+**Team**:
+A named group of users that grants access to resources (data sources, tables).
+
+**Resource Permission**:
+A grant tying a team to one specific resource.
+
+**Template**:
+A pre-built workbook shipped by any installed app via the `insights_workbook_templates`
+hook; imported as one shared, Administrator-owned copy per site.
+
+**Alert**:
+A scheduled check on a query's results that notifies recipients (email or Telegram)
+when its condition is met.

--- a/docs/adr/0001-type-independent-chart-config.md
+++ b/docs/adr/0001-type-independent-chart-config.md
@@ -1,0 +1,96 @@
+# 1. Type-independent chart config
+
+Date: 2026-08-05
+
+## Status
+
+Accepted. The implementation is sequenced as the first step of the frappe-ui
+charts v2 migration.
+
+## Context
+
+A chart stores its configuration as JSON on `Insights Chart v3.config`. Each
+chart type reads its own slot names out of that config:
+
+| Type         | Dimensions                        | Measures                          |
+| ------------ | --------------------------------- | --------------------------------- |
+| Bar/Line/Row | `x_axis.dimension`, `split_by`    | `y_axis.series[].measure`         |
+| Number       | `date_column`                     | `number_columns[]`                |
+| Donut        | `label_column`                    | `value_column`                    |
+| Funnel       | `label_column`                    | `value_column`, `measures[]`      |
+| Table        | `rows[]`, `columns[]`             | `values[]`                        |
+| Map          | `location_column`                 | `value_column`                    |
+| Bubble       | `dimension`, `quadrant_column`    | `xAxis`, `yAxis`, `size_column`   |
+
+These are eight names for two slots. Every chart is a set of dimensions and a
+set of measures, plus options that say how to draw them.
+
+Because the slots are named per type, a type switch leaves the old type's slots
+behind as garbage. `resetConfig` cleans up by emptying the config, but it runs
+only when the switch crosses the axis to non-axis boundary. That boundary means
+nothing to the user. It also destroys work: the selected x-axis is gone after a
+switch to Number, and it does not come back on a switch to Line.
+
+The reset also produced a crash. See the guard shipped alongside this ADR.
+
+frappe-ui charts v2 does not settle this question. Its props name the columns of
+already-shaped data (`x`, `y`, `series`, `category`, `value`). It takes rows and
+draws them. It holds no concept of a dimension, a measure, an aggregation or a
+query. The config shape stays a concern of Insights.
+
+## Decision
+
+Split the chart config into the data selection and the presentation:
+
+```
+config = {
+  dimensions: [...],   // shared across every chart type
+  measures: [...],     // shared across every chart type
+  filters, order_by, limit,
+  display: { Bar: {...}, Line: {...}, Number: {...} },
+}
+```
+
+A chart type change swaps the `display` entry only. The dimensions and the
+measures survive every switch.
+
+Slot mapping is positional. The first dimension fills the primary dimension slot
+of the type, which is the x-axis, the label or the location. The first measure
+fills the primary measure slot.
+
+If the new type reads fewer slots than the user filled, keep the extra entries
+and mark them as unused for this type. Never delete a selection on a type change.
+
+## Consequences
+
+`resetConfig` goes away, and with it the axis to non-axis boundary. Each chart
+type declares how many dimensions and measures it reads. The validator checks
+that count. No option builder can reach a slot that does not exist.
+
+A type switch becomes lossless and reversible. This makes a live preview of each
+type possible, because the switch no longer costs the user any work.
+
+Every chart type needs a mapper from the config to the v2 props. That mapper is
+close to an identity function under this shape. Under the current shape it is
+nine separate translations, and each one carries the old slot names into the new
+render layer. This is why the change comes first in the v2 migration and not
+after it.
+
+The config is persisted, so the change needs a normalizer. `transformChartDoc`
+already normalizes older config shapes on load. The new shape follows the same
+route.
+
+The `split_by` dimension currently forces a `pivot_wider` operation to make the
+result wide. v2 reads long data through its `series` prop. That pivot may become
+unnecessary. Confirm this during the migration.
+
+## Blocked on, for the render layer only
+
+The config change is not blocked. The v2 render swap is. The parity audit in
+frappe-ui lists three gaps that Insights hits:
+
+1. Combo charts. `YAxisConfig` offers a per-series `Line` or `Bar` type. The v2
+   components are homogeneous.
+2. A numeric x-axis. v2 supports `category` and `time` only.
+3. Map, Bubble and Sankey. v2 ships seven chart types and Insights has ten. The
+   audit already lists the raw ECharts escape hatch as missing.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,42 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root — the glossary.
+- **`docs/adr/`** — the ADRs that touch the area you are about to work in.
+
+Do not suggest writing an ADR upfront. The `/domain-modeling` skill (reached via
+`/grill-with-docs` and `/improve-codebase-architecture`) writes them when a term
+or a decision actually gets resolved.
+
+## Durable documents and effort documents
+
+Two kinds of document live in this repo, and they have different lifetimes.
+
+**Durable** documents describe the project. They live on `develop` and they
+change with the code:
+
+- `CONTEXT.md` — the glossary
+- `docs/adr/` — the decisions
+- `docs/agents/` — these conventions
+
+**Effort** documents describe how one piece of work got done. They live under
+`docs/projects/<effort-slug>/` on a feature branch, and they are removed when
+that branch merges. See `issue-tracker.md` for the close-out.
+
+Never move an effort document into `docs/adr/` to keep it alive. Distill the
+decision and let the rest go.
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0001 (type-independent chart config) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,68 @@
+# Issue tracker: Local Markdown
+
+Issues and specs for this repo live as markdown files in `docs/projects/`.
+
+`docs/` is tracked. Effort docs are **branch-scoped**: they live on the feature
+branch, and they are removed when that branch merges into `develop`. They record
+how the work happened, not what the project is. Only durable documents stay on
+`develop` — `CONTEXT.md`, `docs/adr/` and `docs/agents/`.
+
+A few paths stay local-only and are ignored in `.gitignore`. Check it before you
+assume a path is committed.
+
+GitHub Issues (frappe/insights) is the public/community queue, not this tracker.
+Don't create or triage GitHub issues unless explicitly asked.
+
+## Conventions
+
+- One effort per directory: `docs/projects/<effort-slug>/`
+- The spec is `docs/projects/<effort-slug>/spec.md`
+- Implementation issues are one file per ticket at
+  `docs/projects/<effort-slug>/issues/<NN>-<slug>.md`, numbered from `01` —
+  never a single combined tickets file
+- Every ticket carries a `Status:` line near the top. Wayfinder tickets use
+  `claimed` and `resolved` (see *Wayfinding operations*). Tickets raised from an
+  incoming GitHub issue use the triage roles instead: `needs-triage`,
+  `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`
+- Comments and conversation history append to the bottom of the file under a
+  `## Comments` heading
+- Concluded efforts are closed out, not left in place. See *Closing out an
+  effort*
+
+## Closing out an effort
+
+The effort docs die with the branch. The ADR is the only durable record of why
+the work went the way it did, so write it before the branch merges.
+
+1. Write an ADR in `docs/adr/` for each decision the map records. Add any new
+   term to the glossary in `CONTEXT.md`.
+2. Remove the effort with `git rm -r docs/projects/<effort-slug>/`. Put this in
+   the same commit as the ADR. A deletion with no ADR beside it is a lost
+   decision, and a reviewer can see that at a glance.
+3. Move the working copies to `docs/archive/<effort-slug>/` to keep them on the
+   machine. `docs/archive/` is local-only.
+
+When a skill says "publish to the issue tracker", create the file under
+`docs/projects/<effort-slug>/`. When it says "fetch the relevant ticket", read
+the path or the number the user passed.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a file with one **child** file per ticket.
+
+- **Map**: `docs/projects/<effort>/map.md` — the Notes / Decisions-so-far / Fog body.
+- **Child ticket**: `docs/projects/<effort>/issues/NN-<slug>.md`, numbered from `01`,
+  with the question in the body. A `Type:` line records the ticket type
+  (`research`/`prototype`/`grilling`/`task`); a `Status:` line records `claimed`/`resolved`.
+- **Blocking**: a `Blocked by: NN, NN` line near the top. A ticket is unblocked
+  when every file it lists is `resolved`.
+- **Frontier**: scan `docs/projects/<effort>/issues/` for files that are open,
+  unblocked, and unclaimed; first by number wins.
+- **Claim**: set `Status: claimed` and save before any work.
+- **Resolve**: append the answer under an `## Answer` heading, set `Status: resolved`,
+  then append a context pointer (gist + link) to the map's Decisions-so-far in `map.md`.
+  Add the ADR filename to that pointer once the decision reaches `docs/adr/`. An
+  entry with no filename marks reasoning that still has to be distilled before
+  the branch merges.
+- **Research findings**: land in `docs/projects/<effort>/research/`, linked from
+  the ticket's answer.


### PR DESCRIPTION
`.gitignore` ignored all of `docs/`, so `CONTEXT.md`, `CLAUDE.md` and the agent conventions were only ever committed on a feature branch. Any branch cut from `develop` loses them, and every new doc needs `git add -f`.

This tracks the durable documents and ignores the paths that stay local.

The rule the docs now state: documents under `docs/projects/<effort>/` are branch-scoped. They record how one piece of work happened, so they are removed when the branch merges, and the ADR is what survives. `docs/agents/issue-tracker.md` carries the close-out that keeps a decision from being lost with them.

`docs/adr/0001` is the first ADR. It records the chart config decision behind #1277.

🤖 Generated with [Claude Code](https://claude.com/claude-code)