### PR TITLE
fix: do not force SSL verification on database connections

### DIFF
--- a/insights/insights/doctype/insights_data_source/sources/frappe_db.py
+++ b/insights/insights/doctype/insights_data_source/sources/frappe_db.py
@@ -199,6 +199,29 @@ class FrappeTableFactory:
         return dynamic_link_map
 
 
+def get_site_db_ssl_params():
+    """SSL settings for the site database, matching frappe.database.mariadb.
+
+    The framework connects with SSL only when a CA is configured, and verifies
+    against that CA. Without it the site database gets no SSL at all.
+    """
+    if not frappe.conf.db_ssl_ca:
+        return {}
+
+    # pymysql rebuilds its ssl options from scratch when ssl_verify_cert is set,
+    # which drops the CA. Sending the CA alone already means "verify".
+    # sent as a string so that a "no hostname check" setting survives the query
+    # string, where a falsy value would be dropped
+    params = {
+        "ssl_ca": frappe.conf.db_ssl_ca,
+        "ssl_check_hostname": str(bool(frappe.conf.db_ssl_check_hostname)).lower(),
+    }
+    if frappe.conf.db_ssl_cert and frappe.conf.db_ssl_key:
+        params["ssl_cert"] = frappe.conf.db_ssl_cert
+        params["ssl_key"] = frappe.conf.db_ssl_key
+    return params
+
+
 class FrappeDB(MariaDB):
     def __init__(self, data_source, host, port, username, password, database_name, use_ssl, **_):
         self.data_source = data_source
@@ -211,7 +234,7 @@ class FrappeDB(MariaDB):
             host=host,
             port=port,
             ssl=use_ssl,
-            ssl_verify_cert=True,
+            ssl_verify_cert=use_ssl,
             charset="utf8mb4",
             use_unicode=True,
             connect_args={"connect_timeout": 1, "read_timeout": 1, "write_timeout": 1},
@@ -315,10 +338,9 @@ class SiteDB(FrappeDB):
             database=credentials["database"],
             host=credentials["host"],
             port=credentials["port"],
-            ssl=False,
-            ssl_verify_cert=bool(not frappe.conf.developer_mode),
             charset="utf8mb4",
             use_unicode=True,
+            **get_site_db_ssl_params(),
         )
 
 

--- a/insights/insights/doctype/insights_data_source/sources/frappe_db.py
+++ b/insights/insights/doctype/insights_data_source/sources/frappe_db.py
@@ -13,7 +13,7 @@ from insights.insights.query_builders.sql_builder import SQLQueryBuilder
 
 from .base_database import DatabaseCredentialsError, DatabaseParallelConnectionError
 from .mariadb import MARIADB_TO_GENERIC_TYPES, MariaDB
-from .utils import create_insights_table, get_sqlalchemy_engine
+from .utils import CONNECT_TIMEOUT, create_insights_table, get_sqlalchemy_engine
 
 
 class FrappeTableFactory:
@@ -241,7 +241,10 @@ class FrappeDB(MariaDB):
             ssl_verify_cert=use_ssl,
             charset="utf8mb4",
             use_unicode=True,
-            connect_args={"connect_timeout": 1, "read_timeout": 1, "write_timeout": 1},
+            # no read or write timeout: a chart query may well run longer than
+            # the connect timeout, and cutting a read mid packet leaves the
+            # connection out of step
+            connect_args={"connect_timeout": CONNECT_TIMEOUT},
         )
         self.query_builder: SQLQueryBuilder = SQLQueryBuilder(self.engine)
         self.table_factory: FrappeTableFactory = FrappeTableFactory(data_source)

--- a/insights/insights/doctype/insights_data_source/sources/frappe_db.py
+++ b/insights/insights/doctype/insights_data_source/sources/frappe_db.py
@@ -200,20 +200,24 @@ class FrappeTableFactory:
 
 
 def get_site_db_ssl_params():
-    """SSL settings for the site database, matching frappe.database.mariadb.
+    """SSL settings for the site database, as the framework resolves them.
 
-    The framework connects with SSL only when a CA is configured, and verifies
-    against that CA. Without it the site database gets no SSL at all.
+    The site database has no connection fields in the form, so the site config
+    is the only source. This mirrors frappe.database.mariadb.
+
+    frappe.db.get_connection_settings() cannot be reused as is. It carries a
+    converter map, and other keys, built for the driver the framework itself
+    connects with, which is not always the one used here.
     """
     if not frappe.conf.db_ssl_ca:
         return {}
 
     # pymysql rebuilds its ssl options from scratch when ssl_verify_cert is set,
     # which drops the CA. Sending the CA alone already means "verify".
-    # sent as a string so that a "no hostname check" setting survives the query
-    # string, where a falsy value would be dropped
     params = {
         "ssl_ca": frappe.conf.db_ssl_ca,
+        # a string, so that "do not check the hostname" survives the query
+        # string, where a falsy value would be dropped
         "ssl_check_hostname": str(bool(frappe.conf.db_ssl_check_hostname)).lower(),
     }
     if frappe.conf.db_ssl_cert and frappe.conf.db_ssl_key:
@@ -309,6 +313,8 @@ class SiteDB(FrappeDB):
             primary_config["port"] = frappe.conf.replica_db_port
         if frappe.conf.replica_host:
             primary_config["host"] = frappe.conf.replica_host
+            # the primary's socket does not reach the replica
+            primary_config["socket"] = None
 
         if frappe.conf.different_credentials_for_replica:
             primary_config["username"] = (
@@ -319,13 +325,21 @@ class SiteDB(FrappeDB):
         return primary_config
 
     def get_primary_credentials(self):
-        """Get primary database credentials"""
+        """Read back what the framework itself connected with.
+
+        Reading the live connection, rather than resolving the site config a
+        second time, keeps the two in step across framework versions. v15
+        connects as db_name, later versions prefer db_user, and a site may be
+        reached over a socket rather than a host and port.
+        """
+        db = frappe.local.db
         return {
-            "username": frappe.conf.db_name,
-            "password": frappe.conf.db_password,
-            "database": frappe.conf.db_name,
-            "host": frappe.conf.db_host or "127.0.0.1",
-            "port": frappe.conf.db_port or "3306",
+            "username": db.user,
+            "password": db.password,
+            "database": db.cur_db_name,
+            "host": db.host or "127.0.0.1",
+            "port": db.port or "3306",
+            "socket": db.socket,
         }
 
     def create_engine(self, credentials):
@@ -338,6 +352,7 @@ class SiteDB(FrappeDB):
             database=credentials["database"],
             host=credentials["host"],
             port=credentials["port"],
+            unix_socket=credentials.get("socket"),
             charset="utf8mb4",
             use_unicode=True,
             **get_site_db_ssl_params(),

--- a/insights/insights/doctype/insights_data_source/sources/mariadb.py
+++ b/insights/insights/doctype/insights_data_source/sources/mariadb.py
@@ -17,7 +17,7 @@ from .base_database import (
     DatabaseCredentialsError,
     DatabaseParallelConnectionError,
 )
-from .utils import create_insights_table, get_sqlalchemy_engine
+from .utils import CONNECT_TIMEOUT, create_insights_table, get_sqlalchemy_engine
 
 MARIADB_TO_GENERIC_TYPES = {
     "int": "Integer",
@@ -108,7 +108,7 @@ class MariaDB(BaseDatabase):
             ssl_verify_cert=use_ssl,
             charset="utf8mb4",
             use_unicode=True,
-            connect_args={"connect_timeout": 1},
+            connect_args={"connect_timeout": CONNECT_TIMEOUT},
         )
         self.query_builder: SQLQueryBuilder = SQLQueryBuilder(self.engine)
         self.table_factory: MariaDBTableFactory = MariaDBTableFactory(data_source)

--- a/insights/insights/doctype/insights_data_source/sources/postgresql.py
+++ b/insights/insights/doctype/insights_data_source/sources/postgresql.py
@@ -15,7 +15,7 @@ from sqlalchemy.engine.base import Connection
 from insights.insights.query_builders.postgresql.builder import PostgresQueryBuilder
 
 from .base_database import BaseDatabase
-from .utils import create_insights_table, get_sqlalchemy_engine
+from .utils import CONNECT_TIMEOUT, create_insights_table, get_sqlalchemy_engine
 
 IGNORED_TABLES = ["__.*"]
 
@@ -106,7 +106,7 @@ class PostgresTableFactory:
 
 class PostgresDatabase(BaseDatabase):
     def __init__(self, **kwargs):
-        connect_args = {"connect_timeout": 1}
+        connect_args = {"connect_timeout": CONNECT_TIMEOUT}
 
         self.data_source = kwargs.pop("data_source")
         if connection_string := kwargs.pop("connection_string", None):

--- a/insights/insights/doctype/insights_data_source/sources/utils.py
+++ b/insights/insights/doctype/insights_data_source/sources/utils.py
@@ -36,7 +36,10 @@ def get_sqlalchemy_engine(connect_args=None, **kwargs) -> Engine:
     database = kwargs.pop("database")
     host = kwargs.pop("host", "localhost")
     port = kwargs.pop("port") or 3306
-    extra_params = "&".join(f"{k}={v}" for k, v in kwargs.items())
+    # each value becomes a query string, and the driver reads it back as a non-empty
+    # string. "ssl=False" would therefore turn SSL on. Drop falsy values instead of
+    # spelling them out.
+    extra_params = "&".join(f"{k}={v}" for k, v in kwargs.items() if v is not None and v is not False)
 
     uri = f"{dialect}+{driver}://{user}:{password}@{host}:{port}/{database}?{extra_params}"
 

--- a/insights/insights/doctype/insights_data_source/sources/utils.py
+++ b/insights/insights/doctype/insights_data_source/sources/utils.py
@@ -18,6 +18,12 @@ if TYPE_CHECKING:
     from sqlalchemy.engine.interfaces import Dialect
 
 
+# Enough to survive a dropped SYN, whose first retransmit lands about a second
+# in, and a TLS handshake over a wide area link. Short enough that probing a
+# host which does not answer, as is_frappe_db does, still fails quickly.
+CONNECT_TIMEOUT = 5
+
+
 def get_sqlalchemy_engine(connect_args=None, **kwargs) -> Engine:
     connect_args = connect_args or {}
 
@@ -44,7 +50,7 @@ def get_sqlalchemy_engine(connect_args=None, **kwargs) -> Engine:
     uri = f"{dialect}+{driver}://{user}:{password}@{host}:{port}/{database}?{extra_params}"
 
     # TODO: cache the engine by uri
-    return create_engine(uri, poolclass=NullPool, connect_args={})
+    return create_engine(uri, poolclass=NullPool, connect_args=connect_args)
 
 
 def create_insights_table(table, force=False):


### PR DESCRIPTION
Support ticket 76770 — Insights cannot reach any database serving a self-signed certificate.

```
pymysql.err.OperationalError: (2003, "Can't connect to MySQL server on '10.3.128.22'
([SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self-signed certificate)")
```

**Cause.** `get_sqlalchemy_engine` joins every keyword into the URI query string, so the driver reads them back as strings — and `'False'` is truthy. `ssl=False` never disabled anything, and `ssl_verify_cert` then made pymysql verify against the system trust store with no CA. A self-signed certificate could only fail.

Three commits:

1. **Stop forcing verification.** Drop falsy values from the query string. `FrappeDB` verifies only when the data source's **Use SSL** is ticked.

2. **Site DB follows the framework's connection.** It has no connection fields in the form, so `frappe.local.db` is the only source — read `user`, `socket` and the rest back off it instead of resolving the site config a second time. The app supports `frappe >= 15.0.0` and the versions disagree: v15 connects as `db_name`, later ones prefer `db_user`. SSL comes from `db_ssl_ca` and friends, as the framework does.

3. **Honour `connect_args`.** `f0d5615f` ("fix(temp): disable connect args") turned it off while chasing a pooling error, and `336f69ad` ended that work without restoring it, so no MariaDB connection has carried a timeout since April 2024.

Two decisions worth a look:

- The CA is sent *without* `ssl_verify_cert`, deliberately. pymysql rebuilds its SSL options from scratch when that flag is present, which discards the CA.
- Restoring `connect_args` as it stood breaks dashboards. `FrappeDB` asked for `read_timeout=1`, and `select sleep(2)` then dies with `(2013, 'Lost connection to MySQL server during query (timed out)')` — plausibly the source of the "Packet sequence number wrong" errors being chased at the time. Read and write timeouts dropped. Connect timeout kept, raised 1s → 5s: 1s sits under the first TCP retransmit, and leaves no room for a TLS handshake over a WAN now that SSL works.

v2 code only. v3 already handles SSL correctly via `ssl_mode`.
