### PR TITLE
fix: apply user permissions in data source exploration

### DIFF
--- a/insights/api/data_sources.py
+++ b/insights/api/data_sources.py
@@ -1,5 +1,4 @@
 import frappe
-from frappe.utils.caching import site_cache
 
 from insights.decorators import insights_whitelist, validate_type
 from insights.insights.doctype.insights_data_source_v3.ibis_utils import (
@@ -10,6 +9,7 @@ from insights.insights.doctype.insights_data_source_v3.ibis_utils import (
 from insights.insights.doctype.insights_table_link_v3.insights_table_link_v3 import (
     InsightsTableLinkv3,
 )
+from insights.insights.doctype.insights_table_v3.insights_table_v3 import InsightsTablev3
 from insights.insights.doctype.insights_team.insights_team import (
     check_data_source_permission,
     check_table_permission,
@@ -66,12 +66,21 @@ def get_data_source_tables(data_source: str | None = None, search_term: str | No
     return ret
 
 
+def get_permitted_ibis_table(data_source: str, table_name: str):
+    """The table as the current user is allowed to see it.
+
+    Data source exploration reads the source directly, so it stays on a live connection
+    instead of pulling the table into the data store. Everything else — team table
+    restrictions, doctype row and column permissions — is what the query builder applies,
+    and the preview must not show more than a query over the same table would return.
+    """
+    return InsightsTablev3.get_ibis_table(data_source, table_name, use_live_connection=True)
+
+
 @insights_whitelist()
 @validate_type
 def get_data_source_table(data_source: str, table_name: str):
-    check_table_permission(data_source, table_name)
-    ds = frappe.get_doc("Insights Data Source v3", data_source)
-    q = ds.get_ibis_table(table_name).head(100)
+    q = get_permitted_ibis_table(data_source, table_name).head(100)
     data, _ = execute_ibis_query(q, cache_expiry=24 * 60 * 60)
 
     return {
@@ -85,20 +94,15 @@ def get_data_source_table(data_source: str, table_name: str):
 @insights_whitelist()
 @validate_type
 def get_data_source_table_row_count(data_source: str, table_name: str):
-    check_table_permission(data_source, table_name)
-    ds = frappe.get_doc("Insights Data Source v3", data_source)
-    table = ds.get_ibis_table(table_name)
+    table = get_permitted_ibis_table(data_source, table_name)
     result = table.count().execute()
     return int(result)
 
 
 @insights_whitelist()
-@site_cache
 @validate_type
 def get_data_source_table_columns(data_source: str, table_name: str):
-    check_table_permission(data_source, table_name)
-    ds = frappe.get_doc("Insights Data Source v3", data_source)
-    table = ds.get_ibis_table(table_name)
+    table = get_permitted_ibis_table(data_source, table_name)
     return [
         frappe._dict(
             column=column,
@@ -183,11 +187,9 @@ def get_data_sources_of_tables(table_names: list[str]):
 
 
 @insights_whitelist()
-@site_cache(ttl=24 * 60 * 60)
 @validate_type
 def get_schema(data_source: str):
     check_data_source_permission(data_source)
-    ds = frappe.get_doc("Insights Data Source v3", data_source)
 
     tables = get_data_source_tables(data_source)
     schema = {}
@@ -201,7 +203,7 @@ def get_schema(data_source: str):
             "columns": [],
         }
         try:
-            _table = ds.get_ibis_table(table_name)
+            _table = get_permitted_ibis_table(data_source, table_name)
         except Exception:
             continue
         for column, datatype in _table.schema().items():

--- a/insights/tests/test_data_source_permissions.py
+++ b/insights/tests/test_data_source_permissions.py
@@ -1,0 +1,89 @@
+import frappe
+
+from insights.api.data_sources import (
+    get_data_source_table,
+    get_data_source_table_columns,
+    get_data_source_table_row_count,
+)
+from insights.tests.base import InsightsIntegrationTestCase
+
+SITE_DB = "Site DB"
+USER_A = "row-perm-a@example.com"
+USER_B = "row-perm-b@example.com"
+
+
+def create_user(email):
+    if frappe.db.exists("User", email):
+        return
+    user = frappe.new_doc("User")
+    user.email = email
+    user.first_name = email.split("@")[0]
+    user.send_welcome_email = 0
+    user.append("roles", {"role": "Insights User"})
+    user.insert(ignore_permissions=True)
+
+
+class TestSiteDBRowPermissions(InsightsIntegrationTestCase):
+    """Data source exploration must not show rows the user cannot read.
+
+    `ToDo` carries a `permission_query_conditions` hook in frappe, so it stands in for
+    any doctype whose rows are restricted per user.
+    """
+
+    @classmethod
+    def before_class(cls):
+        cls.settings_was = frappe.db.get_single_value("Insights Settings", "apply_user_permissions")
+        frappe.db.set_single_value("Insights Settings", "apply_user_permissions", 1)
+
+        create_user(USER_A)
+        create_user(USER_B)
+
+        cls.todos = {}
+        for user, count in ((USER_A, 2), (USER_B, 3)):
+            cls.todos[user] = [
+                frappe.get_doc(
+                    {
+                        "doctype": "ToDo",
+                        "description": f"row perm test for {user} #{i}",
+                        "allocated_to": user,
+                    }
+                )
+                .insert(ignore_permissions=True)
+                .name
+                for i in range(count)
+            ]
+
+    @classmethod
+    def after_class(cls):
+        for names in cls.todos.values():
+            for name in names:
+                frappe.delete_doc("ToDo", name, force=True, ignore_permissions=True)
+        for email in (USER_A, USER_B):
+            frappe.delete_doc("User", email, force=True, ignore_permissions=True)
+        frappe.db.set_single_value("Insights Settings", "apply_user_permissions", cls.settings_was)
+
+    def permitted_count(self, user):
+        with self.as_user(user):
+            return len(frappe.get_list("ToDo", limit_page_length=0))
+
+    def test_row_count_matches_permitted_rows(self):
+        for user in (USER_A, USER_B):
+            with self.as_user(user):
+                self.assertEqual(
+                    get_data_source_table_row_count(SITE_DB, "tabToDo"),
+                    self.permitted_count(user),
+                )
+
+    def test_preview_shows_only_permitted_rows(self):
+        for user in (USER_A, USER_B):
+            with self.as_user(user):
+                rows = get_data_source_table(SITE_DB, "tabToDo")["rows"]
+                allowed = set(frappe.get_list("ToDo", pluck="name", limit_page_length=0))
+                self.assertEqual({row["name"] for row in rows}, allowed)
+
+    def test_column_list_survives_permission_filtering(self):
+        # the row filter is a semi-join, so it must not drop columns from the preview
+        with self.as_user(USER_A):
+            columns = get_data_source_table_columns(SITE_DB, "tabToDo")
+
+        self.assertTrue(any(column.column == "description" for column in columns))


### PR DESCRIPTION
Closes #1258

The data source exploration endpoints (table preview, row count, column list, schema) built their ibis table straight from the data source, skipping the permission layer that `InsightsTablev3.get_ibis_table` applies. On a Site DB source, a user could preview every row of a table that a query over the same table would have filtered.

Reproduced on `ToDo` (which ships a `permission_query_conditions` hook) with a user permitted 3 of 25 rows: preview and row count returned 25, `get_list` and the query builder returned 3. After the fix, all four agree.

Notes for review:

- Exploration stays on a live connection, so a preview still does not pull the table into the data store.
- The column list and schema now depend on the user, so their `@site_cache` is dropped. Both were cached site-wide, which would have handed one user another user's columns.
- Row count and preview now compile to a semi-join against the permission subquery, so they are slower on large tables. `get_schema` now does a `has_permission` and a `get_list(run=False)` per table, uncached.
- The issue also reports query-builder execution returning all rows. That does not reproduce on `develop` — the builder already routes through the permissioned path. Left as is pending more detail from the reporter.