### PR TITLE
fix(a11y): add alt text to images missing it

### DIFF
--- a/frontend/src2/auth/LoginBox.vue
+++ b/frontend/src2/auth/LoginBox.vue
@@ -2,7 +2,7 @@
 	<div class="h-full w-full pt-4 sm:pt-16">
 		<div class="relative">
 			<div class="flex">
-				<img src="../assets/insights-logo-new.svg" class="mx-auto h-12" />
+				<img src="../assets/insights-logo-new.svg" alt="Frappe Insights" class="mx-auto h-12" />
 			</div>
 			<div
 				class="mx-auto bg-surface-base px-4 py-8 sm:mt-6 sm:w-96 sm:rounded-lg sm:px-8 sm:shadow-xl"

--- a/frontend/src2/dashboard/DashboardCard.vue
+++ b/frontend/src2/dashboard/DashboardCard.vue
@@ -27,6 +27,7 @@ const emit = defineEmits<{
 			<img
 				v-if="dashboard.preview_image"
 				:src="dashboard.preview_image"
+				:alt="`Preview of ${dashboard.title}`"
 				loading="lazy"
 				decoding="async"
 				onerror="this.src = ''"


### PR DESCRIPTION
## Problem

Two images in the shipped frontend (`frontend/src2` — `/src2/main.ts` is the live Vite entry point) had no `alt` attribute.

## Fix

- `auth/LoginBox.vue`: the app logo has no adjacent text — gets a real, descriptive alt.
- `dashboard/DashboardCard.vue`: the dashboard preview thumbnail gets an alt naming the dashboard, matching the convention this same repo already uses for template previews (`workbook/WorkbookTemplates.vue`'s `:alt="template.title"`).

The legacy `frontend/src` tree (superseded by `src2`, unbuilt since 2023 — its entry script is commented out in `index.html`) has similar images but wasn't touched here since it isn't shipped.
