### PR TITLE
fix(rtl): use logical spacing/text-align classes instead of physical ones

### DIFF
--- a/frontend/src2/charts/components/ChartQuerySelector.vue
+++ b/frontend/src2/charts/components/ChartQuerySelector.vue
@@ -34,7 +34,7 @@ wheneverChanges(
 			@update:modelValue="query = $event"
 		>
 			<template #prefix>
-				<Table2 class="mr-1.5 h-4 w-4 text-ink-gray-6" stroke-width="1.5" />
+				<Table2 class="me-1.5 h-4 w-4 text-ink-gray-6" stroke-width="1.5" />
 			</template>
 		</Combobox>
 	</InlineFormControlLabel>

--- a/frontend/src2/charts/components/DimensionPicker.vue
+++ b/frontend/src2/charts/components/DimensionPicker.vue
@@ -82,7 +82,7 @@ function selectDimension(option?: DimensionOption) {
 							</span>
 							<template #suffix>
 								<ChevronDown
-									class="ml-auto h-4 w-4 text-ink-gray-6"
+									class="ms-auto h-4 w-4 text-ink-gray-6"
 									stroke-width="1.5"
 								/>
 							</template>

--- a/frontend/src2/charts/components/FunnelChartConfigForm.vue
+++ b/frontend/src2/charts/components/FunnelChartConfigForm.vue
@@ -75,7 +75,7 @@ const discrete_dimensions = computed(() =>
 						</template>
 					</DraggableList>
 					<button
-						class="mt-1.5 text-left text-xs text-ink-gray-5 hover:underline"
+						class="mt-1.5 text-start text-xs text-ink-gray-5 hover:underline"
 						@click="addStage"
 					>
 						+ Add stage

--- a/frontend/src2/charts/components/NumberChartConfigForm.vue
+++ b/frontend/src2/charts/components/NumberChartConfigForm.vue
@@ -130,7 +130,7 @@ function setNumberOption(index: number, option: keyof NumberColumnOptions, value
 						</template>
 					</DraggableList>
 					<button
-						class="mt-1.5 text-left text-xs text-ink-gray-5 hover:underline"
+						class="mt-1.5 text-start text-xs text-ink-gray-5 hover:underline"
 						@click="config.number_columns.push({} as any)"
 					>
 						+ Add column

--- a/frontend/src2/charts/components/TableChartConfigForm.vue
+++ b/frontend/src2/charts/components/TableChartConfigForm.vue
@@ -206,7 +206,7 @@ function updateTextWrap(column_name: string, wrap: boolean | undefined) {
 				</template>
 			</DraggableList>
 			<button
-				class="mt-1.5 text-left text-xs text-ink-gray-5 hover:underline"
+				class="mt-1.5 text-start text-xs text-ink-gray-5 hover:underline"
 				@click="config.rows.push({} as any)"
 			>
 				+ Add column
@@ -228,7 +228,7 @@ function updateTextWrap(column_name: string, wrap: boolean | undefined) {
 					</template>
 				</DraggableList>
 				<button
-					class="mt-1.5 text-left text-xs text-ink-gray-5 hover:underline"
+					class="mt-1.5 text-start text-xs text-ink-gray-5 hover:underline"
 					@click="config.columns.push({} as any)"
 				>
 					+ Add column
@@ -265,7 +265,7 @@ function updateTextWrap(column_name: string, wrap: boolean | undefined) {
 					</template>
 				</DraggableList>
 				<button
-					class="mt-1.5 text-left text-xs text-ink-gray-5 hover:underline"
+					class="mt-1.5 text-start text-xs text-ink-gray-5 hover:underline"
 					@click="config.values.push({} as any)"
 				>
 					+ Add column

--- a/frontend/src2/charts/components/YAxisConfig.vue
+++ b/frontend/src2/charts/components/YAxisConfig.vue
@@ -100,7 +100,7 @@ function removeReferenceLine(index: number) {
 						</template>
 					</DraggableList>
 					<button
-						class="mt-1.5 text-left text-xs text-ink-gray-5 hover:underline"
+						class="mt-1.5 text-start text-xs text-ink-gray-5 hover:underline"
 						@click="addSeries"
 					>
 						+ Add series
@@ -201,7 +201,7 @@ function removeReferenceLine(index: number) {
 					</div>
 				</div>
 				<button
-					class="mt-1.5 text-left text-xs text-ink-gray-5 hover:underline"
+					class="mt-1.5 text-start text-xs text-ink-gray-5 hover:underline"
 					@click="addReferenceLine"
 				>
 					+ Add reference line

--- a/frontend/src2/components/Checkbox.vue
+++ b/frontend/src2/components/Checkbox.vue
@@ -1,7 +1,7 @@
 <template>
 	<SwitchGroup v-bind="$attrs">
 		<div class="flex items-center justify-between text-sm">
-			<SwitchLabel v-if="$props.label" class="mr-4 select-none text-xs text-ink-gray-5">
+			<SwitchLabel v-if="$props.label" class="me-4 select-none text-xs text-ink-gray-5">
 				{{ $props.label }}
 			</SwitchLabel>
 			<Switch

--- a/frontend/src2/components/ColorInput.vue
+++ b/frontend/src2/components/ColorInput.vue
@@ -17,7 +17,7 @@
 					type="text"
 					class="dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300 dark:focus:bg-zinc-700 w-full rounded-md text-sm text-gray-700"
 					placeholder="Select Color"
-					inputClass="pl-8 pr-6"
+					inputClass="ps-8 pe-6"
 					:modelValue="value"
 					@update:modelValue="handleColorChange"
 				></Input>

--- a/frontend/src2/components/DataTable.vue
+++ b/frontend/src2/components/DataTable.vue
@@ -570,8 +570,8 @@ function toggleNewColumn() {
 							class="h-8 border-b border-r"
 							:class="[
 								header.isLast && isNumberColumn(header.column.name)
-									? 'text-right'
-									: 'text-left',
+									? 'text-end'
+									: 'text-start',
 								isStickyColumn(header.column.name)
 									? 'sticky bg-surface-gray-1'
 									: '',
@@ -633,10 +633,10 @@ function toggleNewColumn() {
 
 						<td
 							v-if="props.showRowTotals"
-							class="h-8 border-b border-r px-3 text-right"
+							class="h-8 border-b border-r px-3 text-end"
 							width="1px"
 						>
-							<div class="truncate pl-3 pr-20"></div>
+							<div class="truncate ps-3 pe-20"></div>
 						</td>
 					</tr>
 
@@ -675,10 +675,10 @@ function toggleNewColumn() {
 						</td>
 						<td
 							v-if="props.showRowTotals"
-							class="border-b border-r px-3 text-right"
+							class="border-b border-r px-3 text-end"
 							width="1px"
 						>
-							<div class="truncate pl-3 pr-20"></div>
+							<div class="truncate ps-3 pe-20"></div>
 						</td>
 					</tr>
 				</thead>
@@ -695,7 +695,7 @@ function toggleNewColumn() {
 						:key="idx"
 					>
 						<td
-							class="tnum sticky left-0 h-8 whitespace-nowrap border-b border-r bg-surface-base px-3 text-right text-xs"
+							class="tnum sticky left-0 h-8 whitespace-nowrap border-b border-r bg-surface-base px-3 text-end text-xs"
 							width="1px"
 							height="30px"
 						>
@@ -707,7 +707,7 @@ function toggleNewColumn() {
 							class="h-8 border-b border-r px-3 text-ink-gray-7 leading-5 py-1.5"
 							:class="[
 								getTextWrapClass(col.name),
-								isNumberColumn(col.name) ? 'tnum text-right' : 'text-left',
+								isNumberColumn(col.name) ? 'tnum text-end' : 'text-start',
 								props.enableColorScale && isNumberColumn(col.name)
 									? colorByValues[row[col.name]]
 									: '',
@@ -742,7 +742,7 @@ function toggleNewColumn() {
 
 						<td
 							v-if="props.showRowTotals && totalPerRow"
-							class="tnum h-8 border-b border-r px-3 text-right font-bold"
+							class="tnum h-8 border-b border-r px-3 text-end font-bold"
 						>
 							{{ _formatNumber(totalPerRow[idx]) }}
 						</td>
@@ -757,7 +757,7 @@ function toggleNewColumn() {
 							v-for="col in props.columns"
 							class="h-8 truncate border-r border-t px-3 font-bold text-ink-gray-7"
 							:class="[
-								isNumberColumn(col.name) ? 'tnum text-right' : 'text-left',
+								isNumberColumn(col.name) ? 'tnum text-end' : 'text-start',
 								isStickyColumn(col.name) ? 'sticky bg-surface-base' : '',
 							]"
 							:style="{
@@ -774,7 +774,7 @@ function toggleNewColumn() {
 
 						<td
 							v-if="props.showRowTotals && totalColumnTotal"
-							class="tnum h-8 border-r border-t px-3 text-right font-bold"
+							class="tnum h-8 border-r border-t px-3 text-end font-bold"
 						>
 							{{ _formatNumber(totalColumnTotal) }}
 						</td>

--- a/frontend/src2/components/DataTableColumn.vue
+++ b/frontend/src2/components/DataTableColumn.vue
@@ -40,7 +40,7 @@ const sortOptions = [
 		<ContentEditable
 			v-model="_label"
 			:placeholder="__('Column')"
-			class="flex h-6 items-center whitespace-nowrap rounded-sm px-0.5 text-sm-medium first:ml-2 focus:ring-1 focus:ring-outline-gray-6 focus:ring-offset-1"
+			class="flex h-6 items-center whitespace-nowrap rounded-sm px-0.5 text-sm-medium first:ms-2 focus:ring-1 focus:ring-outline-gray-6 focus:ring-offset-1"
 			:disabled="!props.onRename"
 			@returned="props.onRename?.(_label)"
 			@blur="props.onRename?.(_label)"

--- a/frontend/src2/components/SidebarLink.vue
+++ b/frontend/src2/components/SidebarLink.vue
@@ -27,8 +27,8 @@
 				class="flex-1 flex-shrink-0 text-base duration-300 ease-in-out"
 				:class="
 					isCollapsed
-						? 'ml-0 w-0 overflow-hidden opacity-0'
-						: 'ml-2 w-auto truncate opacity-100'
+						? 'ms-0 w-0 overflow-hidden opacity-0'
+						: 'ms-2 w-auto truncate opacity-100'
 				"
 			>
 				{{ label }}

--- a/frontend/src2/components/Toast.vue
+++ b/frontend/src2/components/Toast.vue
@@ -2,7 +2,7 @@
 	<div class="m-2 flex transition duration-200 ease-out">
 		<div :class="['w-[22rem] rounded bg-surface-base p-3 shadow-md', variantClasses]">
 			<div class="flex items-start">
-				<div v-if="iconComponent" class="mr-2 pt-1">
+				<div v-if="iconComponent" class="me-2 pt-1">
 					<component
 						:is="iconComponent"
 						:class="['h-4 w-4 rounded-full', variantIconClasses, iconClasses]"
@@ -19,7 +19,7 @@
 						</p>
 					</slot>
 				</div>
-				<div class="ml-auto pl-2">
+				<div class="ms-auto ps-2">
 					<slot name="actions" />
 				</div>
 			</div>

--- a/frontend/src2/components/UserDropdown.vue
+++ b/frontend/src2/components/UserDropdown.vue
@@ -18,11 +18,11 @@
 						class="h-8 w-8 flex-shrink-0 rounded"
 					/>
 					<div
-						class="flex flex-1 flex-col text-left duration-300 ease-in-out"
+						class="flex flex-1 flex-col text-start duration-300 ease-in-out"
 						:class="
 							props.isCollapsed
-								? 'ml-0 w-0 overflow-hidden opacity-0'
-								: 'ml-2 w-auto opacity-100'
+								? 'ms-0 w-0 overflow-hidden opacity-0'
+								: 'ms-2 w-auto opacity-100'
 						"
 					>
 						<div class="text-base-medium leading-none text-ink-gray-8">Insights</div>
@@ -38,8 +38,8 @@
 						class="duration-300 ease-in-out"
 						:class="
 							props.isCollapsed
-								? 'ml-0 w-0 overflow-hidden opacity-0'
-								: 'ml-2 w-auto opacity-100'
+								? 'ms-0 w-0 overflow-hidden opacity-0'
+								: 'ms-2 w-auto opacity-100'
 						"
 					>
 						<ChevronDown class="h-4 w-4 text-ink-gray-5" aria-hidden="true" />

--- a/frontend/src2/dashboard/Dashboard.vue
+++ b/frontend/src2/dashboard/Dashboard.vue
@@ -40,7 +40,7 @@ const verticalCompact = useStorage('dashboard_vertical_compact', true)
 </script>
 
 <template>
-	<header class="flex h-12 items-center justify-between border-b py-2.5 pl-5 pr-2">
+	<header class="flex h-12 items-center justify-between border-b py-2.5 ps-5 pe-2">
 		<Breadcrumbs
 			:items="[
 				{ label: __('Dashboards'), route: '/dashboards' },

--- a/frontend/src2/dashboard/DashboardFilterEditor.vue
+++ b/frontend/src2/dashboard/DashboardFilterEditor.vue
@@ -214,7 +214,7 @@ function saveEdit() {
 									<p class="flex-1 truncate text-base">{{ link.title }}</p>
 									<div
 										v-if="enabledLinks.includes(link.name)"
-										class="ml-auto flex-shrink-0"
+										class="ms-auto flex-shrink-0"
 									>
 										<Combobox
 											class="min-w-[10rem]"

--- a/frontend/src2/dashboard/DashboardList.vue
+++ b/frontend/src2/dashboard/DashboardList.vue
@@ -135,7 +135,7 @@ watchEffect(() => {
 </script>
 
 <template>
-	<header class="flex h-12 items-center justify-between border-b py-2.5 pl-5 pr-2">
+	<header class="flex h-12 items-center justify-between border-b py-2.5 ps-5 pe-2">
 		<Breadcrumbs :items="[{ label: __('Dashboards'), route: '/dashboards' }]" />
 	</header>
 

--- a/frontend/src2/data_source/DataSourceList.vue
+++ b/frontend/src2/data_source/DataSourceList.vue
@@ -143,7 +143,7 @@ document.title = __('Data Sources | Insights')
 </script>
 
 <template>
-	<header class="flex h-12 items-center justify-between border-b py-2.5 pl-5 pr-2">
+	<header class="flex h-12 items-center justify-between border-b py-2.5 ps-5 pe-2">
 		<Breadcrumbs :items="[{ label: __('Data Sources'), route: '/data-source' }]" />
 		<div class="flex items-center gap-2">
 			<Button

--- a/frontend/src2/data_source/DataSourceTable.vue
+++ b/frontend/src2/data_source/DataSourceTable.vue
@@ -19,7 +19,7 @@ watchEffect(() => {
 </script>
 
 <template>
-	<header class="flex h-12 items-center justify-between border-b py-2.5 pl-5 pr-2">
+	<header class="flex h-12 items-center justify-between border-b py-2.5 ps-5 pe-2">
 		<Breadcrumbs
 			:items="[
 				{ label: __('Data Sources'), route: '/data-source' },

--- a/frontend/src2/data_source/DataSourceTableList.vue
+++ b/frontend/src2/data_source/DataSourceTableList.vue
@@ -59,7 +59,7 @@ watchEffect(() => {
 </script>
 
 <template>
-	<header class="flex h-12 items-center justify-between border-b py-2.5 pl-5 pr-2">
+	<header class="flex h-12 items-center justify-between border-b py-2.5 ps-5 pe-2">
 		<Breadcrumbs
 			:items="[
 				{ label: __('Data Sources'), route: '/data-source' },

--- a/frontend/src2/data_source/UploadCSVFileDialog.vue
+++ b/frontend/src2/data_source/UploadCSVFileDialog.vue
@@ -155,7 +155,7 @@ function resetFile() {
 				</div>
 			</div>
 			<div class="mt-4 flex justify-between pt-2">
-				<div class="ml-auto flex items-center space-x-2">
+				<div class="ms-auto flex items-center space-x-2">
 					<Button :disabled="!fileUploaded" @click="resetFile"> Reset File </Button>
 					<Button
 						variant="solid"

--- a/frontend/src2/data_store/DataStoreList.vue
+++ b/frontend/src2/data_store/DataStoreList.vue
@@ -71,7 +71,7 @@ const listOptions = computed(() => ({
 </script>
 
 <template>
-	<header class="flex h-12 items-center justify-between border-b py-2.5 pl-5 pr-2">
+	<header class="flex h-12 items-center justify-between border-b py-2.5 ps-5 pe-2">
 		<Breadcrumbs :items="[{ label: __('Data Store'), route: '/data-store' }]" />
 		<div class="flex items-center gap-2">
 			<Button

--- a/frontend/src2/home/HomeWorkbookList.vue
+++ b/frontend/src2/home/HomeWorkbookList.vue
@@ -52,7 +52,7 @@ watch(searchQuery, (query) => {
 					<div class="w-[50%] truncate">{{ row.title }}</div>
 					<div class="flex-1 text-sm text-ink-gray-4">
 						<Avatar :label="row.owner" />
-						<span class="ml-1.5">{{ row.owner }}</span>
+						<span class="ms-1.5">{{ row.owner }}</span>
 					</div>
 					<div class="flex-1 text-sm text-ink-gray-4">
 						{{ (dayjs(row.creation) as any).fromNow() }}

--- a/frontend/src2/query/components/AddOperationPopover.vue
+++ b/frontend/src2/query/components/AddOperationPopover.vue
@@ -130,7 +130,7 @@ watch(
 				<Button
 					variant="outline"
 					:label="__('Add Operation')"
-					class="-ml-[14px] !h-6 !gap-1.5 bg-surface-base !px-2 text-p-xs"
+					class="-ms-[14px] !h-6 !gap-1.5 bg-surface-base !px-2 text-p-xs"
 				>
 					<template #prefix>
 						<Plus class="h-4 w-4 text-ink-gray-6" stroke-width="1.5" />
@@ -139,7 +139,7 @@ watch(
 			</div>
 		</template>
 		<template #default="{ toggle: togglePopover, isOpen }">
-			<div v-if="isOpen" class="flex min-w-fit flex-col p-1.5 pr-5">
+			<div v-if="isOpen" class="flex min-w-fit flex-col p-1.5 pe-5">
 				<span class="flex h-6 items-center px-2 text-p-xs text-ink-gray-4">
 					{{ __('Select an operation') }}
 				</span>
@@ -163,7 +163,7 @@ watch(
 									class="h-4.5 w-4.5 flex-shrink-0 text-ink-gray-6"
 									stroke-width="1.5"
 								/>
-								<div class="flex flex-1 flex-col text-left">
+								<div class="flex flex-1 flex-col text-start">
 									<p class="truncate text-p-sm">{{ button.label }}</p>
 									<p class="w-40 text-p-xs text-ink-gray-4">
 										{{ button.description }}

--- a/frontend/src2/query/components/AlertSetupDialog.vue
+++ b/frontend/src2/query/components/AlertSetupDialog.vue
@@ -281,7 +281,7 @@ Thanks,
 
 						<div
 							v-html="
-								`<ul class='list-disc pl-4'>
+								`<ul class='list-disc ps-4'>
 							<li>{{ rows }} - The result of the query</li>
 							<li>{{ count }} - The number of rows in the query</li>
 						</ul>`

--- a/frontend/src2/query/components/ColumnFilter.vue
+++ b/frontend/src2/query/components/ColumnFilter.vue
@@ -26,7 +26,7 @@ const props = defineProps<{
 					:class="{ ' !bg-surface-gray-2': isOpen }"
 				>
 					<template #icon>
-						<div class="flex h-7 w-full items-center gap-2 pl-2 pr-1.5 text-base">
+						<div class="flex h-7 w-full items-center gap-2 ps-2 pe-1.5 text-base">
 							<ListFilter class="h-4 w-4 flex-shrink-0" stroke-width="1.5" />
 							<div class="flex flex-1 items-center justify-between">
 								<span class="truncate">Filter</span>

--- a/frontend/src2/query/components/ColumnRemove.vue
+++ b/frontend/src2/query/components/ColumnRemove.vue
@@ -10,7 +10,7 @@ const props = defineProps<{ column: QueryResultColumn }>()
 <template>
 	<Button theme="red" variant="ghost" @click="emit('remove')" class="w-full !justify-start">
 		<template #icon>
-			<div class="flex h-7 w-full items-center gap-2 pl-2 pr-1.5 text-base">
+			<div class="flex h-7 w-full items-center gap-2 ps-2 pe-1.5 text-base">
 				<Trash class="h-4 w-4 flex-shrink-0" stroke-width="1.5" />
 				<div class="flex flex-1 items-center justify-between">
 					<span class="truncate">Remove</span>

--- a/frontend/src2/query/components/PivotSelectorDialog.vue
+++ b/frontend/src2/query/components/PivotSelectorDialog.vue
@@ -114,7 +114,7 @@ function confirmSelections() {
 								/>
 							</div>
 							<button
-								class="mt-1.5 text-left text-xs text-ink-gray-5 hover:underline"
+								class="mt-1.5 text-start text-xs text-ink-gray-5 hover:underline"
 								@click="addRow"
 							>
 								+ Add
@@ -134,7 +134,7 @@ function confirmSelections() {
 								/>
 							</div>
 							<button
-								class="mt-1.5 text-left text-xs text-ink-gray-5 hover:underline"
+								class="mt-1.5 text-start text-xs text-ink-gray-5 hover:underline"
 								@click="addColumn"
 							>
 								+ Add
@@ -154,7 +154,7 @@ function confirmSelections() {
 								/>
 							</div>
 							<button
-								class="mt-1.5 text-left text-xs text-ink-gray-5 hover:underline"
+								class="mt-1.5 text-start text-xs text-ink-gray-5 hover:underline"
 								@click="addValue"
 							>
 								+ Add

--- a/frontend/src2/query/components/QueryBuilderTable.vue
+++ b/frontend/src2/query/components/QueryBuilderTable.vue
@@ -91,7 +91,7 @@ function addNewColumn() {
 			</template>
 
 			<template #header-suffix="{ column }">
-				<div class="ml-auto pl-2">
+				<div class="ms-auto ps-2">
 					<Popover side="bottom" align="end">
 						<template #trigger="{ isOpen }">
 							<Button
@@ -129,7 +129,7 @@ function addNewColumn() {
 			</template>
 
 			<template #new-column-editor="{ toggle }">
-				<div class="flex h-full min-w-64 w-auto items-center gap-1 pl-0.5">
+				<div class="flex h-full min-w-64 w-auto items-center gap-1 ps-0.5">
 					<ColumnTypeChange v-model="newColumn.data_type" />
 					<ExpressionEditor
 						class="inline-expression h-fit max-h-[10rem] text-sm flex-1"

--- a/frontend/src2/query/components/QueryOperations.vue
+++ b/frontend/src2/query/components/QueryOperations.vue
@@ -275,7 +275,7 @@ const CustomOperationInfo = (props: any) => {
 			<div></div>
 		</div>
 		<div
-			class="relative ml-3 flex flex-col-reverse gap-3 border-l border-outline-gray-2 text-sm"
+			class="relative ms-3 flex flex-col-reverse gap-3 border-l border-outline-gray-2 text-sm"
 		>
 			<template v-for="(op, idx) in operations" :key="idx">
 				<div
@@ -285,7 +285,7 @@ const CustomOperationInfo = (props: any) => {
 					@dblclick="query.setActiveEditIndex(idx)"
 				>
 					<div
-						class="-ml-[14px] h-fit flex-shrink-0 rounded border border-outline-gray-3 bg-surface-base p-1"
+						class="-ms-[14px] h-fit flex-shrink-0 rounded border border-outline-gray-3 bg-surface-base p-1"
 					>
 						<component
 							:is="op.meta.icon"

--- a/frontend/src2/query/components/SchemaExplorer.vue
+++ b/frontend/src2/query/components/SchemaExplorer.vue
@@ -150,13 +150,13 @@ const filteredSchema = computed(() => {
 					</div>
 					<div
 						v-if="expandedTables.has(tableName)"
-						class="ml-3 flex flex-col gap-0.5 py-0.5"
+						class="ms-3 flex flex-col gap-0.5 py-0.5"
 					>
 						<button
 							v-for="column in tableData.columns"
 							:key="column.label"
 							@click="insertColumnName(column.label)"
-							class="flex w-full items-center gap-1.5 rounded py-1.5 pl-2 text-left text-ink-gray-5 hover:bg-surface-gray-1"
+							class="flex w-full items-center gap-1.5 rounded py-1.5 ps-2 text-start text-ink-gray-5 hover:bg-surface-gray-1"
 							:title="`${column.label} (${column.detail || column.type})`"
 						>
 							<component
@@ -164,7 +164,7 @@ const filteredSchema = computed(() => {
 								class="h-4 w-4 flex-shrink-0 text-ink-gray-5"
 							/>
 							<span class="truncate text-ink-gray-6">{{ column.label }}</span>
-							<span class="ml-auto flex-shrink-0 pr-1 text-xs text-ink-gray-4">{{
+							<span class="ms-auto flex-shrink-0 pe-1 text-xs text-ink-gray-4">{{
 								column.detail || column.type
 							}}</span>
 						</button>

--- a/frontend/src2/query/components/SummarySelectorDialog.vue
+++ b/frontend/src2/query/components/SummarySelectorDialog.vue
@@ -111,7 +111,7 @@ function confirmSelections() {
 								/>
 							</div>
 							<button
-								class="mt-1.5 text-left text-xs text-ink-gray-5 hover:underline"
+								class="mt-1.5 text-start text-xs text-ink-gray-5 hover:underline"
 								@click="addDimension"
 							>
 								+ Add
@@ -129,7 +129,7 @@ function confirmSelections() {
 								/>
 							</div>
 							<button
-								class="mt-1.5 text-left text-xs text-ink-gray-5 hover:underline"
+								class="mt-1.5 text-start text-xs text-ink-gray-5 hover:underline"
 								@click="addMeasure"
 							>
 								+ Add

--- a/frontend/src2/settings/UsersSettings.vue
+++ b/frontend/src2/settings/UsersSettings.vue
@@ -208,7 +208,7 @@ function sendInvitation() {
 							placeholder="Enter email address"
 							v-model="emailsTxt"
 							@keydown.enter.capture.stop="extractEmails(`${emailsTxt} `)"
-							class="h-7 w-full rounded border-none bg-surface-gray-2 py-1.5 pl-2 pr-2 text-base text-ink-gray-7 placeholder-ink-gray-4 transition-colors focus:outline-none focus:ring-0 focus-visible:outline-none focus-visible:ring-0"
+							class="h-7 w-full rounded border-none bg-surface-gray-2 py-1.5 ps-2 pe-2 text-base text-ink-gray-7 placeholder-ink-gray-4 transition-colors focus:outline-none focus:ring-0 focus-visible:outline-none focus-visible:ring-0"
 						/>
 					</div>
 				</div>

--- a/frontend/src2/teams/TeamList.vue
+++ b/frontend/src2/teams/TeamList.vue
@@ -79,7 +79,7 @@ document.title = 'Teams | Insights'
 </script>
 
 <template>
-	<header class="flex h-12 items-center justify-between border-b py-2.5 pl-5 pr-2">
+	<header class="flex h-12 items-center justify-between border-b py-2.5 ps-5 pe-2">
 		<Breadcrumbs :items="[{ label: __('Teams'), route: '/teams' }]" />
 		<div class="flex items-center gap-2">
 			<Button

--- a/frontend/src2/teams/TeamResourceSelector.vue
+++ b/frontend/src2/teams/TeamResourceSelector.vue
@@ -235,7 +235,7 @@ function getVisibleTableLimit(dataSource: string) {
 	<div
 		v-for="data_source in dataSources"
 		:key="data_source.name"
-		class="flex flex-col pr-2"
+		class="flex flex-col pe-2"
 		:data-source="data_source.name"
 	>
 		<div class="sticky top-0 z-10 flex items-center gap-2 bg-surface-base py-1.5">
@@ -269,7 +269,7 @@ function getVisibleTableLimit(dataSource: string) {
 		</div>
 		<div
 			v-if="expandedDataSource === data_source.name"
-			class="flex flex-col gap-2.5 pl-6 pb-1.5"
+			class="flex flex-col gap-2.5 ps-6 pb-1.5"
 		>
 			<FormControl
 				type="text"
@@ -334,7 +334,7 @@ function getVisibleTableLimit(dataSource: string) {
 							</p>
 						</div>
 					</div>
-					<div v-if="expandedTable === table.name" class="ml-6 flex flex-col gap-1.5">
+					<div v-if="expandedTable === table.name" class="ms-6 flex flex-col gap-1.5">
 						<ExpressionEditor
 							:column-options="expandedTableColumns"
 							v-model="tableRestrictions[table.name]"

--- a/frontend/src2/users/UserList.vue
+++ b/frontend/src2/users/UserList.vue
@@ -144,7 +144,7 @@ document.title = 'Users | Insights'
 </script>
 
 <template>
-	<header class="flex h-12 items-center justify-between border-b py-2.5 pl-5 pr-2">
+	<header class="flex h-12 items-center justify-between border-b py-2.5 ps-5 pe-2">
 		<Breadcrumbs :items="[{ label: __('Users'), route: '/users' }]" />
 		<div class="flex items-center gap-2">
 			<Button
@@ -209,7 +209,7 @@ document.title = 'Users | Insights'
 							placeholder="Enter email address"
 							v-model="emailsTxt"
 							@keydown.enter.capture.stop="extractEmails(`${emailsTxt} `)"
-							class="h-7 w-full rounded border-none bg-surface-gray-2 py-1.5 pl-2 pr-2 text-base text-ink-gray-7 placeholder-ink-gray-4 transition-colors focus:outline-none focus:ring-0 focus-visible:outline-none focus-visible:ring-0"
+							class="h-7 w-full rounded border-none bg-surface-gray-2 py-1.5 ps-2 pe-2 text-base text-ink-gray-7 placeholder-ink-gray-4 transition-colors focus:outline-none focus:ring-0 focus-visible:outline-none focus-visible:ring-0"
 						/>
 					</div>
 				</div>

--- a/frontend/src2/workbook/WorkbookLineageDialog.vue
+++ b/frontend/src2/workbook/WorkbookLineageDialog.vue
@@ -151,7 +151,7 @@ function onNodeClick(_evt: MouseEvent, node: any) {
 					{{ visibleNodes.length }} {{ __('nodes') }}, {{ visibleEdges.length }}
 					{{ __('edges') }}
 				</span>
-				<div class="ml-auto">
+				<div class="ms-auto">
 					<FormControl
 						v-model="searchQuery"
 						:placeholder="__('Search nodes\u2026')"
@@ -223,7 +223,7 @@ function onNodeClick(_evt: MouseEvent, node: any) {
 									data.label
 								}}</span>
 							</div>
-							<span class="truncate pl-5 text-xs text-ink-blue-6">{{
+							<span class="truncate ps-5 text-xs text-ink-blue-6">{{
 								data.data_source
 							}}</span>
 						</div>

--- a/frontend/src2/workbook/WorkbookList.vue
+++ b/frontend/src2/workbook/WorkbookList.vue
@@ -142,7 +142,7 @@ watchEffect(() => {
 </script>
 
 <template>
-	<header class="flex h-12 items-center justify-between border-b py-2.5 pl-5 pr-2">
+	<header class="flex h-12 items-center justify-between border-b py-2.5 ps-5 pe-2">
 		<Breadcrumbs :items="[{ label: __('Workbooks'), route: '/workbook' }]" />
 		<div class="flex items-center gap-2">
 			<Button

--- a/frontend/src2/workbook/WorkbookSidebarFolders.vue
+++ b/frontend/src2/workbook/WorkbookSidebarFolders.vue
@@ -178,7 +178,7 @@ function onListChange(
 					>
 						<router-link
 							:to="route(row)"
-							class="flex h-7.5 items-center justify-between rounded pl-1.5 text-sm"
+							class="flex h-7.5 items-center justify-between rounded ps-1.5 text-sm"
 						>
 							<div class="flex gap-1.5 overflow-hidden">
 								<div class="flex-shrink-0">
@@ -275,21 +275,21 @@ function onListChange(
 							v-if="
 								isFolderExpanded(folder.name) && !folderItems[folder.name]?.length
 							"
-							class="ml-[22px] flex h-7.5 items-center pl-1.5 text-sm text-ink-gray-3"
+							class="ms-[22px] flex h-7.5 items-center ps-1.5 text-sm text-ink-gray-3"
 						>
 							{{ __('Empty') }}
 						</div>
 					</template>
 
 					<template #item="{ element: row }">
-						<div v-show="isFolderExpanded(folder.name)" class="ml-[22px]">
+						<div v-show="isFolderExpanded(folder.name)" class="ms-[22px]">
 							<div
 								class="group w-full cursor-pointer rounded transition-all hover:bg-surface-gray-2"
 								:class="section.isActive(row) ? 'bg-surface-gray-3' : ''"
 							>
 								<router-link
 									:to="route(row)"
-									class="flex h-7.5 items-center justify-between rounded pl-1.5 text-sm"
+									class="flex h-7.5 items-center justify-between rounded ps-1.5 text-sm"
 								>
 									<div class="flex gap-1.5 overflow-hidden">
 										<div class="flex-shrink-0">

--- a/frontend/src2/workbook/WorkbookSidebarListSection.vue
+++ b/frontend/src2/workbook/WorkbookSidebarListSection.vue
@@ -49,7 +49,7 @@ function setDraggedItem(event: DragEvent, row: any) {
 			>
 				<router-link
 					:to="route(row)"
-					class="flex h-7.5 items-center justify-between rounded pl-1.5 text-sm"
+					class="flex h-7.5 items-center justify-between rounded ps-1.5 text-sm"
 				>
 					<div class="flex gap-1.5 overflow-hidden">
 						<div class="flex-shrink-0">

--- a/frontend/src2/workbook/WorkbookTabSwitcher.vue
+++ b/frontend/src2/workbook/WorkbookTabSwitcher.vue
@@ -24,9 +24,9 @@ const workbook = inject(workbookKey)
 				@click="router.push(`/workbook/${workbook.name}/query/${idx}`)"
 			>
 				<Table2 class="h-3.5 w-3.5 text-ink-gray-6" stroke-width="1.5" />
-				<span class="ml-2">{{ query.title }}</span>
+				<span class="ms-2">{{ query.title }}</span>
 				<XIcon
-					class="ml-2 h-3.5 w-3.5 cursor-pointer text-ink-gray-4 transition-all hover:text-ink-gray-7"
+					class="ms-2 h-3.5 w-3.5 cursor-pointer text-ink-gray-4 transition-all hover:text-ink-gray-7"
 					@click.prevent.stop="workbook.removeQuery(query.name)"
 				/>
 			</button>
@@ -38,9 +38,9 @@ const workbook = inject(workbookKey)
 				@click="router.push(`/workbook/${workbook.name}/chart/${idx}`)"
 			>
 				<ChartIcon :chart-type="chart.chart_type" />
-				<span class="ml-2">{{ chart.title }}</span>
+				<span class="ms-2">{{ chart.title }}</span>
 				<XIcon
-					class="ml-2 h-3.5 w-3.5 cursor-pointer text-ink-gray-4 transition-all hover:text-ink-gray-7"
+					class="ms-2 h-3.5 w-3.5 cursor-pointer text-ink-gray-4 transition-all hover:text-ink-gray-7"
 					@click.prevent.stop="workbook.removeChart(chart.name)"
 				/>
 			</button>
@@ -52,15 +52,15 @@ const workbook = inject(workbookKey)
 				@click="router.push(`/workbook/${workbook.name}/dashboard/${idx}`)"
 			>
 				<LayoutPanelTop class="h-3.5 w-3.5 text-ink-gray-6" stroke-width="1.5" />
-				<span class="ml-2">{{ dashboard.title }}</span>
+				<span class="ms-2">{{ dashboard.title }}</span>
 				<XIcon
-					class="ml-2 h-3.5 w-3.5 cursor-pointer text-ink-gray-4 transition-all hover:text-ink-gray-7"
+					class="ms-2 h-3.5 w-3.5 cursor-pointer text-ink-gray-4 transition-all hover:text-ink-gray-7"
 					@click.prevent.stop="workbook.removeDashboard(dashboard.name)"
 				/>
 			</button>
 		</div>
 		<Dropdown
-			class="ml-1.5"
+			class="ms-1.5"
 			:options="[
 				{ label: __('New Query'), onClick: workbook.addQuery },
 				{ label: __('New Chart'), onClick: workbook.addChart },

--- a/frontend/src2/workbook/WorkbookTemplates.vue
+++ b/frontend/src2/workbook/WorkbookTemplates.vue
@@ -196,7 +196,7 @@ function runUpdate(template: WorkbookTemplate) {
 											<CheckCircle2 class="h-4 w-4" />
 											{{ __('Imported') }}
 										</div>
-										<div class="ml-auto flex items-center gap-2">
+										<div class="ms-auto flex items-center gap-2">
 											<Button
 												v-if="template.update_available"
 												:loading="updating === template.name"
@@ -212,7 +212,7 @@ function runUpdate(template: WorkbookTemplate) {
 									</template>
 									<Button
 										v-else
-										class="ml-auto"
+										class="ms-auto"
 										:loading="importing === template.name"
 										:disabled="!!importing"
 										@click="importTemplate(template)"


### PR DESCRIPTION
## Problem

Hardcoded physical spacing/text-align classes (`ml-`/`mr-`, `pl-`/`pr-`, `text-left`/`text-right`) don't mirror when `dir="rtl"` is applied — margin/padding stays on the same physical side and text stays left/right-anchored regardless of direction.

## Fix

Safe subset only: `ml-/mr-` → `ms-/me-`, `pl-/pr-` → `ps-/pe-`, `text-left/right` → `text-start/end`. Behavior-preserving for LTR (these resolve to the same physical side when direction is `ltr`) and correct under `dir="rtl"`.

Deliberately does **not** touch `left-`/`right-` (positioning), `border-l/r` (side border width), or transforms (`translate-x` etc.) — those can sit right next to a converted class and interact with it in a way that needs a human to look, so a blind swap risks moving something to the wrong place.

## How this was done

Converted mechanically with a small script that has its own 15+-case self-test (variant prefixes, negatives, arbitrary values, fractions all covered; verified `px-`/`mx-`/`left-`/`right-`/`border-l-r`/`translate-x` are never touched), then spot-checked by hand. Zero remaining `ml-/mr-/pl-/pr-/text-left/text-right` instances after conversion.
