### PR TITLE
feat: let string filters match an exact value

### DIFF
--- a/frontend/src2/query/components/filter_utils.ts
+++ b/frontend/src2/query/components/filter_utils.ts
@@ -12,6 +12,8 @@ export function getOperatorOptions(filterType: FilterType) {
 	if (filterType === 'String') {
 		options.push({ label: __('is'), value: 'in' }) // value selector
 		options.push({ label: __('is not'), value: 'not_in' }) // value selector
+		options.push({ label: __('equals'), value: '=' }) // text
+		options.push({ label: __('not equals'), value: '!=' }) // text
 		options.push({ label: __('contains'), value: 'contains' }) // text
 		options.push({ label: __('does not contain'), value: 'not_contains' }) // text
 		options.push({ label: __('starts with'), value: 'starts_with' }) // text


### PR DESCRIPTION
A string filter offers only `is` and `is not`, and both read their value from the distinct value list. Picking from that list is the only way to name a value, so on a column with many similar values you cannot express `path = '/erpnext'` — the list is capped, and the entries that merely contain the term crowd out the one you want.

`equals` and `not equals` take a typed value instead. Number and date filters already offer both, and the query engine already applies them to a column of any type, so this only adds the two options to the string list.

### Review notes

- `getValueSelectorType` already returns `text` for any string operator outside `in`/`not_in`, so both operators get a plain input with no further wiring.
- One shared operator list feeds the query builder filter rule, the dashboard filter, and the dashboard filter editor, so all three pick this up.
- Each of those three clears the value when the operator changes, so switching from `is` does not leave an array behind.
- The column header filter (`ColumnFilterTypeText.vue`) has the same limitation and is untouched here: it labels `=` as "is" and routes it to the value list, converting it to `in` on the way out. Worth a separate look.