### PR TITLE
feat: Alerts via web hooks

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -103,5 +103,10 @@ A pre-built workbook shipped by any installed app via the `insights_workbook_tem
 hook; imported as one shared, Administrator-owned copy per site.
 
 **Alert**:
-A scheduled check on a query's results that notifies recipients (email or Telegram)
-when its condition is met.
+A scheduled check on a query's results that notifies recipients over a channel when its
+condition is met.
+
+**Channel**:
+How an alert reaches its recipients: email, Telegram or a webhook. A webhook posts to a
+URL the user supplies, which is why outbound requests carry an address policy — see
+ADR-0002.

--- a/docs/adr/0002-outbound-http-to-user-chosen-urls.md
+++ b/docs/adr/0002-outbound-http-to-user-chosen-urls.md
@@ -1,0 +1,96 @@
+# 2. Outbound HTTP to user-chosen URLs
+
+Date: 2026-08-11
+
+## Status
+
+Accepted. Implemented in `insights/http.py` alongside the webhook alert channel.
+
+## Context
+
+Webhook alerts are the first feature where a user hands Insights a URL and the
+server makes the request. That is a different thing from a request to a URL
+written in the code, and the difference is the permission model.
+
+`Insights User` is the least privileged role the app has. It can create and
+write an `Insights Alert`, and `send_alert` and `test_alert` are both
+whitelisted. So the role can choose the destination and fire the request on
+demand, which makes the response timing and the error text readable to it.
+The same role cannot create an `Insights Data Source`, so the REST connector
+that also makes outbound requests is out of its reach. The webhook URL is the
+first outbound sink an `Insights User` can aim.
+
+A server-side request forgery is what that buys an attacker. A URL that
+resolves onto the server's own network reaches the database, the admin ports,
+the redis instances and the cloud metadata service — all of them things the
+role cannot reach through Insights, and several of them things nobody outside
+the host can reach at all.
+
+The framework does not solve this. `frappe.utils.get_request_session` applies
+no address policy, and the `Webhook` doctype makes no address check either. It
+does not need one today, because only a System Manager can configure it. That
+is not our situation.
+
+## Decision
+
+One module, `insights/http.py`, owns outbound HTTP to any URL a user chose.
+Anything with a user-supplied URL goes through `post_to_public_url`. A fixed
+URL in the code — the dashboard preview service, for instance — does not.
+
+Four rules define a permitted destination:
+
+1. **https only.** Checked from the URL text, without a name lookup.
+2. **Publicly routable addresses only.** Every address the name resolves to
+   must satisfy `ipaddress.is_global`. One private answer refuses the name.
+3. **No redirect.** A 3xx is an error, not a hop. Configure the final URL.
+4. **No proxy.** The environment's proxy settings are ignored, and a proxy
+   passed by a caller is refused.
+
+The address check runs **in the connection**, not before the request. A urllib3
+connection subclass resolves the name, refuses a non-public answer, and pins
+the surviving address onto the socket. The hostname stays on the connection for
+SNI and certificate verification, so pinning does not weaken TLS.
+
+`validate_public_url` holds only rule 1, because it runs inside `validate()`.
+A save must not wait on a resolver, and an address that resolves publicly at
+save time proves nothing about send time. "Send test" is the button that
+answers the question a user actually has.
+
+## Consequences
+
+**Rebinding is closed, and closing it costs private API.** Checking the address
+before the request and then letting requests resolve the name again is a
+check of one lookup and a connection to another. Doing it in the connection is
+the only place where the address checked is the address used. That means
+`HTTPSConnection._new_conn`, `_dns_host` and `pool_classes_by_scheme` —
+three pieces of urllib3 that carry no compatibility promise.
+
+The failure mode is what makes this dangerous: if a urllib3 upgrade renames
+`_new_conn`, the subclass overrides nothing, nothing raises, and the defence
+silently stops existing. `insights/tests/test_http.py` drives a request to the
+socket to catch that. Match the refusal message in those tests, not just the
+exception type — an unreachable socket raises the same type, so a bare
+`assertRaises` stays green after the override comes unstuck.
+
+**A deployment behind an egress proxy cannot deliver.** This is the real cost of
+rule 4, and it is deliberate: a proxy resolves and connects for us, so there is
+no address left here to check, and trusting the proxy to have checked is not a
+policy. The connection error names it rather than leaving an operator to guess.
+If a customer needs it, the answer is an allow-list of destinations, not a
+trusted proxy.
+
+**Ignoring the environment also drops netrc and `REQUESTS_CA_BUNDLE`.** The
+netrc part matters: a user picks the host, so a matching netrc entry would hand
+that host this server's credentials. That is worth more than reading an
+operator's CA bundle from the environment.
+
+**The address check is not an authorization check.** It stops a request onto
+this server's own network. It does not stop a request to a public host the user
+should not be talking to. If that becomes a requirement, it wants an
+allow-list, and the allow-list belongs in this module.
+
+**This belongs in the framework.** Every Frappe app that accepts a URL from a
+user has this problem, and `frappe.utils.get_request_session` is where the
+answer would serve all of them. Until it moves there, `insights/http.py` is the
+one place in this app that knows the policy — do not copy the connection
+classes into a second module.

--- a/frontend/src2/query/alert.ts
+++ b/frontend/src2/query/alert.ts
@@ -8,7 +8,7 @@ export type InsightsAlert = {
 	doctype: 'Insights Alert'
 	disabled: 0 | 1
 	title: string
-	channel: 'Telegram' | 'Email'
+	channel: 'Telegram' | 'Email' | 'Webhook'
 	query: string
 	frequency: 'Hourly' | 'Daily' | 'Weekly' | 'Monthly' | 'Cron'
 	cron_format: string
@@ -16,6 +16,9 @@ export type InsightsAlert = {
 	next_execution: string
 	telegram_chat_id: string
 	recipients: string
+	webhook_url: string
+	// Stored in __Auth; the server hands back a masked value it ignores on save.
+	webhook_token: string
 	condition: string
 	custom_condition: 0 | 1
 	message: string
@@ -55,6 +58,8 @@ const EMPTY_ALERT: InsightsAlert = {
 	next_execution: '',
 	telegram_chat_id: '',
 	recipients: '',
+	webhook_url: '',
+	webhook_token: '',
 	condition: '',
 	custom_condition: 0,
 	message: '',

--- a/frontend/src2/query/components/AlertSetupDialog.vue
+++ b/frontend/src2/query/components/AlertSetupDialog.vue
@@ -43,7 +43,9 @@ wheneverChanges(
 
 const webhookError = computed(() => {
 	if (alert.doc.channel !== 'Webhook') return ''
-	if (!alert.doc.webhook_url?.trim()) return __('Webhook URL is required')
+	const url = alert.doc.webhook_url?.trim()
+	if (!url) return __('Webhook URL is required')
+	if (!url.startsWith('https://')) return __('Webhook URL must use https://')
 	if (!alert.doc.webhook_token) return __('Token is required')
 	return ''
 })
@@ -203,7 +205,7 @@ function toggleAlert() {
 									:label="__('Webhook URL')"
 									v-model="alert.doc.webhook_url"
 									:placeholder="__('e.g. https://example.com/hooks/insights')"
-								/>
+									/>
 								<ErrorMessage v-if="webhookError" :message="webhookError" />
 							</div>
 							<FormControl

--- a/frontend/src2/query/components/AlertSetupDialog.vue
+++ b/frontend/src2/query/components/AlertSetupDialog.vue
@@ -205,7 +205,7 @@ function toggleAlert() {
 									:label="__('Webhook URL')"
 									v-model="alert.doc.webhook_url"
 									:placeholder="__('e.g. https://example.com/hooks/insights')"
-									/>
+								/>
 								<ErrorMessage v-if="webhookError" :message="webhookError" />
 							</div>
 							<FormControl

--- a/frontend/src2/query/components/AlertSetupDialog.vue
+++ b/frontend/src2/query/components/AlertSetupDialog.vue
@@ -41,14 +41,9 @@ wheneverChanges(
 	{ deep: true },
 )
 
-// Mirrors InsightsAlert.validate_webhook, so a bad endpoint is caught here
-// instead of coming back as a server error on save.
 const webhookError = computed(() => {
 	if (alert.doc.channel !== 'Webhook') return ''
-	const url = alert.doc.webhook_url?.trim()
-	if (!url) return __('Webhook URL is required')
-	// The token is sent as a header, so plain http would expose it in transit.
-	if (!url.startsWith('https://')) return __('Webhook URL must start with https://')
+	if (!alert.doc.webhook_url?.trim()) return __('Webhook URL is required')
 	if (!alert.doc.webhook_token) return __('Token is required')
 	return ''
 })

--- a/frontend/src2/query/components/AlertSetupDialog.vue
+++ b/frontend/src2/query/components/AlertSetupDialog.vue
@@ -41,6 +41,18 @@ wheneverChanges(
 	{ deep: true },
 )
 
+// Mirrors InsightsAlert.validate_webhook, so a bad endpoint is caught here
+// instead of coming back as a server error on save.
+const webhookError = computed(() => {
+	if (alert.doc.channel !== 'Webhook') return ''
+	const url = alert.doc.webhook_url?.trim()
+	if (!url) return __('Webhook URL is required')
+	// The token is sent as a header, so plain http would expose it in transit.
+	if (!url.startsWith('https://')) return __('Webhook URL must start with https://')
+	if (!alert.doc.webhook_token) return __('Token is required')
+	return ''
+})
+
 const isValidAlert = computed(() => {
 	if (!alert.doc.title) return false
 	if (!alert.doc.frequency) return false
@@ -48,6 +60,7 @@ const isValidAlert = computed(() => {
 	if (!alert.doc.channel) return false
 	if (alert.doc.channel === 'Email' && !alert.doc.recipients) return false
 	if (alert.doc.channel === 'Telegram' && !alert.doc.telegram_chat_id) return false
+	if (webhookError.value) return false
 	if (alert.doc.custom_condition && !alert.doc.condition) return false
 	if (!alert.doc.custom_condition && !filterCondition.left) return false
 	if (!alert.doc.custom_condition && !filterCondition.operator) return false
@@ -170,6 +183,7 @@ function toggleAlert() {
 							v-model="alert.doc.channel"
 							:options="[
 								{ label: __('Email'), value: 'Email' },
+								{ label: __('Webhook'), value: 'Webhook' },
 								// { label: 'Telegram', value: 'Telegram' },
 							]"
 						/>
@@ -187,6 +201,23 @@ function toggleAlert() {
 							v-model="alert.doc.telegram_chat_id"
 							:placeholder="__('e.g. 123456789')"
 						/>
+						<template v-if="alert.doc.channel === 'Webhook'">
+							<div class="flex flex-col gap-1.5">
+								<FormControl
+									type="text"
+									:label="__('Webhook URL')"
+									v-model="alert.doc.webhook_url"
+									:placeholder="__('e.g. https://example.com/hooks/insights')"
+								/>
+								<ErrorMessage v-if="webhookError" :message="webhookError" />
+							</div>
+							<FormControl
+								type="password"
+								:label="__('Token')"
+								v-model="alert.doc.webhook_token"
+								:placeholder="__('Sent as an Authorization: Bearer header')"
+							/>
+						</template>
 					</div>
 				</div>
 

--- a/insights/http.py
+++ b/insights/http.py
@@ -1,0 +1,166 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+"""Outbound HTTP to a URL that a user chose.
+
+An Insights User is the least privileged role the app has, and it can already
+save a webhook alert and press "send test". A URL from that form is therefore
+an instruction to this server from an untrusted caller. A URL that resolves
+onto the server's own network reaches databases, admin ports and metadata
+services that the caller cannot otherwise touch, so only publicly routable
+addresses are delivery targets.
+
+Four rules hold that line:
+
+- https only, so the payload and the destination stay confidential
+- the address is checked again while the socket is opening, so a name that
+  answers differently on a second lookup cannot slip past the first check
+- a redirect is refused, so the address that was checked is the address that
+  receives the body
+- a proxy resolves and connects for us, which leaves nothing here to check, so
+  this module ignores the environment's proxy settings and refuses a proxy a
+  caller passes in
+
+The last rule has a cost worth knowing: a deployment whose only route out is an
+egress proxy cannot deliver. It hears so from the connection error below rather
+than guessing.
+
+Use this for any request whose URL came from a user. A fixed URL in the code
+needs none of it.
+"""
+
+import ipaddress
+import socket
+from urllib.parse import urlparse
+
+import frappe
+import requests
+from frappe import _
+from requests.adapters import HTTPAdapter
+from urllib3.connection import HTTPSConnection
+from urllib3.connectionpool import HTTPSConnectionPool
+
+# A hanging endpoint must not hold the scheduled job that serves every caller.
+DEFAULT_TIMEOUT_SECONDS = 10
+
+
+class OutboundRequestRefused(frappe.ValidationError):
+    """Every refusal in this module, so one `except` covers them all."""
+
+
+def validate_public_url(url: str) -> None:
+    """Check what a URL says, without touching the network.
+
+    Cheap and deterministic, so a form can call it on save. It does not check
+    where the host resolves - that is `post_to_public_url`'s job, because an
+    answer from save time tells you nothing about send time.
+    """
+    parsed = urlparse(url)
+    if parsed.scheme != "https":
+        frappe.throw(_("URL must use https"), exc=OutboundRequestRefused)
+    if not parsed.hostname:
+        frappe.throw(_("URL must include a hostname"), exc=OutboundRequestRefused)
+
+
+def resolve_public_address(hostname: str, port: int) -> str:
+    """The one publicly routable address this hostname may be reached on.
+
+    Returning the address, rather than approving the name, is what stops a
+    second lookup from answering differently.
+    """
+    try:
+        resolved = socket.getaddrinfo(hostname, port, proto=socket.IPPROTO_TCP)
+    except socket.gaierror:
+        frappe.throw(_("Could not resolve host: {0}").format(hostname), exc=OutboundRequestRefused)
+
+    for *_rest, sockaddr in resolved:
+        address = ipaddress.ip_address(sockaddr[0])
+        if address.version == 6 and address.ipv4_mapped:
+            address = address.ipv4_mapped
+        if not address.is_global:
+            frappe.throw(
+                _(
+                    "{0} resolves to a non-public address ({1}). "
+                    "Requests can only be sent to publicly routable hosts."
+                ).format(hostname, address),
+                exc=OutboundRequestRefused,
+            )
+    return resolved[0][-1][0]
+
+
+class _PublicOnlyConnection(HTTPSConnection):
+    def _new_conn(self):
+        # `host` reads `_dns_host`, and urllib3 reads `host` again for SNI and
+        # the certificate check after this returns. Restoring it is what keeps
+        # the pin off the TLS handshake.
+        pinned = resolve_public_address(self.host, self.port)
+        original = self._dns_host
+        self._dns_host = pinned
+        try:
+            return super()._new_conn()
+        finally:
+            self._dns_host = original
+
+
+class _PublicOnlyConnectionPool(HTTPSConnectionPool):
+    ConnectionCls = _PublicOnlyConnection
+
+
+class PublicOnlyAdapter(HTTPAdapter):
+    """Checks the address actually connected to, which DNS cannot change afterwards."""
+
+    def init_poolmanager(self, *args, **kwargs):
+        super().init_poolmanager(*args, **kwargs)
+        self.poolmanager.pool_classes_by_scheme = {"https": _PublicOnlyConnectionPool}
+
+    def proxy_manager_for(self, proxy, **proxy_kwargs):
+        # `post_to_public_url` already ignores the environment's proxies, so
+        # arriving here means a caller passed one in. Refuse it too, rather
+        # than leave the adapter unsafe for its next caller.
+        frappe.throw(
+            _("Requests cannot be sent through a proxy ({0})").format(proxy),
+            exc=OutboundRequestRefused,
+        )
+
+
+def post_to_public_url(
+    url: str,
+    data: str,
+    headers: dict,
+    timeout: int = DEFAULT_TIMEOUT_SECONDS,
+) -> requests.Response:
+    """POST to a publicly routable destination, or refuse and say why.
+
+    The address check lives in the connection, not here, so there is one place
+    that decides and it is the place that opens the socket.
+    """
+    validate_public_url(url)
+
+    with requests.Session() as session:
+        session.mount("https://", PublicOnlyAdapter())
+        # Drops the environment's proxies, its CA bundle and its netrc
+        # credentials. A user picks the host, so netrc could hand that host
+        # this server's credentials for it.
+        session.trust_env = False
+        try:
+            response = session.post(
+                url,
+                data=data,
+                headers=headers,
+                timeout=timeout,
+                allow_redirects=False,
+            )
+        except requests.ConnectionError:
+            frappe.throw(
+                _(
+                    "Could not reach {0}. Requests go out directly, never through a "
+                    "proxy, so this server needs outbound access to the host."
+                ).format(url),
+                exc=OutboundRequestRefused,
+            )
+
+    if response.is_redirect:
+        frappe.throw(
+            _("{0} redirects ({1}). Configure the final URL instead.").format(url, response.status_code),
+            exc=OutboundRequestRefused,
+        )
+    return response

--- a/insights/insights/doctype/insights_alert/insights_alert.json
+++ b/insights/insights/doctype/insights_alert/insights_alert.json
@@ -16,7 +16,7 @@
   "cron_format",
   "last_execution",
   "next_execution",
-  "webhook_uri",
+  "webhook_url",
   "webhook_token",
   "column_break_ktop",
   "telegram_chat_id",
@@ -123,22 +123,22 @@
   },
   {
    "depends_on": "eval: doc.channel == \"Webhook\"",
-   "fieldname": "webhook_uri",
-   "fieldtype": "Data",
-   "label": "Webhook URI",
+   "fieldname": "webhook_token",
+   "fieldtype": "Password",
+   "label": "Webhook Token",
    "mandatory_depends_on": "eval: doc.channel == \"Webhook\""
   },
   {
    "depends_on": "eval: doc.channel == \"Webhook\"",
-   "fieldname": "webhook_token",
-   "fieldtype": "Password",
-   "label": "Webhook Token",
+   "fieldname": "webhook_url",
+   "fieldtype": "Data",
+   "label": "Webhook URL",
    "mandatory_depends_on": "eval: doc.channel == \"Webhook\""
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-08-10 17:59:06.379187",
+ "modified": "2026-08-10 18:17:36.273483",
  "modified_by": "Administrator",
  "module": "Insights",
  "name": "Insights Alert",

--- a/insights/insights/doctype/insights_alert/insights_alert.json
+++ b/insights/insights/doctype/insights_alert/insights_alert.json
@@ -16,6 +16,8 @@
   "cron_format",
   "last_execution",
   "next_execution",
+  "webhook_uri",
+  "webhook_token",
   "column_break_ktop",
   "telegram_chat_id",
   "recipients",
@@ -49,7 +51,7 @@
    "fieldname": "channel",
    "fieldtype": "Select",
    "label": "Channel",
-   "options": "Email\nTelegram"
+   "options": "Email\nTelegram\nWebhook"
   },
   {
    "fieldname": "recipients",
@@ -118,11 +120,25 @@
    "fieldname": "custom_condition",
    "fieldtype": "Check",
    "label": "Custom Condition"
+  },
+  {
+   "depends_on": "eval: doc.channel == \"Webhook\"",
+   "fieldname": "webhook_uri",
+   "fieldtype": "Data",
+   "label": "Webhook URI",
+   "mandatory_depends_on": "eval: doc.channel == \"Webhook\""
+  },
+  {
+   "depends_on": "eval: doc.channel == \"Webhook\"",
+   "fieldname": "webhook_token",
+   "fieldtype": "Password",
+   "label": "Webhook Token",
+   "mandatory_depends_on": "eval: doc.channel == \"Webhook\""
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-03-21 15:42:02.011577",
+ "modified": "2026-08-10 17:59:06.379187",
  "modified_by": "Administrator",
  "module": "Insights",
  "name": "Insights Alert",
@@ -153,6 +169,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "show_title_field_in_link": 1,
  "sort_field": "modified",
  "sort_order": "DESC",

--- a/insights/insights/doctype/insights_alert/insights_alert.py
+++ b/insights/insights/doctype/insights_alert/insights_alert.py
@@ -1,7 +1,10 @@
 # Copyright (c) 2023, Frappe Technologies Pvt. Ltd. and contributors
 # For license information, please see license.txt
+import ipaddress
 import re
+import socket
 from datetime import datetime
+from urllib.parse import urlparse
 
 import frappe
 import pandas as pd
@@ -66,6 +69,7 @@ class InsightsAlert(Document):
             frappe.throw("Webhook URI is required for a webhook alert")
         if not self.webhook_token:
             frappe.throw("Webhook token is required for a webhook alert")
+        validate_public_url(self.webhook_url)
 
     def has_query_permission(self):
         if not frappe.has_permission("Insights Query v3", "read", self.query):
@@ -119,11 +123,10 @@ class InsightsAlert(Document):
         try:
             # frappe.as_json, not requests' json=: query rows carry datetimes
             # and Decimals that the plain encoder refuses.
-            response = requests.post(
+            response = post_to_public_url(
                 self.webhook_url,
                 data=frappe.as_json(payload),
                 headers=headers,
-                timeout=WEBHOOK_TIMEOUT_SECONDS,
             )
             response.raise_for_status()
         except requests.RequestException as e:
@@ -252,6 +255,52 @@ class TelegramAlert:
     @property
     def bot(self):
         return telegram.Bot(token=self.token)
+
+
+def validate_public_url(url: str) -> None:
+    """Reject a destination an Insights User should not be able to make this
+    server talk to. Any Insights User can create an alert, so a webhook that
+    resolves onto the server's own network reaches services that are not
+    otherwise exposed to them. Only publicly routable hosts are delivery
+    targets."""
+    parsed = urlparse(url)
+    if parsed.scheme != "https":
+        frappe.throw("Webhook URL must use https")
+    if not parsed.hostname:
+        frappe.throw("Webhook URL must include a hostname")
+
+    port = parsed.port or 443
+    try:
+        resolved = socket.getaddrinfo(parsed.hostname, port, proto=socket.IPPROTO_TCP)
+    except socket.gaierror:
+        frappe.throw(f"Could not resolve webhook host: {parsed.hostname}")
+
+    for *_, sockaddr in resolved:
+        address = ipaddress.ip_address(sockaddr[0])
+        if address.version == 6 and address.ipv4_mapped:
+            address = address.ipv4_mapped
+        if not address.is_global:
+            frappe.throw(
+                f"Webhook URL resolves to a non-public address ({address}). "
+                "Alerts can only be sent to publicly routable hosts."
+            )
+
+
+def post_to_public_url(url: str, data: str, headers: dict) -> requests.Response:
+    """POST to a validated destination. A redirect is refused rather than
+    followed, so the address that was checked is the address that receives the
+    alert - configure the final URL instead."""
+    validate_public_url(url)
+    response = requests.post(
+        url,
+        data=data,
+        headers=headers,
+        timeout=WEBHOOK_TIMEOUT_SECONDS,
+        allow_redirects=False,
+    )
+    if response.is_redirect:
+        frappe.throw(f"Webhook URL must not redirect (got {response.status_code})")
+    return response
 
 
 def render_template_restricted(template: str, context: dict) -> str:

--- a/insights/insights/doctype/insights_alert/insights_alert.py
+++ b/insights/insights/doctype/insights_alert/insights_alert.py
@@ -248,6 +248,24 @@ def send_alerts():
         except Exception:
             frappe.db.rollback()
             frappe.log_error(title=f"Failed to send alert: {alert.name}")
+            record_execution(alert.name)
+
+
+def record_execution(name: str):
+    """Mark an alert as run, whether or not it delivered.
+
+    `last_execution` is the cron's start point, so leaving it unset after a
+    failure makes the alert due again on the next four-minute tick. A webhook
+    pointed at an endpoint that is down would be retried forever, several
+    hundred times a day, against somebody else's server. The alert ran. The
+    next attempt belongs in the next scheduled window.
+
+    This runs after the rollback above, so it needs its own commit.
+    """
+    frappe.db.set_value("Insights Alert", name, "last_execution", now_datetime(), update_modified=False)
+    # The caller rolled back the failed alert. Without a commit of its own this
+    # write goes out with the next one, or with nothing at all.
+    frappe.db.commit()  # nosemgrep
 
 
 class TelegramAlert:

--- a/insights/insights/doctype/insights_alert/insights_alert.py
+++ b/insights/insights/doctype/insights_alert/insights_alert.py
@@ -273,11 +273,21 @@ def validate_public_url(url: str) -> None:
     if not parsed.hostname:
         frappe.throw(_("Webhook URL must include a hostname"))
 
-    port = parsed.port or 443
+    resolve_public_address(parsed.hostname, parsed.port or 443)
+
+
+class BlockedWebhookAddress(frappe.ValidationError):
+    pass
+
+
+def resolve_public_address(hostname: str, port: int) -> str:
+    """The one publicly routable address this hostname is allowed to be reached
+    on. Returning the address, rather than approving the name, is what stops a
+    second lookup from answering differently."""
     try:
-        resolved = socket.getaddrinfo(parsed.hostname, port, proto=socket.IPPROTO_TCP)
+        resolved = socket.getaddrinfo(hostname, port, proto=socket.IPPROTO_TCP)
     except socket.gaierror:
-        frappe.throw(_("Could not resolve webhook host: {0}").format(parsed.hostname))
+        frappe.throw(_("Could not resolve webhook host: {0}").format(hostname))
 
     for *_rest, sockaddr in resolved:
         address = ipaddress.ip_address(sockaddr[0])
@@ -288,25 +298,21 @@ def validate_public_url(url: str) -> None:
                 _(
                     "Webhook URL resolves to a non-public address ({0}). "
                     "Alerts can only be sent to publicly routable hosts."
-                ).format(address)
+                ).format(address),
+                exc=BlockedWebhookAddress,
             )
-
-
-class BlockedWebhookAddress(frappe.ValidationError):
-    pass
+    return resolved[0][-1][0]
 
 
 class _PublicOnlyConnection(HTTPSConnection):
-    def connect(self):
-        super().connect()
-        address = ipaddress.ip_address(self.sock.getpeername()[0])
-        if address.version == 6 and address.ipv4_mapped:
-            address = address.ipv4_mapped
-        if not address.is_global:
-            frappe.throw(
-                _("Webhook host connected to a non-public address ({0})").format(address),
-                exc=BlockedWebhookAddress,
-            )
+    def _new_conn(self):
+        pinned = resolve_public_address(self.host, self.port)
+        original = self._dns_host
+        self._dns_host = pinned
+        try:
+            return super()._new_conn()
+        finally:
+            self._dns_host = original
 
 
 class _PublicOnlyConnectionPool(HTTPSConnectionPool):

--- a/insights/insights/doctype/insights_alert/insights_alert.py
+++ b/insights/insights/doctype/insights_alert/insights_alert.py
@@ -14,6 +14,9 @@ from croniter import croniter
 from frappe.model.document import Document
 from frappe.utils import validate_email_address
 from frappe.utils.data import get_datetime, get_datetime_str, now_datetime
+from requests.adapters import HTTPAdapter
+from urllib3.connection import HTTPSConnection
+from urllib3.connectionpool import HTTPSConnectionPool
 
 from insights.insights.doctype.insights_data_source_v3.insights_data_source_v3 import (
     db_connections,
@@ -129,7 +132,7 @@ class InsightsAlert(Document):
                 headers=headers,
             )
             response.raise_for_status()
-        except requests.RequestException as e:
+        except (requests.RequestException, BlockedWebhookAddress) as e:
             frappe.log_error(
                 message=frappe.get_traceback(),
                 title=f"Insights webhook alert failed: {self.title}",
@@ -286,18 +289,49 @@ def validate_public_url(url: str) -> None:
             )
 
 
+class BlockedWebhookAddress(frappe.ValidationError):
+    pass
+
+
+class _PublicOnlyConnection(HTTPSConnection):
+    def connect(self):
+        super().connect()
+        address = ipaddress.ip_address(self.sock.getpeername()[0])
+        if address.version == 6 and address.ipv4_mapped:
+            address = address.ipv4_mapped
+        if not address.is_global:
+            frappe.throw(
+                f"Webhook host connected to a non-public address ({address})",
+                exc=BlockedWebhookAddress,
+            )
+
+
+class _PublicOnlyConnectionPool(HTTPSConnectionPool):
+    ConnectionCls = _PublicOnlyConnection
+
+
+class PublicOnlyAdapter(HTTPAdapter):
+    """Checks the address actually connected to, which DNS cannot change after the fact."""
+
+    def init_poolmanager(self, *args, **kwargs):
+        super().init_poolmanager(*args, **kwargs)
+        self.poolmanager.pool_classes_by_scheme = {"https": _PublicOnlyConnectionPool}
+
+
 def post_to_public_url(url: str, data: str, headers: dict) -> requests.Response:
     """POST to a validated destination. A redirect is refused rather than
     followed, so the address that was checked is the address that receives the
     alert - configure the final URL instead."""
     validate_public_url(url)
-    response = requests.post(
-        url,
-        data=data,
-        headers=headers,
-        timeout=WEBHOOK_TIMEOUT_SECONDS,
-        allow_redirects=False,
-    )
+    with requests.Session() as session:
+        session.mount("https://", PublicOnlyAdapter())
+        response = session.post(
+            url,
+            data=data,
+            headers=headers,
+            timeout=WEBHOOK_TIMEOUT_SECONDS,
+            allow_redirects=False,
+        )
     if response.is_redirect:
         frappe.throw(f"Webhook URL must not redirect (got {response.status_code})")
     return response

--- a/insights/insights/doctype/insights_alert/insights_alert.py
+++ b/insights/insights/doctype/insights_alert/insights_alert.py
@@ -11,6 +11,7 @@ import pandas as pd
 import requests
 import telegram
 from croniter import croniter
+from frappe import _
 from frappe.model.document import Document
 from frappe.utils import validate_email_address
 from frappe.utils.data import get_datetime, get_datetime_str, now_datetime
@@ -69,9 +70,9 @@ class InsightsAlert(Document):
 
     def validate_webhook(self):
         if not self.webhook_url:
-            frappe.throw("Webhook URI is required for a webhook alert")
+            frappe.throw(_("Webhook URL is required for a webhook alert"))
         if not self.webhook_token:
-            frappe.throw("Webhook token is required for a webhook alert")
+            frappe.throw(_("Webhook token is required for a webhook alert"))
         validate_public_url(self.webhook_url)
 
     def has_query_permission(self):
@@ -137,7 +138,7 @@ class InsightsAlert(Document):
                 message=frappe.get_traceback(),
                 title=f"Insights webhook alert failed: {self.title}",
             )
-            frappe.throw(f"Could not deliver the alert to {self.webhook_url}: {e}")
+            frappe.throw(_("Could not deliver the alert to {0}: {1}").format(self.webhook_url, str(e)))
 
     def send_email_alert(self, message):
         subject = f"Insights Alert: {self.title}"
@@ -268,24 +269,26 @@ def validate_public_url(url: str) -> None:
     targets."""
     parsed = urlparse(url)
     if parsed.scheme != "https":
-        frappe.throw("Webhook URL must use https")
+        frappe.throw(_("Webhook URL must use https"))
     if not parsed.hostname:
-        frappe.throw("Webhook URL must include a hostname")
+        frappe.throw(_("Webhook URL must include a hostname"))
 
     port = parsed.port or 443
     try:
         resolved = socket.getaddrinfo(parsed.hostname, port, proto=socket.IPPROTO_TCP)
     except socket.gaierror:
-        frappe.throw(f"Could not resolve webhook host: {parsed.hostname}")
+        frappe.throw(_("Could not resolve webhook host: {0}").format(parsed.hostname))
 
-    for *_, sockaddr in resolved:
+    for *_rest, sockaddr in resolved:
         address = ipaddress.ip_address(sockaddr[0])
         if address.version == 6 and address.ipv4_mapped:
             address = address.ipv4_mapped
         if not address.is_global:
             frappe.throw(
-                f"Webhook URL resolves to a non-public address ({address}). "
-                "Alerts can only be sent to publicly routable hosts."
+                _(
+                    "Webhook URL resolves to a non-public address ({0}). "
+                    "Alerts can only be sent to publicly routable hosts."
+                ).format(address)
             )
 
 
@@ -301,7 +304,7 @@ class _PublicOnlyConnection(HTTPSConnection):
             address = address.ipv4_mapped
         if not address.is_global:
             frappe.throw(
-                f"Webhook host connected to a non-public address ({address})",
+                _("Webhook host connected to a non-public address ({0})").format(address),
                 exc=BlockedWebhookAddress,
             )
 
@@ -322,7 +325,7 @@ class PublicOnlyAdapter(HTTPAdapter):
 
     def proxy_manager_for(self, proxy, **proxy_kwargs):
         frappe.throw(
-            f"Webhook alerts cannot be delivered through a proxy ({proxy})",
+            _("Webhook alerts cannot be delivered through a proxy ({0})").format(proxy),
             exc=BlockedWebhookAddress,
         )
 
@@ -344,7 +347,7 @@ def post_to_public_url(url: str, data: str, headers: dict) -> requests.Response:
             proxies={},
         )
     if response.is_redirect:
-        frappe.throw(f"Webhook URL must not redirect (got {response.status_code})")
+        frappe.throw(_("Webhook URL must not redirect (got {0})").format(response.status_code))
     return response
 
 

--- a/insights/insights/doctype/insights_alert/insights_alert.py
+++ b/insights/insights/doctype/insights_alert/insights_alert.py
@@ -5,6 +5,7 @@ from datetime import datetime
 
 import frappe
 import pandas as pd
+import requests
 import telegram
 from croniter import croniter
 from frappe.model.document import Document
@@ -16,6 +17,9 @@ from insights.insights.doctype.insights_data_source_v3.insights_data_source_v3 i
 )
 from insights.utils import deep_convert_dict_to_dict
 
+# A hanging endpoint must not hold the scheduled job that sends every alert.
+WEBHOOK_TIMEOUT_SECONDS = 10
+
 
 class InsightsAlert(Document):
     # begin: auto-generated types
@@ -26,7 +30,7 @@ class InsightsAlert(Document):
     if TYPE_CHECKING:
         from frappe.types import DF
 
-        channel: DF.Literal["Email", "Telegram"]
+        channel: DF.Literal["Email", "Telegram", "Webhook"]
         condition: DF.Code
         cron_format: DF.Data | None
         custom_condition: DF.Check
@@ -34,11 +38,12 @@ class InsightsAlert(Document):
         frequency: DF.Literal["Hourly", "Daily", "Weekly", "Monthly", "Cron"]
         last_execution: DF.Datetime | None
         message: DF.MarkdownEditor | None
-        next_execution: DF.Datetime | None
         query: DF.Link
         recipients: DF.SmallText | None
         telegram_chat_id: DF.Data | None
         title: DF.Data
+        webhook_token: DF.Password | None
+        webhook_uri: DF.Data | None
     # end: auto-generated types
 
     def validate(self):
@@ -48,10 +53,22 @@ class InsightsAlert(Document):
         if self.query:
             self.has_query_permission()
 
+        if self.channel == "Webhook":
+            self.validate_webhook()
+
         try:
             self.evaluate_condition()
         except Exception as e:
             frappe.throw(f"Invalid condition: {e}")
+
+    def validate_webhook(self):
+        if not self.webhook_uri:
+            frappe.throw("Webhook URI is required for a webhook alert")
+        if not self.webhook_uri.startswith(("http://", "https://")):
+            frappe.throw("Webhook URI must start with http:// or https://")
+        # The token is sent as a header, so plain http would expose it in transit.
+        if self.webhook_token and self.webhook_uri.startswith("http://"):
+            frappe.throw("A webhook with a token must use https://")
 
     def has_query_permission(self):
         if not frappe.has_permission("Insights Query v3", "read", self.query):
@@ -63,18 +80,60 @@ class InsightsAlert(Document):
         if not results and not force:
             return
 
-        message = self.evaluate_message()
+        # Built once: the context runs the query, and a webhook alert sends the
+        # rendered message and the rows behind it.
+        context = self.get_message_context()
+        message = self.evaluate_message(context)
 
         if self.channel == "Email":
             self.send_email_alert(message)
         if self.channel == "Telegram":
             self.send_telegram_alert(message)
+        if self.channel == "Webhook":
+            self.send_webhook_alert(message, context)
 
         self.db_set("last_execution", now_datetime(), update_modified=False)
 
     def send_telegram_alert(self, message):
         tg = TelegramAlert(self.telegram_chat_id)
         tg.send(message)
+
+    def send_webhook_alert(self, message, context):
+        """POST the alert to the configured endpoint. The token travels in an
+        Authorization header rather than the URI, which would put it in the
+        receiver's access logs."""
+        payload = {
+            "event": "insights_alert",
+            "message": message,
+            "context": {
+                "alert": context["alert"]["title"],
+                "query": context["query"]["title"],
+                "count": context["count"],
+                "rows": context["rows"],
+                "triggered_at": get_datetime_str(now_datetime()),
+            },
+        }
+
+        headers = {"Content-Type": "application/json"}
+        if token := self.get_password("webhook_token", raise_exception=False):
+            headers["Authorization"] = f"Bearer {token}"
+
+        try:
+            # frappe.as_json, not requests' json=: query rows carry datetimes
+            # and Decimals that the plain encoder refuses.
+            response = requests.post(
+                self.webhook_uri,
+                data=frappe.as_json(payload),
+                headers=headers,
+                timeout=WEBHOOK_TIMEOUT_SECONDS,
+            )
+            response.raise_for_status()
+        except requests.RequestException as e:
+            frappe.log_error(
+                message=frappe.get_traceback(),
+                title=f"Insights webhook alert failed: {self.title}",
+            )
+            frappe.throw(f"Could not deliver the alert to {self.webhook_uri}: {e}")
 
     def send_email_alert(self, message):
         subject = f"Insights Alert: {self.title}"
@@ -91,13 +150,14 @@ class InsightsAlert(Document):
         with db_connections():
             return doc.evaluate_alert_expression(self.condition)
 
-    def evaluate_message(self):
+    def evaluate_message(self, context=None):
         rows_pattern = r"{{\s*rows\s*}}"
         message_md = re.sub(rows_pattern, "{{ datatable }}", self.message)
 
-        context = self.get_message_context()
+        context = context or self.get_message_context()
         message_md = render_template_restricted(message_md, context)
-        if self.channel == "Telegram":
+        # A webhook consumer wants the text, not the styled email body.
+        if self.channel in ("Telegram", "Webhook"):
             return message_md
 
         message_html = frappe.utils.md_to_html(message_md)

--- a/insights/insights/doctype/insights_alert/insights_alert.py
+++ b/insights/insights/doctype/insights_alert/insights_alert.py
@@ -13,11 +13,19 @@ from frappe.model.document import Document
 from frappe.utils import validate_email_address
 from frappe.utils.data import get_datetime, get_datetime_str, now_datetime
 
-from insights.http import OutboundRequestRefused, post_to_public_url, validate_public_url
+from insights.http import post_to_public_url, validate_public_url
 from insights.insights.doctype.insights_data_source_v3.insights_data_source_v3 import (
     db_connections,
 )
 from insights.utils import deep_convert_dict_to_dict
+
+# The payload is a contract with somebody else's code. Version it, so it can
+# change without breaking every receiver that already parses it.
+WEBHOOK_PAYLOAD_VERSION = 1
+
+# A query with no ceiling on its rows must not become a POST with no ceiling on
+# its body. `count` still reports the real total.
+WEBHOOK_MAX_ROWS = 100
 
 
 class InsightsAlert(Document):
@@ -65,6 +73,9 @@ class InsightsAlert(Document):
             frappe.throw(_("Webhook URL is required for a webhook alert"))
         if not self.webhook_token:
             frappe.throw(_("Webhook token is required for a webhook alert"))
+        # Only what the URL says, not where it resolves. Resolving here would
+        # put a name lookup inside the save transaction and still prove nothing
+        # about send time. "Send test" is the button that answers that.
         validate_public_url(self.webhook_url)
 
     def has_query_permission(self):
@@ -100,13 +111,15 @@ class InsightsAlert(Document):
         Authorization header rather than the URI, which would put it in the
         receiver's access logs."""
         payload = {
+            "version": WEBHOOK_PAYLOAD_VERSION,
             "event": "insights_alert",
             "message": message,
             "context": {
                 "alert": context["alert"]["title"],
                 "query": context["query"]["title"],
                 "count": context["count"],
-                "rows": context["rows"],
+                "rows": context["rows"][:WEBHOOK_MAX_ROWS],
+                "truncated": context["count"] > WEBHOOK_MAX_ROWS,
                 "triggered_at": get_datetime_str(now_datetime()),
             },
         }
@@ -125,12 +138,17 @@ class InsightsAlert(Document):
                 headers=headers,
             )
             response.raise_for_status()
-        except (requests.RequestException, OutboundRequestRefused) as e:
-            frappe.log_error(
-                message=frappe.get_traceback(),
-                title=f"Insights webhook alert failed: {self.title}",
+        except requests.HTTPError as e:
+            frappe.throw(
+                _("The webhook at {0} returned {1}").format(self.webhook_url, e.response.status_code)
             )
-            frappe.throw(_("Could not deliver the alert to {0}: {1}").format(self.webhook_url, str(e)))
+        except requests.RequestException as e:
+            # No log_error here: `send_alerts` logs, and the interactive caller
+            # reads the message. An OutboundRequestRefused already says what it
+            # refused, so it goes up untouched.
+            frappe.throw(
+                _("Could not deliver the alert to {0} ({1})").format(self.webhook_url, type(e).__name__)
+            )
 
     def send_email_alert(self, message):
         subject = f"Insights Alert: {self.title}"
@@ -147,11 +165,10 @@ class InsightsAlert(Document):
         with db_connections():
             return doc.evaluate_alert_expression(self.condition)
 
-    def evaluate_message(self, context=None):
+    def evaluate_message(self, context):
         rows_pattern = r"{{\s*rows\s*}}"
         message_md = re.sub(rows_pattern, "{{ datatable }}", self.message)
 
-        context = context or self.get_message_context()
         message_md = render_template_restricted(message_md, context)
         # A webhook consumer wants the text, not the styled email body.
         if self.channel in ("Telegram", "Webhook"):

--- a/insights/insights/doctype/insights_alert/insights_alert.py
+++ b/insights/insights/doctype/insights_alert/insights_alert.py
@@ -43,7 +43,7 @@ class InsightsAlert(Document):
         telegram_chat_id: DF.Data | None
         title: DF.Data
         webhook_token: DF.Password | None
-        webhook_uri: DF.Data | None
+        webhook_url: DF.Data | None
     # end: auto-generated types
 
     def validate(self):
@@ -62,13 +62,13 @@ class InsightsAlert(Document):
             frappe.throw(f"Invalid condition: {e}")
 
     def validate_webhook(self):
-        if not self.webhook_uri:
+        if not self.webhook_url:
             frappe.throw("Webhook URI is required for a webhook alert")
-        if not self.webhook_uri.startswith(("http://", "https://")):
-            frappe.throw("Webhook URI must start with http:// or https://")
+        if not self.webhook_token:
+            frappe.throw("Webhook token is required for a webhook alert")
         # The token is sent as a header, so plain http would expose it in transit.
-        if self.webhook_token and self.webhook_uri.startswith("http://"):
-            frappe.throw("A webhook with a token must use https://")
+        if not self.webhook_url.startswith("https://"):
+            frappe.throw("Webhook URI must start with https://")
 
     def has_query_permission(self):
         if not frappe.has_permission("Insights Query v3", "read", self.query):
@@ -114,15 +114,16 @@ class InsightsAlert(Document):
             },
         }
 
-        headers = {"Content-Type": "application/json"}
-        if token := self.get_password("webhook_token", raise_exception=False):
-            headers["Authorization"] = f"Bearer {token}"
+        headers = {
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {self.get_password('webhook_token')}",
+        }
 
         try:
             # frappe.as_json, not requests' json=: query rows carry datetimes
             # and Decimals that the plain encoder refuses.
             response = requests.post(
-                self.webhook_uri,
+                self.webhook_url,
                 data=frappe.as_json(payload),
                 headers=headers,
                 timeout=WEBHOOK_TIMEOUT_SECONDS,
@@ -133,7 +134,7 @@ class InsightsAlert(Document):
                 message=frappe.get_traceback(),
                 title=f"Insights webhook alert failed: {self.title}",
             )
-            frappe.throw(f"Could not deliver the alert to {self.webhook_uri}: {e}")
+            frappe.throw(f"Could not deliver the alert to {self.webhook_url}: {e}")
 
     def send_email_alert(self, message):
         subject = f"Insights Alert: {self.title}"

--- a/insights/insights/doctype/insights_alert/insights_alert.py
+++ b/insights/insights/doctype/insights_alert/insights_alert.py
@@ -311,11 +311,20 @@ class _PublicOnlyConnectionPool(HTTPSConnectionPool):
 
 
 class PublicOnlyAdapter(HTTPAdapter):
-    """Checks the address actually connected to, which DNS cannot change after the fact."""
+    """Checks the address actually connected to, which DNS cannot change after the fact.
+
+    A proxy resolves and connects on our behalf, so the destination cannot be
+    checked here at all - proxied delivery is refused rather than trusted."""
 
     def init_poolmanager(self, *args, **kwargs):
         super().init_poolmanager(*args, **kwargs)
         self.poolmanager.pool_classes_by_scheme = {"https": _PublicOnlyConnectionPool}
+
+    def proxy_manager_for(self, proxy, **proxy_kwargs):
+        frappe.throw(
+            f"Webhook alerts cannot be delivered through a proxy ({proxy})",
+            exc=BlockedWebhookAddress,
+        )
 
 
 def post_to_public_url(url: str, data: str, headers: dict) -> requests.Response:
@@ -325,12 +334,14 @@ def post_to_public_url(url: str, data: str, headers: dict) -> requests.Response:
     validate_public_url(url)
     with requests.Session() as session:
         session.mount("https://", PublicOnlyAdapter())
+        session.trust_env = False
         response = session.post(
             url,
             data=data,
             headers=headers,
             timeout=WEBHOOK_TIMEOUT_SECONDS,
             allow_redirects=False,
+            proxies={},
         )
     if response.is_redirect:
         frappe.throw(f"Webhook URL must not redirect (got {response.status_code})")

--- a/insights/insights/doctype/insights_alert/insights_alert.py
+++ b/insights/insights/doctype/insights_alert/insights_alert.py
@@ -1,10 +1,7 @@
 # Copyright (c) 2023, Frappe Technologies Pvt. Ltd. and contributors
 # For license information, please see license.txt
-import ipaddress
 import re
-import socket
 from datetime import datetime
-from urllib.parse import urlparse
 
 import frappe
 import pandas as pd
@@ -15,17 +12,12 @@ from frappe import _
 from frappe.model.document import Document
 from frappe.utils import validate_email_address
 from frappe.utils.data import get_datetime, get_datetime_str, now_datetime
-from requests.adapters import HTTPAdapter
-from urllib3.connection import HTTPSConnection
-from urllib3.connectionpool import HTTPSConnectionPool
 
+from insights.http import OutboundRequestRefused, post_to_public_url, validate_public_url
 from insights.insights.doctype.insights_data_source_v3.insights_data_source_v3 import (
     db_connections,
 )
 from insights.utils import deep_convert_dict_to_dict
-
-# A hanging endpoint must not hold the scheduled job that sends every alert.
-WEBHOOK_TIMEOUT_SECONDS = 10
 
 
 class InsightsAlert(Document):
@@ -133,7 +125,7 @@ class InsightsAlert(Document):
                 headers=headers,
             )
             response.raise_for_status()
-        except (requests.RequestException, BlockedWebhookAddress) as e:
+        except (requests.RequestException, OutboundRequestRefused) as e:
             frappe.log_error(
                 message=frappe.get_traceback(),
                 title=f"Insights webhook alert failed: {self.title}",
@@ -259,102 +251,6 @@ class TelegramAlert:
     @property
     def bot(self):
         return telegram.Bot(token=self.token)
-
-
-def validate_public_url(url: str) -> None:
-    """Reject a destination an Insights User should not be able to make this
-    server talk to. Any Insights User can create an alert, so a webhook that
-    resolves onto the server's own network reaches services that are not
-    otherwise exposed to them. Only publicly routable hosts are delivery
-    targets."""
-    parsed = urlparse(url)
-    if parsed.scheme != "https":
-        frappe.throw(_("Webhook URL must use https"))
-    if not parsed.hostname:
-        frappe.throw(_("Webhook URL must include a hostname"))
-
-    resolve_public_address(parsed.hostname, parsed.port or 443)
-
-
-class BlockedWebhookAddress(frappe.ValidationError):
-    pass
-
-
-def resolve_public_address(hostname: str, port: int) -> str:
-    """The one publicly routable address this hostname is allowed to be reached
-    on. Returning the address, rather than approving the name, is what stops a
-    second lookup from answering differently."""
-    try:
-        resolved = socket.getaddrinfo(hostname, port, proto=socket.IPPROTO_TCP)
-    except socket.gaierror:
-        frappe.throw(_("Could not resolve webhook host: {0}").format(hostname))
-
-    for *_rest, sockaddr in resolved:
-        address = ipaddress.ip_address(sockaddr[0])
-        if address.version == 6 and address.ipv4_mapped:
-            address = address.ipv4_mapped
-        if not address.is_global:
-            frappe.throw(
-                _(
-                    "Webhook URL resolves to a non-public address ({0}). "
-                    "Alerts can only be sent to publicly routable hosts."
-                ).format(address),
-                exc=BlockedWebhookAddress,
-            )
-    return resolved[0][-1][0]
-
-
-class _PublicOnlyConnection(HTTPSConnection):
-    def _new_conn(self):
-        pinned = resolve_public_address(self.host, self.port)
-        original = self._dns_host
-        self._dns_host = pinned
-        try:
-            return super()._new_conn()
-        finally:
-            self._dns_host = original
-
-
-class _PublicOnlyConnectionPool(HTTPSConnectionPool):
-    ConnectionCls = _PublicOnlyConnection
-
-
-class PublicOnlyAdapter(HTTPAdapter):
-    """Checks the address actually connected to, which DNS cannot change after the fact.
-
-    A proxy resolves and connects on our behalf, so the destination cannot be
-    checked here at all - proxied delivery is refused rather than trusted."""
-
-    def init_poolmanager(self, *args, **kwargs):
-        super().init_poolmanager(*args, **kwargs)
-        self.poolmanager.pool_classes_by_scheme = {"https": _PublicOnlyConnectionPool}
-
-    def proxy_manager_for(self, proxy, **proxy_kwargs):
-        frappe.throw(
-            _("Webhook alerts cannot be delivered through a proxy ({0})").format(proxy),
-            exc=BlockedWebhookAddress,
-        )
-
-
-def post_to_public_url(url: str, data: str, headers: dict) -> requests.Response:
-    """POST to a validated destination. A redirect is refused rather than
-    followed, so the address that was checked is the address that receives the
-    alert - configure the final URL instead."""
-    validate_public_url(url)
-    with requests.Session() as session:
-        session.mount("https://", PublicOnlyAdapter())
-        session.trust_env = False
-        response = session.post(
-            url,
-            data=data,
-            headers=headers,
-            timeout=WEBHOOK_TIMEOUT_SECONDS,
-            allow_redirects=False,
-            proxies={},
-        )
-    if response.is_redirect:
-        frappe.throw(_("Webhook URL must not redirect (got {0})").format(response.status_code))
-    return response
 
 
 def render_template_restricted(template: str, context: dict) -> str:

--- a/insights/insights/doctype/insights_alert/insights_alert.py
+++ b/insights/insights/doctype/insights_alert/insights_alert.py
@@ -66,9 +66,6 @@ class InsightsAlert(Document):
             frappe.throw("Webhook URI is required for a webhook alert")
         if not self.webhook_token:
             frappe.throw("Webhook token is required for a webhook alert")
-        # The token is sent as a header, so plain http would expose it in transit.
-        if not self.webhook_url.startswith("https://"):
-            frappe.throw("Webhook URI must start with https://")
 
     def has_query_permission(self):
         if not frappe.has_permission("Insights Query v3", "read", self.query):

--- a/insights/insights/doctype/insights_alert/test_insights_alert.py
+++ b/insights/insights/doctype/insights_alert/test_insights_alert.py
@@ -1,9 +1,143 @@
 # Copyright (c) 2023, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
 
-# import frappe
-from frappe.tests.utils import FrappeTestCase
+from unittest.mock import patch
+
+import frappe
+import requests
+from frappe.tests import IntegrationTestCase
+
+from insights.http import OutboundRequestRefused
+from insights.insights.doctype.insights_alert.insights_alert import (
+    WEBHOOK_MAX_ROWS,
+    InsightsAlert,
+    send_alerts,
+)
+from insights.tests.base import InsightsIntegrationTestCase
+from insights.tests.factories import create_test_query, create_test_workbook
+
+POST = "insights.insights.doctype.insights_alert.insights_alert.post_to_public_url"
 
 
-class TestInsightsAlert(FrappeTestCase):
-    pass
+def message_context(row_count=1):
+    return {
+        "alert": {"title": "Late invoices"},
+        "query": {"title": "Invoices overdue"},
+        "count": row_count,
+        "rows": [{"invoice": f"INV-{i}"} for i in range(row_count)],
+    }
+
+
+def webhook_alert():
+    """An unsaved alert, which is all `send_webhook_alert` reads."""
+    doc = frappe.new_doc("Insights Alert")
+    doc.title = "Late invoices"
+    doc.channel = "Webhook"
+    doc.webhook_url = "https://example.com/hooks/insights"
+    doc.webhook_token = "sekret-token"
+    return doc
+
+
+class TestWebhookPayload(IntegrationTestCase):
+    """The payload is a contract with a receiver's parser. Pin its shape."""
+
+    def post_one(self, context):
+        with patch(POST) as post:
+            webhook_alert().send_webhook_alert("**3 invoices are overdue**", context)
+        return frappe.parse_json(post.call_args.kwargs["data"]), post.call_args
+
+    def test_payload_carries_a_version(self):
+        payload, _ = self.post_one(message_context())
+        self.assertEqual(payload["version"], 1)
+        self.assertEqual(payload["event"], "insights_alert")
+        self.assertEqual(payload["message"], "**3 invoices are overdue**")
+        self.assertEqual(payload["context"]["alert"], "Late invoices")
+        self.assertEqual(payload["context"]["query"], "Invoices overdue")
+
+    def test_token_travels_in_the_authorization_header(self):
+        """Not in the URI, which would land it in the receiver's access logs."""
+        _, call = self.post_one(message_context())
+        self.assertEqual(call.kwargs["headers"]["Authorization"], "Bearer sekret-token")
+        self.assertNotIn("sekret-token", call.args[0])
+
+    def test_rows_are_capped_and_the_cap_is_declared(self):
+        payload, _ = self.post_one(message_context(row_count=WEBHOOK_MAX_ROWS + 150))
+        self.assertEqual(len(payload["context"]["rows"]), WEBHOOK_MAX_ROWS)
+        self.assertEqual(payload["context"]["count"], WEBHOOK_MAX_ROWS + 150)
+        self.assertTrue(payload["context"]["truncated"])
+
+    def test_a_short_result_is_not_marked_truncated(self):
+        payload, _ = self.post_one(message_context(row_count=3))
+        self.assertEqual(len(payload["context"]["rows"]), 3)
+        self.assertFalse(payload["context"]["truncated"])
+
+
+class TestWebhookFailures(IntegrationTestCase):
+    def test_a_status_code_is_reported(self):
+        response = requests.Response()
+        response.status_code = 503
+        error = requests.HTTPError(response=response)
+        with patch(POST, side_effect=error):
+            with self.assertRaisesRegex(frappe.ValidationError, "returned 503"):
+                webhook_alert().send_webhook_alert("msg", message_context())
+
+    def test_transport_failure_does_not_leak_the_exception_text(self):
+        """Any Insights User can reach this. It gets the class, not the internals."""
+        with patch(POST, side_effect=requests.ConnectionError("connect to 10.1.2.3 failed")):
+            with self.assertRaises(frappe.ValidationError) as raised:
+                webhook_alert().send_webhook_alert("msg", message_context())
+        self.assertNotIn("10.1.2.3", str(raised.exception))
+        self.assertIn("ConnectionError", str(raised.exception))
+
+    def test_a_refusal_is_passed_through_unchanged(self):
+        """It already says what it refused, so restating it loses the reason."""
+        refusal = OutboundRequestRefused("resolves to a non-public address (10.0.0.1)")
+        with patch(POST, side_effect=refusal):
+            with self.assertRaisesRegex(OutboundRequestRefused, "non-public address"):
+                webhook_alert().send_webhook_alert("msg", message_context())
+
+
+class TestFailedAlertIsNotRetriedEveryTick(InsightsIntegrationTestCase):
+    # `send_alerts` rolls back what it catches, which would take the fixtures
+    # with it. Committing them in class setup is what keeps them around.
+
+    @classmethod
+    def before_class(cls):
+        cls.workbook = create_test_workbook("Administrator")
+        query = create_test_query("Administrator", cls.workbook.name)
+        cls.alert = frappe.get_doc(
+            doctype="Insights Alert",
+            title="Webhook that is down",
+            channel="Webhook",
+            query=query.name,
+            frequency="Daily",
+            condition="q['status'] == 'Open'",
+            custom_condition=1,
+            message="{{ rows }}",
+            webhook_url="https://example.com/hooks/insights",
+            webhook_token="sekret-token",
+        ).insert()
+
+    @classmethod
+    def after_class(cls):
+        frappe.delete_doc("Insights Alert", cls.alert.name, force=True)
+        frappe.delete_doc("Insights Workbook", cls.workbook.name, force=True)
+
+    def test_a_failed_delivery_records_the_run(self):
+        """`last_execution` is the cron's start point. Left unset by a failure,
+        the alert is due again on the next four-minute tick and a dead endpoint
+        gets several hundred POSTs a day.
+
+        The condition is stubbed to met: this is about what the scheduler
+        records, not about what the query returns.
+        """
+        self.assertIsNone(self.alert.last_execution)
+
+        with (
+            patch.object(InsightsAlert, "evaluate_condition", return_value=True),
+            patch.object(InsightsAlert, "get_message_context", return_value=message_context()),
+            patch(POST, side_effect=requests.ConnectionError("endpoint is down")),
+        ):
+            send_alerts()
+
+        self.assertIsNotNone(frappe.db.get_value("Insights Alert", self.alert.name, "last_execution"))

--- a/insights/tests/test_http.py
+++ b/insights/tests/test_http.py
@@ -1,0 +1,122 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
+# See license.txt
+"""Tests for `insights.http`.
+
+The point of the connect-time test below: `insights.http` reaches into private
+urllib3 API to check the address a socket actually opens on. If a urllib3
+upgrade renames `_new_conn`, the override binds to nothing, no error is raised,
+and the rebinding defence quietly stops existing. Only a test that drives a
+request all the way to the socket notices that.
+
+Every test stubs DNS, so none of them touch the network.
+"""
+
+import socket
+from unittest.mock import patch
+
+from frappe.tests import UnitTestCase
+
+from insights.http import (
+    OutboundRequestRefused,
+    PublicOnlyAdapter,
+    post_to_public_url,
+    resolve_public_address,
+    validate_public_url,
+)
+
+PUBLIC = "93.184.216.34"
+
+
+def addrinfo(*addresses: str) -> list:
+    """What `socket.getaddrinfo` returns, for the addresses a test cares about."""
+    entries = []
+    for address in addresses:
+        family = socket.AF_INET6 if ":" in address else socket.AF_INET
+        sockaddr = (address, 443, 0, 0) if family == socket.AF_INET6 else (address, 443)
+        entries.append((family, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", sockaddr))
+    return entries
+
+
+def resolving_to(*addresses: str):
+    return patch("socket.getaddrinfo", return_value=addrinfo(*addresses))
+
+
+class TestPublicUrlValidation(UnitTestCase):
+    def test_http_is_refused(self):
+        with self.assertRaises(OutboundRequestRefused):
+            validate_public_url("http://example.com/hook")
+
+    def test_scheme_without_hostname_is_refused(self):
+        with self.assertRaises(OutboundRequestRefused):
+            validate_public_url("https:///hook")
+
+    def test_https_url_passes(self):
+        validate_public_url("https://example.com/hook")
+
+    def test_validation_does_not_resolve(self):
+        """It runs inside a save, so it must not wait on a resolver."""
+        with patch("socket.getaddrinfo") as getaddrinfo:
+            validate_public_url("https://example.com/hook")
+        getaddrinfo.assert_not_called()
+
+
+class TestPublicAddressResolution(UnitTestCase):
+    def test_public_address_is_returned(self):
+        with resolving_to(PUBLIC):
+            self.assertEqual(resolve_public_address("example.com", 443), PUBLIC)
+
+    def test_loopback_is_refused(self):
+        with resolving_to("127.0.0.1"), self.assertRaises(OutboundRequestRefused):
+            resolve_public_address("example.com", 443)
+
+    def test_private_range_is_refused(self):
+        with resolving_to("10.0.0.1"), self.assertRaises(OutboundRequestRefused):
+            resolve_public_address("example.com", 443)
+
+    def test_link_local_metadata_address_is_refused(self):
+        with resolving_to("169.254.169.254"), self.assertRaises(OutboundRequestRefused):
+            resolve_public_address("example.com", 443)
+
+    def test_ipv6_loopback_is_refused(self):
+        with resolving_to("::1"), self.assertRaises(OutboundRequestRefused):
+            resolve_public_address("example.com", 443)
+
+    def test_ipv4_mapped_ipv6_is_unwrapped_before_the_check(self):
+        with resolving_to("::ffff:127.0.0.1"), self.assertRaises(OutboundRequestRefused):
+            resolve_public_address("example.com", 443)
+
+    def test_one_private_answer_refuses_the_whole_name(self):
+        """A name that answers with both is still a way onto the network."""
+        with resolving_to(PUBLIC, "10.0.0.1"), self.assertRaises(OutboundRequestRefused):
+            resolve_public_address("example.com", 443)
+
+    def test_unresolvable_host_is_refused(self):
+        with patch("socket.getaddrinfo", side_effect=socket.gaierror):
+            with self.assertRaises(OutboundRequestRefused):
+                resolve_public_address("nope.example.com", 443)
+
+
+class TestPostToPublicUrl(UnitTestCase):
+    def test_rebinding_is_refused_while_connecting(self):
+        """The check that survives a lookup answering differently the second time.
+
+        `validate_public_url` is stubbed to a pass, so nothing but the
+        connection itself can refuse this. Match the message, not just the
+        type: a socket that is merely unreachable also raises
+        OutboundRequestRefused, so `assertRaises` alone stays green even after
+        the urllib3 override comes unstuck.
+        """
+        with (
+            patch("insights.http.validate_public_url"),
+            # Nothing should get this far. If it does, fail here rather than
+            # open a socket to whatever is listening on the test machine.
+            patch("urllib3.util.connection.create_connection", side_effect=OSError),
+            resolving_to("127.0.0.1"),
+        ):
+            with self.assertRaisesRegex(OutboundRequestRefused, "non-public address"):
+                post_to_public_url("https://example.com/hook", data="{}", headers={})
+
+    def test_a_proxy_is_refused(self):
+        """A proxy connects for us, which leaves no address here to check."""
+        with self.assertRaises(OutboundRequestRefused):
+            PublicOnlyAdapter().proxy_manager_for("https://proxy.example.com:3128")


### PR DESCRIPTION
Adds a webhook channel to Insights alerts. The alert POSTs a JSON payload to a
URL the user configures, with a token in an `Authorization: Bearer` header.

An `Insights User` can create an alert and send it on demand, so the URL is an
untrusted destination. Outbound requests to it are restricted to publicly
routable addresses: https only, the address is checked again as the socket
opens, and a redirect or a proxy is refused. `insights/http.py` holds the
policy, and [ADR-0002](docs/adr/0002-outbound-http-to-user-chosen-urls.md)
records why.

Two consequences to know about:

- A deployment whose only route out is an egress proxy cannot deliver. The
  connection error says so.
- The address check reaches into private urllib3 API, so a rename upstream
  would remove it silently. `insights/tests/test_http.py` drives a request to
  the socket to catch that.

Also fixes a scheduling bug this channel made visible: `last_execution` was
written only after a delivery succeeded, so a failure left the alert due on
every four-minute tick.

Not included: delivery retries and a delivery log. A failure writes one Error
Log and waits for the next scheduled window.
