### PR TITLE
chore: bump sqlglot to 30.12.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "SQLAlchemy==2.0.41",
     "python-telegram-bot==21.4",
     "duckdb~=1.4.3",
-    "sqlglot<28.0.0",
+    "sqlglot>=30.12.0,<31",
     "ibis-framework~=11.0.0",
     "ibis-framework[duckdb]",
     "ibis-framework[mysql]",


### PR DESCRIPTION
Required for compat with frappe after https://github.com/frappe/frappe/pull/41956

Needs backports to `version-3` and `main` as well.