### PR TITLE
fix: add schema selection consideration when adding a data source

### DIFF
--- a/insights/api/data_sources.py
+++ b/insights/api/data_sources.py
@@ -146,6 +146,7 @@ def make_data_source(data_source):
     ds.username = data_source.username
     ds.password = data_source.password
     ds.database_name = data_source.database_name
+    ds.schema = data_source.schema
     ds.use_ssl = data_source.use_ssl
     ds.connection_string = data_source.connection_string
     return ds


### PR DESCRIPTION
When adding a new data source, schema specification fails : it was never transferred to the backend as the api didn't have a "schema" field. Public schema was then always selected.

Now, when wanting to select one or several schemas from the UI, the schemas are actually selected as data sources.