### PR TITLE
fix(query cache): keep column names when the result is empty

### DIFF
--- a/insights/insights/doctype/insights_data_source_v3/ibis_utils.py
+++ b/insights/insights/doctype/insights_data_source_v3/ibis_utils.py
@@ -1023,26 +1023,36 @@ def to_insights_type(dtype: DataType):
     return "String"
 
 
+def _results_cache_key(cache_key):
+    # v2 stores the column names alongside the rows, so the prefix change drops
+    # the v1 entries that cannot be read back with their schema intact
+    return "insights:query_results:v2:" + cache_key
+
+
 def cache_results(cache_key, result: pd.DataFrame, cache_expiry=3600):
-    cache_key = "insights:query_results:" + cache_key
-    data = result.to_dict(orient="records")
-    data = frappe.as_json(data)
-    frappe.cache().set_value(cache_key, data, expires_in_sec=cache_expiry)
+    payload = {
+        "columns": list(result.columns),
+        "rows": result.to_dict(orient="records"),
+    }
+    frappe.cache().set_value(
+        _results_cache_key(cache_key),
+        frappe.as_json(payload),
+        expires_in_sec=cache_expiry,
+    )
 
 
 def get_cached_results(cache_key) -> pd.DataFrame:
-    cache_key = "insights:query_results:" + cache_key
-    data = frappe.cache().get_value(cache_key)
+    data = frappe.cache().get_value(_results_cache_key(cache_key))
     if not data:
         return None
-    data = frappe.parse_json(data)
-    df = pd.DataFrame(data).replace({pd.NaT: None, np.nan: None})
-    return df
+    payload = frappe.parse_json(data)
+    # a result with no rows still has columns, and records alone cannot carry them
+    df = pd.DataFrame(payload["rows"], columns=payload["columns"])
+    return df.replace({pd.NaT: None, np.nan: None})
 
 
 def has_cached_results(cache_key):
-    cache_key = "insights:query_results:" + cache_key
-    return frappe.cache().get_value(cache_key) is not None
+    return frappe.cache().get_value(_results_cache_key(cache_key)) is not None
 
 
 def exec_with_return(

--- a/insights/tests/workbook/test_querying.py
+++ b/insights/tests/workbook/test_querying.py
@@ -306,6 +306,33 @@ class TestQuerying(InsightsIntegrationTestCase):
         self.assertIn(f"{TODO_PREFIX} Open Alpha", csv_data)
         self.assertIn(f"{TODO_PREFIX} Closed Beta", csv_data)
 
+    def test_distinct_values_of_an_all_null_column_stay_empty_when_cached(self):
+        self.seed_todos()
+        workbook = create_test_workbook(USER_1)
+        query = create_test_query(
+            USER_1,
+            workbook.name,
+            title="Workbook Flow Test Query Null Column",
+            operations=[
+                table_source(),
+                {
+                    "type": "filter",
+                    "column": column("description"),
+                    "operator": "contains",
+                    "value": TODO_PREFIX,
+                },
+            ],
+        )
+        query_doc = self.get_query(query.name)
+
+        with db_connections():
+            # no seeded todo sets a color, so the first call caches an empty result
+            first = query_doc.get_distinct_column_values("color")
+            second = query_doc.get_distinct_column_values("color")
+
+        self.assertEqual(first, [])
+        self.assertEqual(second, [])
+
     def test_query_can_use_another_query_as_its_source(self):
         self.seed_todos()
         workbook = create_test_workbook(USER_1)


### PR DESCRIPTION
Fixes a 500 on a dashboard filter dropdown when the linked column has no non-null values ([support 76378](https://support.frappe.io/helpdesk/tickets/76378)).

The result cache serialized with `to_dict(orient="records")`, which carries no schema. A zero-row result came back as a frame with no columns, so `get_distinct_column_values` raised `KeyError` on every request after the first, for the whole 24 hour cache window.

The cache now stores the column names next to the rows. The non-empty payload is unchanged, so results round-trip exactly as before. The key prefix moves to `v2` — old entries hold a bare list and cannot be read back with a schema, so they are stranded until they expire.

`get_distinct_column_values` is the only caller that reads a column off the returned frame. The others take columns from the ibis schema or aggregate to one row.

The new test reproduces the reported `KeyError` without the fix.

Needs a backport to `version-3`.