### PR TITLE
fix: stop dialogs closing on the first click inside

### DIFF
--- a/frontend/src2/index.css
+++ b/frontend/src2/index.css
@@ -20,12 +20,13 @@ body {
 	font-feature-settings: 'tnum';
 }
 
-.dialog-overlay {
-	z-index: 100;
-}
-
-[data-reka-popper-content-wrapper] {
-	z-index: 100 !important;
+/* Contain the app's own z-indexes (sticky headers, CodeMirror tooltips) so they
+   can't compete with dialogs and popovers, which portal to the body. Without a
+   stacking context here they escape to the root and paint over the portal; with
+   one, body order alone layers app < dialog < popover, so neither needs a
+   z-index. */
+#app {
+	isolation: isolate;
 }
 
 /* Combobox/MultiSelect dropdowns match their trigger width. frappe-ui applies


### PR DESCRIPTION
Every dialog in `src2` was unusable: the first click anywhere inside it dismissed the dialog, so no field could be focused.

frappe-ui's Dialog renders the content as a sibling of the overlay rather than nested inside it. Our `.dialog-overlay { z-index: 100 }` therefore lifted only the backdrop, which painted over the content and swallowed every click as an outside-click.

That rule existed because the app's own z-indexes (sticky table headers, the CodeMirror tooltip at `z-index: 50 !important`) reach the root stacking context and paint over portalled UI. Rather than matching numbers, this isolates `#app` so those values stay contained. Body order then layers app, dialog and popover on its own, and none of them needs a z-index.

The popper rule goes with it — reka-ui already sets the same z-index inline, so it never did anything.

Verified on a local site: the Share dialog and the query "Pick Starting Data" dialog both take clicks and keystrokes, select and combobox popups still render above the dialog, and an injected `z-index: 9999` element inside `#app` no longer paints over an open dialog.

One case to know about: a dialog opened while a reka popper is still open would now sit under it. Dropdowns close before their dialog opens, checked on the workbook menu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)