### PR TITLE
fix: stop the weekly cleanup from dropping tables it cannot rebuild

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -69,6 +69,11 @@ _Avoid_: warehouse (implementation file name only)
 **Table Import**:
 The sync job that copies a source table into the Data Store.
 
+**Unexplained Orphan**:
+A Data Store table the weekly cleanup cannot show to be rebuildable. The cleanup
+keeps it and raises an `Error Log`. See ADR-0003.
+_Avoid_: unknown table, stray table
+
 ### Framework integration
 
 **Island**:

--- a/docs/adr/0003-the-cleanup-deletes-only-what-it-can-rebuild.md
+++ b/docs/adr/0003-the-cleanup-deletes-only-what-it-can-rebuild.md
@@ -1,0 +1,90 @@
+# 3. The cleanup deletes only what it can rebuild
+
+Date: 2026-08-13
+
+## Status
+
+Accepted. Interim — see "Where this is going".
+
+## Context
+
+The weekly cleanup dropped any DuckDB table that no `Insights Table v3` row
+claimed with `stored = 1`. Two paths write tables and only `WarehouseTableImporter`
+set the flag. `WarehouseTableWriter`, which every `Insights Table Import Job`
+writes through, set nothing. A job's table was therefore an orphan by the
+cleanup's own definition.
+
+One production job had run daily since January and kept only the days since the
+last Sunday. Every import log said `Completed` (frappe/insights#1295). The
+record did not survive either: `frappe.logger()` writes to `logs/frappe.log`,
+which rotates.
+
+## Decision
+
+**A drop must be reversible. The sweep deletes nothing it cannot show to be
+rebuildable.** A table is dropped when one of these holds:
+
+- A doc says a source sync can re-import it. These are the tables
+  `prune_unused_tables` un-stored, read back from the docs so a run that died
+  mid-sweep still finishes next week.
+- A live or re-importable table replaced it. This covers the flat
+  `main."<source>.<table>"` copies left by the move to one schema per source.
+- It holds no rows.
+
+The sweep keeps everything else and reports it through `Error Log`. A row count
+that fails reads as "not empty".
+
+Two supporting choices:
+
+- **Import job tables are named in the expected set**, read from the source's
+  `schema` field and the job's `table_name` — the two values `TableWriter` hands
+  to DuckDB. This is scaffolding around a write path we intend to remove, not a
+  rule. It exists so a case we already understand raises no alarm.
+- **`Error Log`, not a new doctype.** It is durable, filterable and has
+  retention. The gap in #1295 was that the file log rotated.
+
+Rejected: teach `WarehouseTableWriter` to claim its table and add a
+`write_path_owner` field naming which writer maintains it. That fixes the writer
+that forgot, not the next one, and spends a schema change plus a backfill patch
+on a write path we intend to delete.
+
+## The same rule, one layer up
+
+`JobState.set` wrote the script's cursor to the job row inside the open
+transaction, and the next log line committed it. A failed DuckDB commit left the
+run marked `Failed` with the cursor past rows nothing wrote, so the next run
+skipped the day.
+
+`JobState` now buffers and `save()` runs after `_commit_table` returns. A run
+that writes no rows reports `Success (No Rows)` — a transient empty response and
+an empty day are indistinguishable from here.
+
+## Consequences
+
+**Some tables need a person.** A deleted data source leaves tables nobody
+claims. The sweep keeps and reports them every week until someone acts. The
+right fix is to drop a source's store copy when the source is deleted, at the
+moment of the act.
+
+**The alarm has to stay meaningful.** If unexplained orphans become routine, the
+`Error Log` becomes noise and this guard buys nothing. Anything that writes Data
+Store tables must claim them or be named the way import jobs are here.
+
+## Where this is going
+
+The durable fix is that no writer puts rows into the Data Store that exist
+nowhere else.
+
+An import job should write to a doctype, and the ordinary source sync should
+copy that into the store. The store returns to being a pure cache, every table
+becomes rebuildable, and this question disappears — no owner field, no exception
+list, no alarm. `Insights Table Import Job` is then a scheduled Server Script,
+which needs nothing from Insights.
+
+One question stays open, which is why this ADR is interim. A log-shaped doctype
+eventually gets a retention policy, and truncating it makes the store the only
+copy again. The answer is an immutable archive — closed, date-partitioned
+Parquet as the system of record, the store derived from it, and source retention
+driven by the archive's watermark rather than a calendar. That also fixes a
+measured problem: an open 41 GB `.duckdb` file cannot be backed up reliably,
+while a closed Parquet partition can. See frappe/insights#1256.

--- a/insights/insights/doctype/insights_data_source_v3/data_warehouse.py
+++ b/insights/insights/doctype/insights_data_source_v3/data_warehouse.py
@@ -785,12 +785,13 @@ def cleanup_data_store():
     # warehouse table has already been dropped.
     frappe.db.commit()  # nosemgrep
 
-    orphans = drop_orphan_warehouse_tables()
+    dropped, kept = drop_orphan_warehouse_tables()
     compacted = compact_warehouse()
 
     summary = {
         "tables_pruned": len(pruned),
-        "orphans_dropped": len(orphans),
+        "orphans_dropped": len(dropped),
+        "orphans_kept": len(kept),
         "size_before": compacted[0] if compacted else None,
         "size_after": compacted[1] if compacted else None,
     }
@@ -917,22 +918,22 @@ def get_first_import_per_table() -> dict[tuple[str, str], object]:
     return {(r.data_source, r.table_name): get_datetime(r.first_imported_on) for r in imports}
 
 
-def drop_orphan_warehouse_tables() -> list[str]:
+def drop_orphan_warehouse_tables() -> tuple[list[str], list[str]]:
     """Drop warehouse tables that no longer have a `stored` doc behind them.
 
-    Covers deleted data sources (their whole schema), deleted table docs,
-    tables just pruned, and legacy flat `source.table` tables left in `main`.
-    An orphan has no doc left to hold a bookmark or sync config, so the
-    "never touch incremental" rule does not apply to it.
+    A table is dropped only if the drop is reversible: a doc says a source sync
+    can re-import it, a live table replaced it, or it holds no rows. The sweep
+    keeps and reports anything else, because its rows may be the only copy.
+
+    Returns (dropped, kept).
     """
     logger = frappe.logger()
 
-    expected = {
-        (get_warehouse_schema_name(t.data_source), frappe.scrub(t.table))
-        for t in frappe.get_all("Insights Table v3", filters={"stored": 1}, fields=["data_source", "table"])
-    }
+    expected = get_stored_warehouse_tables() | get_import_job_warehouse_tables()
+    replaceable = expected | get_reimportable_warehouse_tables()
+    flat_prefixes = get_legacy_flat_prefixes()
 
-    dropped = []
+    dropped, kept, occupied = [], [], set()
     with insights.warehouse.get_write_connection(timeout=CLEANUP_LOCK_TIMEOUT) as db:
         tables = db.raw_sql(
             "select schema_name, table_name from duckdb_tables() where database_name = current_database()"
@@ -940,12 +941,24 @@ def drop_orphan_warehouse_tables() -> list[str]:
 
         for schema, table in tables:
             if (schema, table) in expected:
+                occupied.add(schema)
                 continue
+
+            successor = resolve_legacy_flat_table(schema, table, flat_prefixes)
+            if (schema, table) not in replaceable and successor not in replaceable:
+                # A count that fails reads as "not empty". The sweep deletes
+                # nothing it could not look inside first.
+                rows = count_table_rows(db, schema, table)
+                if rows != 0:
+                    kept.append(f"{schema}.{table}")
+                    occupied.add(schema)
+                    report_unexplained_orphan(schema, table, rows)
+                    continue
+
             db.raw_sql(f"DROP TABLE IF EXISTS {quote_identifier(schema)}.{quote_identifier(table)}")
             dropped.append(f"{schema}.{table}")
             logger.info(f"Data store cleanup: dropped '{schema}.{table}' (orphan: no matching doc)")
 
-        occupied = {schema for schema, table in tables if (schema, table) in expected}
         schemas = db.raw_sql(
             "select schema_name from duckdb_schemas() "
             "where database_name = current_database() and not internal"
@@ -958,7 +971,111 @@ def drop_orphan_warehouse_tables() -> list[str]:
                 db.raw_sql(f"DROP SCHEMA IF EXISTS {quote_identifier(schema)}")
                 logger.info(f"Data store cleanup: dropped empty schema '{schema}'")
 
-    return dropped
+    return dropped, kept
+
+
+def get_stored_warehouse_tables() -> set[tuple[str, str]]:
+    """Where the source sync says its live tables are."""
+    return {
+        (get_warehouse_schema_name(t.data_source), frappe.scrub(t.table))
+        for t in frappe.get_all("Insights Table v3", filters={"stored": 1}, fields=["data_source", "table"])
+    }
+
+
+def get_import_job_warehouse_tables() -> set[tuple[str, str]]:
+    """Where import jobs write, named the way they write it.
+
+    `WarehouseTableWriter` sets no `stored` flag, so a job's table reads as an
+    orphan. The pair comes from the data source's `schema` field and the job's
+    `table_name` because those are the two values `TableWriter` hands to DuckDB.
+    Disabled jobs count — their rows are still the only copy.
+    """
+    schemas = {
+        d.name: d.get("schema")
+        for d in frappe.get_all("Insights Data Source v3", fields=["name", "`schema`"])
+    }
+    return {
+        # "main" is `WarehouseTableWriter`'s own default for an unset schema.
+        (schemas.get(job.data_source) or "main", job.table_name)
+        for job in frappe.get_all("Insights Table Import Job", fields=["data_source", "table_name"])
+        if job.table_name
+    }
+
+
+def get_reimportable_warehouse_tables() -> set[tuple[str, str]]:
+    """Warehouse tables a source sync can rebuild, so dropping them loses nothing.
+
+    Read from the docs rather than from this run's prune, so a run that died
+    between the prune and the sweep does not leave a table nothing ever drops.
+    """
+    return {
+        (get_warehouse_schema_name(t.data_source), frappe.scrub(t.table))
+        for t in frappe.get_all(
+            "Insights Table v3",
+            filters={"stored": 0},
+            fields=["data_source", "table", "sync_mode"],
+        )
+        if t.sync_mode != "Incremental"
+    }
+
+
+def get_legacy_flat_prefixes() -> list[tuple[str, str]]:
+    """(name prefix, warehouse schema) per data source, longest prefix first.
+
+    A source name can itself contain dots, so a flat name has to be split
+    against the known sources rather than on its first dot.
+    """
+    prefixes = [
+        (f"{frappe.scrub(name)}.", get_warehouse_schema_name(name))
+        for name in frappe.get_all("Insights Data Source v3", pluck="name")
+    ]
+    return sorted(prefixes, key=lambda p: len(p[0]), reverse=True)
+
+
+def resolve_legacy_flat_table(schema: str, table: str, prefixes) -> tuple[str, str] | None:
+    """Map a flat `main."<source>.<table>"` name to the table that replaced it.
+
+    Tables lived in `main` under a dotted name before the move to one schema
+    per data source. The rename left the old copies behind. A flat table is
+    safe to drop once its successor is accounted for.
+    """
+    if schema != "main":
+        return None
+
+    for prefix, source_schema in prefixes:
+        if table.startswith(prefix):
+            return (source_schema, frappe.scrub(table[len(prefix) :]))
+
+    return None
+
+
+def count_table_rows(db: DuckDBBackend, schema: str, table: str) -> int | None:
+    """Rows in a warehouse table, or None if the count itself failed."""
+    try:
+        query = f"select count(*) from {quote_identifier(schema)}.{quote_identifier(table)}"
+        return int(db.raw_sql(query).fetchone()[0])
+    except Exception:
+        frappe.logger().exception(f"Data store cleanup: could not count rows in '{schema}.{table}'")
+        return None
+
+
+def report_unexplained_orphan(schema: str, table: str, rows: int | None) -> None:
+    """Report a table the sweep refused to drop.
+
+    An `Error Log` outlives `logs/frappe.log`, which rotated before anyone
+    could ask what happened to seven months of imports.
+    """
+    held = f"{rows} rows" if rows is not None else "an unknown number of rows (the count failed)"
+    frappe.logger().error(f"Data store cleanup: kept '{schema}.{table}' (unexplained orphan, {held})")
+    frappe.log_error(
+        title="Data store cleanup kept an unexplained table",
+        message=(
+            f"'{schema}.{table}' holds {held}. Nothing claims it with `stored = 1`, so the "
+            "cleanup cannot tell whether a re-import would bring it back.\n\n"
+            "The table was left in place. Either claim it from the writer that maintains it, "
+            "or drop it by hand once you know what it holds."
+        ),
+    )
 
 
 def compact_warehouse() -> tuple[int, int] | None:

--- a/insights/insights/doctype/insights_table_import_job/insights_table_import_job.py
+++ b/insights/insights/doctype/insights_table_import_job/insights_table_import_job.py
@@ -139,12 +139,15 @@ class TableImportJobRun:
         self.rows_written = 0
         self.last_log_time = None
         self._table_writer: TableWriter | None = None
+        self.job_state: JobState | None = None
 
     def execute(self):
         try:
             self._prepare_execution()
             self._run_script()
             self._commit_table()
+            # The cursor moves only after the rows it points past are stored.
+            self.job_state.save()
             self._mark_success()
         except Exception as e:
             self._rollback_table()
@@ -172,6 +175,7 @@ class TableImportJobRun:
 
         # Create the table writer for writing data
         self._table_writer = TableWriter(self)
+        self.job_state = JobState(self.job)
 
         self._log("Execution started")
 
@@ -192,7 +196,7 @@ class TableImportJobRun:
         _globals = {
             "client": self.data_source.get_api_client(),
             "table": table_interface,
-            "state": JobState(self.job),
+            "state": self.job_state,
             "secrets": JobSecrets(self.job),
             "log": self._log,
             "pandas": frappe._dict(
@@ -251,7 +255,8 @@ class TableImportJobRun:
         self.job.db_set(
             {
                 "last_run": now(),
-                "last_status": "Success",
+                # An empty response and an empty day look the same from here.
+                "last_status": "Success" if self.rows_written else "Success (No Rows)",
                 "last_log": self.log.name,
             },
             commit=True,
@@ -422,6 +427,13 @@ class TableWriter:
 
 
 class JobState:
+    """What the script carries between runs — usually the cursor its next run starts from.
+
+    Buffered in memory, written by `save()` on the success path only. A `db_set`
+    here lands inside the open transaction and the next log line commits it, so
+    a failed DuckDB commit used to leave the cursor past rows nothing wrote.
+    """
+
     def __init__(self, job: InsightsTableImportJob):
         self._job = job
         self._state = self._load_state()
@@ -434,7 +446,7 @@ class JobState:
             frappe.log_error(title=f"Invalid state JSON for job {self._job.name}")
             return {}
 
-    def _save_state(self):
+    def save(self):
         self._job.db_set("state", dump(self._state))
 
     def get(self, key: str, default=None):
@@ -442,16 +454,12 @@ class JobState:
 
     def set(self, key: str, value):
         self._state[key] = value
-        self._save_state()
 
     def delete(self, key: str):
-        if key in self._state:
-            del self._state[key]
-            self._save_state()
+        self._state.pop(key, None)
 
     def clear(self):
         self._state = {}
-        self._save_state()
 
 
 class JobSecrets:

--- a/insights/tests/test_data_store_cleanup.py
+++ b/insights/tests/test_data_store_cleanup.py
@@ -50,6 +50,23 @@ class TestDataStoreCleanup(InsightsIntegrationTestCase):
         doc.insert(ignore_permissions=True)
         return doc
 
+    def create_import_job(self, table_name):
+        if frappe.db.exists("Insights Table Import Job", table_name):
+            frappe.delete_doc("Insights Table Import Job", table_name, force=True)
+
+        doc = frappe.get_doc(
+            {
+                "doctype": "Insights Table Import Job",
+                "title": table_name,
+                "data_source": DATA_SOURCE,
+                "table_name": table_name,
+                "script": "pass",
+            }
+        )
+        doc.flags.ignore_links = True
+        doc.insert(ignore_permissions=True)
+        return doc
+
     def log_execution(self, query, days_ago):
         log = frappe.get_doc({"doctype": "Insights Query Execution Log", "query": query, "sql": "select 1"})
         log.flags.ignore_links = True
@@ -206,28 +223,135 @@ class TestDataStoreCleanup(InsightsIntegrationTestCase):
             ).fetchall()
         )
 
-    def test_orphan_sweep_keeps_stored_tables_and_drops_the_rest(self):
+    def test_orphan_sweep_keeps_stored_tables_and_drops_empty_orphans(self):
         self.create_table("tabCleanupKept")
         schema = data_warehouse.get_warehouse_schema_name(DATA_SOURCE)
 
         with self.warehouse_file() as (db, _):
             db.raw_sql(f'create schema "{schema}"')
             db.raw_sql(f'create table "{schema}".tabcleanupkept as select 1 as a')
-            db.raw_sql(f'create table "{schema}".tabcleanupdeleted as select 1 as a')
+            db.raw_sql(f'create table "{schema}".tabcleanupdeleted as select 1 as a where false')
             db.raw_sql('create schema "gone_data_source"')
-            db.raw_sql('create table "gone_data_source".t as select 1 as a')
-            db.raw_sql("create table main.site_db_tabcleanuplegacy as select 1 as a")
+            db.raw_sql('create table "gone_data_source".t as select 1 as a where false')
+            db.raw_sql("create table main.site_db_tabcleanuplegacy as select 1 as a where false")
 
             with self.patched_write_connection(db):
-                dropped = drop_orphan_warehouse_tables()
+                dropped, kept = drop_orphan_warehouse_tables()
 
             self.assertEqual(self.warehouse_tables(db), {(schema, "tabcleanupkept")})
             self.assertIn(f"{schema}.tabcleanupdeleted", dropped)
             self.assertIn("gone_data_source.t", dropped)
             self.assertIn("main.site_db_tabcleanuplegacy", dropped)
+            self.assertEqual(kept, [])
 
             schemas = {row[0] for row in db.raw_sql("select schema_name from duckdb_schemas()").fetchall()}
             self.assertNotIn("gone_data_source", schemas)
+
+    def test_orphan_sweep_keeps_an_unexplained_table_holding_rows(self):
+        """The bug behind frappe/insights#1295: a writer that never set `stored`."""
+        schema = data_warehouse.get_warehouse_schema_name(DATA_SOURCE)
+
+        with self.warehouse_file() as (db, _):
+            db.raw_sql(f'create schema "{schema}"')
+            db.raw_sql(f'create table "{schema}".tabcleanuporphan as select 1 as a')
+
+            with self.patched_write_connection(db):
+                dropped, kept = drop_orphan_warehouse_tables()
+
+            self.assertEqual(dropped, [])
+            self.assertEqual(kept, [f"{schema}.tabcleanuporphan"])
+            self.assertIn((schema, "tabcleanuporphan"), self.warehouse_tables(db))
+
+        self.assertTrue(
+            frappe.db.exists("Error Log", {"method": "Data store cleanup kept an unexplained table"}),
+            "a table the sweep refuses to drop must leave a record that outlives the file log",
+        )
+
+    def test_orphan_sweep_drops_a_pruned_table_holding_rows(self):
+        """A pruned table is not unexplained: its doc says a re-import rebuilds it."""
+        self.create_table("tabCleanupPruned", stored=0)
+        schema = data_warehouse.get_warehouse_schema_name(DATA_SOURCE)
+
+        with self.warehouse_file() as (db, _):
+            db.raw_sql(f'create schema "{schema}"')
+            db.raw_sql(f'create table "{schema}".tabcleanuppruned as select 1 as a')
+
+            with self.patched_write_connection(db):
+                dropped, kept = drop_orphan_warehouse_tables()
+
+            self.assertEqual(dropped, [f"{schema}.tabcleanuppruned"])
+            self.assertEqual(kept, [])
+
+    def test_orphan_sweep_keeps_a_pruned_incremental_table_holding_rows(self):
+        """An incremental re-import restarts from `sync_from`, so it rebuilds nothing."""
+        self.create_table("tabCleanupPrunedInc", stored=0, sync_mode="Incremental")
+        schema = data_warehouse.get_warehouse_schema_name(DATA_SOURCE)
+
+        with self.warehouse_file() as (db, _):
+            db.raw_sql(f'create schema "{schema}"')
+            db.raw_sql(f'create table "{schema}".tabcleanupprunedinc as select 1 as a')
+
+            with self.patched_write_connection(db):
+                dropped, kept = drop_orphan_warehouse_tables()
+
+            self.assertEqual(dropped, [])
+            self.assertEqual(kept, [f"{schema}.tabcleanupprunedinc"])
+
+    def test_orphan_sweep_drops_a_legacy_flat_table_its_successor_replaced(self):
+        """`main."site_db.tabX"` is the pre-rename copy of `site_db.tabx`."""
+        self.create_table("tabCleanupFlat")
+        schema = data_warehouse.get_warehouse_schema_name(DATA_SOURCE)
+
+        with self.warehouse_file() as (db, _):
+            db.raw_sql(f'create schema "{schema}"')
+            db.raw_sql(f'create table "{schema}".tabcleanupflat as select 1 as a')
+            db.raw_sql(f'create table main."{schema}.tabCleanupFlat" as select 1 as a')
+
+            with self.patched_write_connection(db):
+                dropped, kept = drop_orphan_warehouse_tables()
+
+            self.assertEqual(dropped, [f"main.{schema}.tabCleanupFlat"])
+            self.assertEqual(kept, [])
+
+    def test_orphan_sweep_keeps_a_legacy_flat_table_with_no_successor(self):
+        """Nothing replaced it, so its rows may be the only copy."""
+        schema = data_warehouse.get_warehouse_schema_name(DATA_SOURCE)
+
+        with self.warehouse_file() as (db, _):
+            db.raw_sql(f'create table main."{schema}.tabCleanupLost" as select 1 as a')
+
+            with self.patched_write_connection(db):
+                dropped, kept = drop_orphan_warehouse_tables()
+
+            self.assertEqual(dropped, [])
+            self.assertEqual(kept, [f"main.{schema}.tabCleanupLost"])
+
+    def test_orphan_sweep_keeps_a_flat_table_it_cannot_attribute(self):
+        """No data source claims this prefix, so the split cannot name a successor."""
+        with self.warehouse_file() as (db, _):
+            db.raw_sql('create table main."tabCleanupUnowned" as select 1 as a')
+
+            with self.patched_write_connection(db):
+                dropped, kept = drop_orphan_warehouse_tables()
+
+            self.assertEqual(dropped, [])
+            self.assertEqual(kept, ["main.tabCleanupUnowned"])
+
+    def test_orphan_sweep_keeps_the_table_an_import_job_writes(self):
+        # A job writes to the source's `schema` field, not to the derived name.
+        frappe.db.set_value("Insights Data Source v3", DATA_SOURCE, "schema", "job_schema")
+        self.create_import_job("cleanup_job_table")
+
+        with self.warehouse_file() as (db, _):
+            db.raw_sql('create schema "job_schema"')
+            db.raw_sql('create table "job_schema".cleanup_job_table as select 1 as a')
+
+            with self.patched_write_connection(db):
+                dropped, kept = drop_orphan_warehouse_tables()
+
+            self.assertEqual(dropped, [])
+            self.assertEqual(kept, [], "a known import job table is explained, so it raises no alarm")
+            self.assertIn(("job_schema", "cleanup_job_table"), self.warehouse_tables(db))
 
     # compaction
 

--- a/insights/tests/test_import_job.py
+++ b/insights/tests/test_import_job.py
@@ -1,0 +1,64 @@
+import json
+
+import frappe
+
+from insights.insights.doctype.insights_table_import_job.insights_table_import_job import JobState
+from insights.tests.base import InsightsIntegrationTestCase
+
+DATA_SOURCE = "Site DB"
+
+
+class TestJobState(InsightsIntegrationTestCase):
+    """The cursor must describe what is in the data store, not what a run intended."""
+
+    def before_test(self):
+        self.job = self.create_job("state_test_table")
+
+    def create_job(self, table_name):
+        if frappe.db.exists("Insights Table Import Job", table_name):
+            frappe.delete_doc("Insights Table Import Job", table_name, force=True)
+
+        doc = frappe.get_doc(
+            {
+                "doctype": "Insights Table Import Job",
+                "title": table_name,
+                "data_source": DATA_SOURCE,
+                "table_name": table_name,
+                "script": "pass",
+                "state": json.dumps({"cursor": "2026-01-01"}),
+            }
+        )
+        doc.flags.ignore_links = True
+        doc.insert(ignore_permissions=True)
+        return doc
+
+    def stored_state(self):
+        return json.loads(frappe.db.get_value("Insights Table Import Job", self.job.name, "state") or "{}")
+
+    def test_setting_state_does_not_touch_the_job_row(self):
+        state = JobState(self.job)
+        state.set("cursor", "2026-08-13")
+
+        self.assertEqual(state.get("cursor"), "2026-08-13")
+        self.assertEqual(
+            self.stored_state()["cursor"],
+            "2026-01-01",
+            "a run that fails after this point must start again from the old cursor",
+        )
+
+    def test_saving_state_writes_the_job_row(self):
+        state = JobState(self.job)
+        state.set("cursor", "2026-08-13")
+        state.save()
+
+        self.assertEqual(self.stored_state()["cursor"], "2026-08-13")
+
+    def test_clear_and_delete_are_also_deferred(self):
+        state = JobState(self.job)
+        state.delete("cursor")
+        state.clear()
+
+        self.assertEqual(self.stored_state()["cursor"], "2026-01-01")
+
+        state.save()
+        self.assertEqual(self.stored_state(), {})


### PR DESCRIPTION
Fixes #1295.

The cleanup dropped any warehouse table no `Insights Table v3` row claimed with `stored = 1`. `WarehouseTableWriter` never set that flag, so every table an import job wrote was an orphan.

A drop must now be reversible. The sweep drops a table when:

- a doc says a source sync can re-import it,
- a live table replaced it (the flat `main."<source>.<table>"` copies), or
- it holds no rows.

It keeps everything else and reports it through `Error Log`. A row count that fails reads as "not empty".

The second commit fixes a related hole found on production: an import job advanced its cursor inside the open transaction, so a failed DuckDB commit left the cursor past rows nothing wrote.

Checked on `insights.localhost`: both live import job tables are kept, the 8 legacy flat tables resolve to their successors and are dropped, and one table (`main.tabVersion`) has no source prefix and raises the alarm.

Reasoning is in `docs/adr/0003-the-cleanup-deletes-only-what-it-can-rebuild.md`, including why the durable fix is that no writer puts rows into the Data Store that exist nowhere else.