### PR TITLE
fix(ibis): a column named "count" collides with the synthetic count-of-rows pseudo-measure

### DIFF
--- a/insights/insights/doctype/insights_data_source_v3/ibis_utils.py
+++ b/insights/insights/doctype/insights_data_source_v3/ibis_utils.py
@@ -778,7 +778,19 @@ class IbisQueryBuilder:
         )
 
     def translate_measure(self, measure):
-        if measure.column_name == "count" and measure.aggregation == "count":
+        # The frontend's synthetic "Count of records" measure (query/helpers.ts
+        # `count()`) always sets this exact triple, including measure_name —
+        # column_name/aggregation alone aren't enough to identify it: a table
+        # with a real column literally named "count", aggregated with COUNT,
+        # produces the same column_name/aggregation pair. Without the
+        # measure_name check that real measure was silently replaced by a
+        # count of self.query.columns[0] — whichever column happens to be
+        # first in table order, unrelated to what the user selected.
+        if (
+            measure.column_name == "count"
+            and measure.aggregation == "count"
+            and measure.measure_name == "count_of_rows"
+        ):
             first_column = self.query.columns[0]
             first_column = getattr(self.query, first_column)
             return first_column.count().name(measure.measure_name)

--- a/insights/tests/test_ibis_utils.py
+++ b/insights/tests/test_ibis_utils.py
@@ -118,9 +118,9 @@ class TestIbisQueryBuilderCountMeasure(InsightsIntegrationTestCase):
                 "type": "code",
                 "code": """
 results = [
-    {"count": 5, "label": "alpha"},
-    {"count": None, "label": "beta"},
-    {"count": 7, "label": "gamma"},
+    {"label": "alpha", "count": 5},
+    {"label": "beta", "count": None},
+    {"label": "gamma", "count": 7},
 ]
 """,
             }
@@ -130,11 +130,16 @@ results = [
         return IbisQueryBuilder(self.make_query_doc(operations)).build()
 
     def test_counting_a_column_literally_named_count_counts_that_column(self):
-        # COUNT is non-null-count in SQL/ibis, so the middle row (count=None)
-        # is excluded: 2, not 3. Before the fix this returned 3 — every row —
-        # because it silently substituted whichever column is first in the
-        # table (here, "count" itself, coincidentally; on a table where a
-        # different column came first it would count that one instead).
+        # "count" is deliberately NOT the first column here. Before the fix,
+        # the collision substituted self.query.columns[0] regardless of which
+        # column the user actually picked — with "count" first, that
+        # substitution would coincidentally land on the right column anyway
+        # and this test would pass even with the bug still present. With
+        # "label" first, the old code counts "label" (3, all non-null) where
+        # the correct answer is 2 (the "count" column's own non-null count,
+        # since count is a non-null-count in SQL/ibis and the middle row is
+        # None), so this only passes once the fix actually reads the
+        # measure's own column rather than substituting the first one.
         query = self.build_query(
             [
                 *self.make_source_operations(),

--- a/insights/tests/test_ibis_utils.py
+++ b/insights/tests/test_ibis_utils.py
@@ -95,3 +95,106 @@ results = [
             self.build_query(operations)
 
         self.assertIn("Supported granularities: second, minute, hour", str(exc.exception))
+
+
+class TestIbisQueryBuilderCountMeasure(InsightsIntegrationTestCase):
+    """translate_measure() special-cases the synthetic "Count of records"
+    pseudo-measure (query/helpers.ts `count()`) by checking column_name ==
+    "count" and aggregation == "count" — both of which a real table column
+    literally named "count" also satisfies when a user counts it. See #963.
+    """
+
+    def make_query_doc(self, operations):
+        return frappe._dict(
+            name="Ibis Count Column Test",
+            title="Ibis Count Column Test",
+            use_live_connection=0,
+            operations=frappe.as_json(operations),
+        )
+
+    def make_source_operations(self):
+        return [
+            {
+                "type": "code",
+                "code": """
+results = [
+    {"count": 5, "label": "alpha"},
+    {"count": None, "label": "beta"},
+    {"count": 7, "label": "gamma"},
+]
+""",
+            }
+        ]
+
+    def build_query(self, operations):
+        return IbisQueryBuilder(self.make_query_doc(operations)).build()
+
+    def test_counting_a_column_literally_named_count_counts_that_column(self):
+        # COUNT is non-null-count in SQL/ibis, so the middle row (count=None)
+        # is excluded: 2, not 3. Before the fix this returned 3 — every row —
+        # because it silently substituted whichever column is first in the
+        # table (here, "count" itself, coincidentally; on a table where a
+        # different column came first it would count that one instead).
+        query = self.build_query(
+            [
+                *self.make_source_operations(),
+                {
+                    "type": "summarize",
+                    "measures": [
+                        # measure_name here is what getAutoMeasureName() in
+                        # MeasurePicker.vue produces for a real column-based
+                        # measure — `${aggregation}_of_${column_name}` — never
+                        # the synthetic pseudo-measure's fixed "count_of_rows".
+                        {
+                            "measure_name": "count_of_count",
+                            "column_name": "count",
+                            "aggregation": "count",
+                        }
+                    ],
+                    "dimensions": [],
+                },
+            ]
+        )
+
+        result = query.execute()
+        self.assertEqual(int(result["count_of_count"][0]), 2)
+
+    def test_the_actual_synthetic_count_of_rows_measure_still_counts_every_row(self):
+        # The real "Count of records" pseudo-measure from query/helpers.ts —
+        # column_name/aggregation/measure_name all fixed, regardless of
+        # whether the table happens to have a "count" column at all.
+        #
+        # Deliberately no nulls anywhere in this fixture: the synthetic
+        # measure implements "count every row" as `first_column.count()`,
+        # which is a non-null count of one arbitrary column, not COUNT(*) —
+        # a separate, pre-existing quirk of its own (undercounts if that
+        # column has nulls) that is not what #963 is about and not what
+        # this test is trying to isolate.
+        query = self.build_query(
+            [
+                {
+                    "type": "code",
+                    "code": """
+results = [
+    {"count": 5, "label": "alpha"},
+    {"count": 3, "label": "beta"},
+    {"count": 7, "label": "gamma"},
+]
+""",
+                },
+                {
+                    "type": "summarize",
+                    "measures": [
+                        {
+                            "measure_name": "count_of_rows",
+                            "column_name": "count",
+                            "aggregation": "count",
+                        }
+                    ],
+                    "dimensions": [],
+                },
+            ]
+        )
+
+        result = query.execute()
+        self.assertEqual(int(result["count_of_rows"][0]), 3)


### PR DESCRIPTION
## What's wrong

`translate_measure()` treats any measure with `column_name == "count"` and `aggregation == "count"` as the frontend's synthetic "Count of records" pseudo-measure (`query/helpers.ts` `count()`), and substitutes counting `self.query.columns[0]` — whichever column happens to be first in table order — instead of evaluating the measure normally:

```python
def translate_measure(self, measure):
    if measure.column_name == "count" and measure.aggregation == "count":
        first_column = self.query.columns[0]
        first_column = getattr(self.query, first_column)
        return first_column.count().name(measure.measure_name)
```

A real table column literally named `count`, aggregated with COUNT, satisfies that exact same two-field check. Its measure gets silently replaced by a count of an unrelated column. This is #963 ("Row named `count` triggers bug").

## Why the fix is a third field, not a rewrite

The frontend's synthetic measure sets a field the check doesn't look at. `query/helpers.ts`:

```ts
export const count = (): Measure => ({
  column_name: 'count',
  aggregation: 'count',
  measure_name: 'count_of_rows',
  ...
})
```

`measure_name: 'count_of_rows'` is a fixed literal — a GitHub code search for `count_of_rows` across this repo returns exactly this one definition. A real column-based measure never gets that name through normal use: `getAutoMeasureName()` in `MeasurePicker.vue` names it `` `${aggregation}_of_${column_name}` `` — `count_of_count` for this exact scenario. The only way a real measure collides is a user hand-typing `count_of_rows` as a custom label, which requires *also* already aggregating a column named `count` with COUNT — at which point the two values are frequently numerically close anyway (both are counts of the same column, one masquerading as the other).

```python
if (
    measure.column_name == "count"
    and measure.aggregation == "count"
    and measure.measure_name == "count_of_rows"
):
```

Checked `get_column()` (the path a real "count" measure now falls through to) isn't independently at risk from the same class of bug — it resolves columns via `self.query[column_name]`, not `getattr`, so it doesn't collide with `count` being a real method name on the underlying ibis `Table` object. That risk is real for the *synthetic* branch's own `getattr(self.query, first_column)` if the first column happens to share a name with an ibis Table method — but that's a separate, pre-existing quirk of the synthetic measure's own implementation, present regardless of this fix, and not what #963 is about.

## Verification

I don't have a Frappe bench, so — same as it's been for the other Python-side fixes I've sent this session — I'm being precise about what's actually run versus reasoned through.

**Run:** a standalone reproduction of just the branch decision (no ibis/DuckDB — the discriminator is pure field comparison):

```
case                                                                    before   after   expected
the real synthetic 'Count of records' measure — frontend's count() helper    True   True      True
a real table column named 'count', COUNTed, auto-named by the picker      True  False     False <- WRONG
same real column, user typed a custom label                               True  False     False <- WRONG

before: 2/3 misclassified
after:  0/3 misclassified
```

**Not run, but added and syntax-checked:** two integration tests in `test_ibis_utils.py`, following the file's existing `IbisQueryBuilder` + `"code"`-operation pattern exactly (same shape as `TestIbisQueryBuilderGranularity`). One seeds a table with a real `count` column (values `5, None, 7`) and asserts counting it returns `2` — the column's own non-null count — not `3`. Deliberately not reusing that fixture for the synthetic-measure test: `first_column.count()` is ibis's non-null count of one column, not `COUNT(*)`, so a null in the first column would make that test's expected value depend on a detail unrelated to what it's checking; that test uses an all-populated fixture instead so the two are provably the same number regardless.

Happy to adjust if CI surfaces anything I couldn't see without a running site.
