### PR TITLE
fix: let a workbook owner share without an admin role

### DIFF
--- a/frontend/src2/components/UserSelector.vue
+++ b/frontend/src2/components/UserSelector.vue
@@ -1,37 +1,76 @@
 <script setup lang="ts">
+import { watchDebounced } from '@vueuse/core'
 import { SearchIcon } from 'lucide-vue-next'
-import { computed } from 'vue'
-import useUserStore from '../users/users'
+import { computed, ref } from 'vue'
+import { __ } from '../translation'
+import useUserStore, { User } from '../users/users'
 
 const props = defineProps<{
 	placeholder?: string
 	hideUsers?: string[]
+	// only for pickers whose server side rejects an address that belongs to
+	// nobody - otherwise a typo becomes a silent grant
+	allowCustomEmail?: boolean
 }>()
 const selectedUserEmail = defineModel<string>()
 
 const userStore = useUserStore()
-const filteredUsers = computed(() => {
-	return userStore.users
-		.filter((user) => user.enabled)
-		.filter((user) => !props.hideUsers?.includes(user.email))
-		.map((user) => {
-			return {
-				...user,
-				label: user.full_name,
-				value: user.email,
-				description: user.email,
-			}
+const query = ref('')
+const matches = ref<User[]>([])
+
+watchDebounced(
+	query,
+	() => {
+		const term = query.value
+		userStore.searchUsers(term).then((res) => {
+			// a slow answer for an earlier term must not replace a later one
+			if (term === query.value) matches.value = res
 		})
+	},
+	{ debounce: 300, immediate: true },
+)
+
+const isEmail = (value: string) => /^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(value.trim())
+
+const options = computed(() => {
+	const hidden = new Set(props.hideUsers || [])
+	const found = matches.value
+		.filter((user) => user.enabled && !hidden.has(user.email))
+		.map((user) => ({
+			...user,
+			label: user.full_name,
+			value: user.email,
+			description: user.email,
+		}))
+
+	const address = query.value.trim()
+	if (!props.allowCustomEmail || found.length || !isEmail(address) || hidden.has(address)) {
+		return found
+	}
+
+	// nobody to browse here, so let the address stand on its own - the server
+	// decides whether it belongs to an Insights user
+	return [{ label: address, value: address, description: __('Share with this address') }]
 })
+
+const emptyText = computed(() =>
+	props.allowCustomEmail
+		? __('No matches. Type a full email address to share.')
+		: __('No matches.'),
+)
 </script>
 
 <template>
 	<Combobox
 		class="w-full"
+		v-model:query="query"
+		:filterable="false"
+		:loading="userStore.searching"
 		:modelValue="selectedUserEmail"
 		@update:modelValue="selectedUserEmail = $event"
-		:options="filteredUsers"
-		:placeholder="props.placeholder || 'Search user...'"
+		:options="options"
+		:placeholder="props.placeholder || __('Search user...')"
+		:emptyText="emptyText"
 	>
 		<template #prefix>
 			<SearchIcon class="h-4 w-4 text-ink-gray-4" stroke-width="1.5" />

--- a/frontend/src2/types/workbook.types.ts
+++ b/frontend/src2/types/workbook.types.ts
@@ -160,5 +160,6 @@ export type ShareAccess = 'view' | 'edit' | undefined
 export type WorkbookSharePermission = {
 	email: string
 	full_name: string
+	user_image?: string
 	access: ShareAccess
 }

--- a/frontend/src2/users/users.ts
+++ b/frontend/src2/users/users.ts
@@ -26,6 +26,21 @@ async function getUsers(search_term = '') {
 	})
 }
 
+// a search result is a slice of the roster, so it is merged in rather than
+// swapped for it - names already on screen must survive the next keystroke
+const searching = ref(false)
+async function searchUsers(search_term = '') {
+	searching.value = true
+	return call('insights.api.user.get_users', { search_term })
+		.then((res) => {
+			const matches = res as User[]
+			const known = new Set(users.value.map((u) => u.email))
+			users.value = users.value.concat(matches.filter((u) => !known.has(u.email)))
+			return matches
+		})
+		.finally(() => (searching.value = false))
+}
+
 function getUser(email: string) {
 	return users.value.find((user) => user.email === email)
 }
@@ -100,6 +115,8 @@ export default function useUserStore() {
 		users,
 		loading,
 		getUsers,
+		searchUsers,
+		searching,
 		getUser,
 		getName,
 		getImage,

--- a/frontend/src2/workbook/WorkbookShareDialog.vue
+++ b/frontend/src2/workbook/WorkbookShareDialog.vue
@@ -3,6 +3,7 @@ import { Building2 } from 'lucide-vue-next'
 import { __ } from '../translation'
 import { computed, inject, ref } from 'vue'
 import UserSelector from '../components/UserSelector.vue'
+import { showErrorToast } from '../helpers'
 import { createToast } from '../helpers/toasts'
 import session from '../session'
 import { ShareAccess, WorkbookSharePermission } from '../types/workbook.types'
@@ -18,7 +19,10 @@ const selectedUserEmail = ref<string>('')
 
 function shareWorkbook() {
 	if (!selectedUserEmail.value) return
-	permissionMap.value[selectedUserEmail.value] = 'view'
+	const email = selectedUserEmail.value
+	const user = userStore.getUser(email)
+	userInfo.value[email] = { full_name: user?.full_name || email, user_image: user?.user_image }
+	permissionMap.value[email] = 'view'
 	selectedUserEmail.value = ''
 }
 
@@ -44,27 +48,31 @@ const accessOptions = (user_email: string) => [
 
 const workbook = inject(workbookKey) as Workbook
 const workbookPermissions = ref<PermissionMap>({})
+
+// who a share belongs to comes from the share itself, not from the roster -
+// an owner may not be allowed to look up the people they shared with
+type UserInfo = { full_name: string; user_image?: string }
+const userInfo = ref<Record<string, UserInfo>>({})
+
 workbook.getSharePermissions().then((permissions) => {
 	permissions.user_permissions.forEach((p) => {
 		workbookPermissions.value[p.email] = p.access
 		permissionMap.value[p.email] = p.access
+		userInfo.value[p.email] = { full_name: p.full_name, user_image: p.user_image }
 	})
 	originalOrganizationAccess.value = permissions.organization_access
 	organizationAccess.value = permissions.organization_access
 })
 
 const userPermissions = computed(() => {
-	return Object.keys(permissionMap.value)
-		.map((email) => {
-			const user = userStore.users.find((u) => u.email === email)
-			if (!user) return null
-			return {
-				email,
-				full_name: user.full_name,
-				access: permissionMap.value[email],
-			}
-		})
-		.filter(Boolean) as WorkbookSharePermission[]
+	return Object.keys(permissionMap.value).map((email) => {
+		return {
+			email,
+			full_name: userInfo.value[email]?.full_name || email,
+			user_image: userInfo.value[email]?.user_image,
+			access: permissionMap.value[email],
+		}
+	}) as WorkbookSharePermission[]
 })
 const saveDisabled = computed(() => {
 	return (
@@ -73,15 +81,19 @@ const saveDisabled = computed(() => {
 	)
 })
 function updatePermissions() {
-	workbook.updateSharePermissions({
-		user_permissions: userPermissions.value,
-		organization_access: organizationAccess.value,
-	})
-	show.value = false
-	createToast({
-		title: __('Permissions updated'),
-		variant: 'success',
-	})
+	workbook
+		.updateSharePermissions({
+			user_permissions: userPermissions.value,
+			organization_access: organizationAccess.value,
+		})
+		.then(() => {
+			show.value = false
+			createToast({
+				title: __('Permissions updated'),
+				variant: 'success',
+			})
+		})
+		.catch(showErrorToast)
 }
 </script>
 
@@ -141,6 +153,7 @@ function updatePermissions() {
 						<UserSelector
 							v-model="selectedUserEmail"
 							placeholder="Search by name or email"
+							allow-custom-email
 							:hide-users="
 								userPermissions.filter((u) => u.access).map((u) => u.email)
 							"
@@ -161,11 +174,7 @@ function updatePermissions() {
 						:key="user.email"
 						class="flex w-full items-center gap-2 py-1"
 					>
-						<Avatar
-							size="xl"
-							:label="user.full_name"
-							:image="userStore.getUser(user.email)?.user_image"
-						/>
+						<Avatar size="xl" :label="user.full_name" :image="user.user_image" />
 						<div class="flex flex-1 flex-col">
 							<div class="leading-5">{{ user.full_name }}</div>
 							<div class="text-xs text-ink-gray-5">{{ user.email }}</div>

--- a/frontend/src2/workbook/workbook.ts
+++ b/frontend/src2/workbook/workbook.ts
@@ -200,7 +200,8 @@ function makeWorkbook(name: string) {
 				user_permissions: permissions.user_permissions.map((p: any) => {
 					return {
 						email: p.user,
-						full_name: p.full_name,
+						full_name: p.full_name || p.user,
+						user_image: p.user_image,
 						access: p.read ? (p.write ? 'edit' : 'view') : undefined,
 					}
 				}),
@@ -225,7 +226,7 @@ function makeWorkbook(name: string) {
 					write: p.access === 'edit',
 				}
 			}),
-		}).catch(showErrorToast)
+		})
 	}
 
 	function duplicate() {

--- a/insights/api/user.py
+++ b/insights/api/user.py
@@ -10,45 +10,67 @@ from insights.insights.doctype.insights_team.insights_team import (
     get_teams as get_user_teams,
 )
 from insights.insights.doctype.insights_team.insights_team import is_admin
+from insights.permissions import get_insights_users
 from insights.utils import get_app_url
+
+# the roster is a directory to share from, so it carries what a picker shows
+# and nothing else
+USER_FIELDS = ["name", "full_name", "email", "last_active", "user_image", "enabled"]
+
+
+def user_lookup_allowed():
+    """Whether members may look each other up. On unless a site turns it off.
+
+    The setting reads as off, not unset, on a site that never saved it: a Check
+    is absent from `tabSingles` until the doc is first saved, and
+    `get_single_value` casts a missing value to 0. Naming the setting for the
+    exception is what keeps the default on.
+    """
+    return not frappe.db.get_single_value("Insights Settings", "disable_user_lookup")
 
 
 @insights_whitelist()
 def get_users(search_term: str | None = None):
-    """Returns full_name, email, type, teams, last_active"""
+    """Returns full_name, email, type, last_active; admins also get teams and pending invites"""
 
-    perm_enabled = frappe.db.get_single_value("Insights Settings", "enable_permissions")
-    if perm_enabled and not is_admin(frappe.session.user):
-        user_info = frappe.db.get_value(
-            "User",
-            frappe.session.user,
-            ["name", "full_name", "email", "last_active", "user_image", "enabled"],
-            as_dict=True,
-        )
-        user_info["type"] = "User"
-        user_info["teams"] = get_user_teams(frappe.session.user)
-        return [user_info]
+    caller_is_admin = is_admin(frappe.session.user)
+    if not caller_is_admin and not user_lookup_allowed():
+        # sharing still works on a site that opted out - the owner names an
+        # address instead of picking one
+        own_profile = frappe.db.get_value("User", frappe.session.user, USER_FIELDS, as_dict=True)
+        own_profile["type"] = "User"
+        return [own_profile]
 
-    insights_admins = get_users_with_role("Insights Admin")
-    insights_users = get_users_with_role("Insights User")
-
-    additional_filters = {}
+    or_filters = {}
     if search_term:
-        additional_filters = {
+        # a name or an address, not both - the picker offers "search by name or
+        # email", so a match on either is a hit
+        or_filters = {
             "full_name": ["like", f"%{search_term}%"],
             "email": ["like", f"%{search_term}%"],
         }
 
-    users = frappe.get_list(
+    # read without a permission check on purpose: `insights_whitelist` has
+    # already settled that the caller belongs here, the cohort filter bounds the
+    # rows, and USER_FIELDS bounds the columns. Listing `User` through the
+    # framework instead would need a `select` grant that no field permission can
+    # narrow, because `User` is a core doctype and those skip field filtering
+    users = frappe.get_all(
         "User",
-        fields=["name", "full_name", "email", "last_active", "user_image", "enabled"],
-        filters={
-            "name": ["in", list(set(insights_users + insights_admins))],
-            **additional_filters,
-        },
+        fields=USER_FIELDS,
+        filters={"name": ["in", list(get_insights_users())]},
+        or_filters=or_filters,
     )
+
+    insights_admins = get_users_with_role("Insights Admin")
     for user in users:
         user["type"] = "Admin" if user.name in insights_admins else "User"
+
+    # team membership and pending invitations are for managing users, not sharing
+    if not caller_is_admin:
+        return users
+
+    for user in users:
         user["teams"] = get_user_teams(user.name)
 
     invitations = frappe.get_list(

--- a/insights/api/workbooks.py
+++ b/insights/api/workbooks.py
@@ -2,7 +2,28 @@ import frappe
 from frappe import _
 
 from insights.decorators import insights_whitelist
+from insights.permissions import get_insights_users
 from insights.utils import DocShare
+
+
+def validate_shareable_users(emails):
+    """A workbook is shareable with Insights users only.
+
+    The picker cannot always show the person being named - an address typed by
+    a user who may not look anyone up still has to land somewhere real.
+    """
+    if not emails:
+        return
+
+    # Administrator owns the workbooks a template import creates and so stays on
+    # the share list whenever one of them is re-shared
+    shareable = get_insights_users() | {"Administrator"}
+    unknown = sorted(set(emails) - shareable)
+    if unknown:
+        frappe.throw(
+            _("Cannot share with {0} - they are not an Insights user").format(", ".join(unknown)),
+            title=_("Not an Insights user"),
+        )
 
 
 @insights_whitelist()
@@ -132,6 +153,7 @@ def get_share_permissions(workbook_name: str):
             DocShare.write,
             DocShare.share,
             User.full_name,
+            User.user_image,
         )
         .where(DocShare.share_doctype == "Insights Workbook")
         .where(DocShare.share_name == workbook_name)
@@ -139,10 +161,12 @@ def get_share_permissions(workbook_name: str):
         .run(as_dict=True)
     )
     owner = frappe.db.get_value("Insights Workbook", workbook_name, "owner")
+    owner_info = frappe.db.get_value("User", owner, ["full_name", "user_image"], as_dict=True) or {}
     user_permissions.append(
         {
             "user": owner,
-            "full_name": frappe.get_value("User", owner, "full_name"),
+            "full_name": owner_info.get("full_name"),
+            "user_image": owner_info.get("user_image"),
             "read": 1,
             "write": 1,
         }
@@ -185,6 +209,7 @@ def update_share_permissions(
     )
 
     allowed_users = {permission["user"] for permission in user_permissions}
+    validate_shareable_users(allowed_users)
     for share in existing_shares:
         if share.user and share.user not in allowed_users:
             frappe.delete_doc("DocShare", share.name, ignore_permissions=True)

--- a/insights/insights/doctype/insights_settings/insights_settings.json
+++ b/insights/insights/doctype/insights_settings/insights_settings.json
@@ -11,6 +11,7 @@
   "allow_download",
   "enable_data_store",
   "apply_user_permissions",
+  "disable_user_lookup",
   "allowed_origins",
   "max_records_to_sync",
   "max_memory_usage",
@@ -142,6 +143,13 @@
    "fieldname": "apply_user_permissions",
    "fieldtype": "Check",
    "label": "Apply User Permissions"
+  },
+  {
+   "default": "0",
+   "description": "Stops members from finding each other by name or email when sharing. Turn this on for a site where anyone can sign up.",
+   "fieldname": "disable_user_lookup",
+   "fieldtype": "Check",
+   "label": "Disable User Lookup"
   },
   {
    "default": "60",

--- a/insights/permissions.py
+++ b/insights/permissions.py
@@ -33,6 +33,24 @@ TEAM_BASED_PERMISSION_DOCTYPES = [
     "Insights Chart v3",
 ]
 
+INSIGHTS_ROLES = ("Insights User", "Insights Admin")
+
+
+def get_insights_users():
+    """Everyone who may use Insights: an enabled holder of an Insights role.
+
+    One definition serves both sides of sharing - the picker lists this set and
+    `validate_shareable_users` accepts it - so a name the picker offers is never
+    refused when the share is saved. Administrator is left out: it is nobody to
+    browse for, though it can still own a workbook and be granted access to one.
+    """
+    from frappe.utils.user import get_users_with_role
+
+    users = set()
+    for role in INSIGHTS_ROLES:
+        users.update(get_users_with_role(role))
+    return users
+
 
 class InsightsPermissions:
     def __init__(self, user=None):

--- a/insights/tests/test_permissions.py
+++ b/insights/tests/test_permissions.py
@@ -2,6 +2,7 @@ import frappe
 import frappe.share
 from frappe.permissions import update_permission_property
 
+from insights.api.user import USER_FIELDS, get_users, user_lookup_allowed
 from insights.api.workbooks import get_share_permissions, update_share_permissions
 from insights.decorators import insights_whitelist
 from insights.insights.doctype.insights_data_source_v3.insights_data_source_v3 import db_connections
@@ -144,6 +145,103 @@ class TestInsightsPermissions(InsightsIntegrationTestCase):
             update_share_permissions(workbook.name, [])
 
         self.assert_not_visible_to(USER_2, DT.WORKBOOK, workbook.name)
+
+    def test_workbook_owner_can_look_up_users_to_share_with(self):
+        # the share picker reads this roster, so an owner without an admin role
+        # must find the other Insights users in it - with or without team permissions
+        for team_permissions in (False, True):
+            with self.subTest(team_permissions=team_permissions):
+                self.toggle_team_permissions(team_permissions)
+                with self.as_user(USER_1):
+                    emails = [user["email"] for user in get_users()]
+
+                self.assertIn(USER_2, emails)
+                self.assertIn(ADMIN, emails)
+                self.assertNotIn(NON_INSIGHTS_USER, emails)
+
+    def test_roster_carries_nothing_but_directory_fields(self):
+        # the api is the only way into `User`, so its field list is the whole
+        # exposure - no phone number or api key may ride along
+        with self.as_user(USER_1):
+            users = get_users()
+
+        self.assertTrue(users)
+        for user in users:
+            self.assertEqual(set(user.keys()), set(USER_FIELDS) | {"type"})
+
+    def test_users_are_found_by_name_or_by_email(self):
+        # the two are alternatives: matching a name must not also require the
+        # address to match
+        with self.as_user(USER_1):
+            by_email = [user["email"] for user in get_users("user1")]
+            by_name = [user["email"] for user in get_users("Insights User")]
+
+        self.assertIn(USER_1, by_email)
+        self.assertNotIn(USER_2, by_email)
+        self.assertIn(USER_1, by_name)
+        self.assertIn(USER_2, by_name)
+
+    def test_user_lookup_is_on_for_a_site_that_never_set_it(self):
+        # a Check stays out of `tabSingles` until the doc is first saved, and
+        # `get_single_value` casts the missing value to 0. A setting named for
+        # permission would therefore read as "off" on every existing site, so
+        # the setting has to name the exception instead.
+        frappe.db.sql(
+            "delete from `tabSingles` where doctype = %s and field = %s",
+            (DT.SETTINGS, "disable_user_lookup"),
+        )
+        frappe.db.value_cache.pop(DT.SETTINGS, None)
+
+        self.assertTrue(user_lookup_allowed())
+        with self.as_user(USER_1):
+            self.assertIn(USER_2, [user["email"] for user in get_users()])
+
+    def test_user_lookup_can_be_turned_off(self):
+        # an open-signup site turns the roster off; sharing then works by naming
+        # an address rather than picking one, so the roster may hold only the caller
+        frappe.db.set_single_value(DT.SETTINGS, "disable_user_lookup", 1)
+        self.addCleanup(frappe.db.set_single_value, DT.SETTINGS, "disable_user_lookup", 0)
+
+        with self.as_user(USER_1):
+            self.assertEqual([user["email"] for user in get_users()], [USER_1])
+
+        # an admin still manages users, so the roster stays whole for them
+        with self.as_user(ADMIN):
+            self.assertIn(USER_2, [user["email"] for user in get_users()])
+
+    def test_workbook_owned_by_administrator_can_still_be_shared(self):
+        # a template import leaves Administrator owning the workbook, and the
+        # owner rides along on every share update the dialog sends back
+        workbook = create_test_workbook("Administrator")
+
+        update_share_permissions(
+            workbook.name,
+            [
+                {"user": "Administrator", "read": 1, "write": 1},
+                {"user": USER_1, "read": 1, "write": 0},
+            ],
+        )
+
+        self.assert_visible_to(USER_1, DT.WORKBOOK, workbook.name)
+
+    def test_workbook_cannot_be_shared_with_a_non_insights_user(self):
+        workbook = create_test_workbook(USER_1)
+
+        with self.as_user(USER_1):
+            with self.assertRaisesRegex(frappe.ValidationError, "not an Insights user"):
+                update_share_permissions(
+                    workbook.name,
+                    [{"user": NON_INSIGHTS_USER, "read": 1, "write": 0}],
+                )
+
+    def test_team_membership_is_listed_for_admins_only(self):
+        self.toggle_team_permissions(True)
+
+        with self.as_user(USER_1):
+            self.assertNotIn("teams", get_users()[0])
+
+        with self.as_user(ADMIN):
+            self.assertIn("teams", get_users()[0])
 
     def test_permission_for_dashboard(self):
         workbook = create_test_workbook(USER_1)


### PR DESCRIPTION
An owner who is not an Insights admin cannot share a workbook. The picker in the
share dialog is empty, and the people already shared with are missing from it.

`get_users` returned only the caller. Team permissions ended the query early, and
listing `User` needs a role a plain Insights user does not hold. The dialog read
each share's name from that same roster, so the shares went with it.

**The call worth reviewing.** `get_users` reads the cohort itself. It does not
grant the `Insights User` role `select` on `User`. The grant reads tidier, but no
field permission holds it to names. `User` is a core doctype, so
`get_permitted_fields` returns every column and skips permlevels. The grant gives
each cohort member's `phone`, `birth_date` and `api_key` to any Insights user
through `/api/resource/User`. A `permission_query_conditions` hook cannot narrow
this, because it bounds rows and not columns. `USER_FIELDS` is now the whole
exposure, in one place, behind an endpoint that already admits Insights users
only.

Also worth a look:

- `disable_user_lookup` replaces revoking a permission as the way an open-signup
  site opts out. The setting names the exception on purpose. A Check stays out of
  `tabSingles` until the doc is first saved, and `get_single_value` casts a
  missing value to 0. A setting named for permission therefore reads as off on
  every site that never saved it.
- The roster no longer depends on `enable_permissions`. Directory visibility is
  its own setting, separate from data access. This changes behavior on a site
  that runs team permissions.
- `get_insights_users` is the single cohort definition. The picker and share
  validation both use it, so the picker cannot offer a name the server refuses.
  Administrator is not browsable but stays shareable, because a template import
  leaves it owning the workbook.
