### PR TITLE
fix(iris): remove the env probes that broke CI runs

### DIFF
--- a/.claude/commands/iris-review.md
+++ b/.claude/commands/iris-review.md
@@ -1,5 +1,5 @@
 ---
-allowed-tools: Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr checks:*),Bash(gh pr comment:*),Bash(gh search:*),Bash(git log:*),Bash(git show:*),Bash(git blame:*),Bash(git diff:*),Bash(git rev-parse:*),Bash(git merge-base:*),Bash(git ls-files:*),Bash(wc:*),Bash(rg:*),Read,Glob,Grep
+allowed-tools: Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr checks:*),Bash(gh pr comment:*),Bash(gh search:*),Bash(git log:*),Bash(git show:*),Bash(git blame:*),Bash(git diff:*),Bash(git rev-parse:*),Bash(git merge-base:*),Bash(git ls-files:*),Bash(wc:*),Bash(rg:*),Read,Write,Glob,Grep
 description: Review an Insights pull request or branch against this repo's standards, and report the findings in chat.
 ---
 
@@ -17,17 +17,22 @@ again?"* Ask both questions of every diff.
 something small. *"don't change anything, share your feedback first"*. If a follow-up is
 worth doing, say so in one line and stop.
 
-**Where the review goes.** If `$IRIS_EVENT` is set you are running in CI: post the review
-as exactly one PR comment with `gh pr comment <N> --body-file <path>`, then stop. One
-comment per run, always, even for "Looks good". Otherwise print it in chat and post
-nothing. When `$IRIS_EVENT` is `issue_comment`, read `$IRIS_COMMENT_BODY` — if it asks for
-a specific angle, lead with "Re-reviewing per @$IRIS_COMMENT_AUTHOR — focused on <thing>."
+**Where the review goes.** If `$ARGUMENTS` contains `--ci`, you are running in CI: Write
+the review to `/tmp/review.md`, post it with `gh pr comment <N> --body-file /tmp/review.md`,
+then stop. One comment per run, always, even for "Looks good". Otherwise print it in chat
+and post nothing. Do not probe the environment to decide — the arguments are the only
+signal. When the `--ci` event is `issue_comment`, Read `/tmp/iris-comment.txt` — if it asks
+for a specific angle, lead with "Re-reviewing per @<author> — focused on <thing>", with the
+author from `/tmp/iris-comment-author.txt`.
+
+This command is already running — never call the Skill tool.
 
 
 **Push back on him too.** *"don't trust my words, but first find out how people are doing
 it"*. If the PR is his, or he states a premise you can check, check it.
 
-Inputs: `$ARGUMENTS` is a PR number, a git ref, or empty.
+Inputs: `$ARGUMENTS` is a PR number, a git ref, or empty. In CI it is
+`<pr> --ci <event>`.
 
 - A number → `gh pr view <N>`, `gh pr diff <N>`. Read the PR, not the working tree.
 - A ref → `git diff <ref>...HEAD` (three-dot).
@@ -52,8 +57,10 @@ limit, no filtering — a candidate you are unsure of still goes on the list.
 **Phase 2 — confirm each candidate.** One at a time. **Run the check. Do not reason about
 it.** If the claim is that a value comes back wrong, read the code that produces it and
 say what it returns. If the claim is that a caller breaks, open the caller. If the claim
-is about a framework default, read the framework. A candidate you cannot confirm is either
-dropped, or stated as a question with the word "worth checking" in it — never asserted.
+is about a framework default, read the framework. Your checks are reads — you have no
+interpreter, so a check that needs one counts as unconfirmable. A candidate you cannot
+confirm is either dropped, or stated as a question with the word "worth checking" in it —
+never asserted.
 Budget for this phase is separate: do not skip a check because the comment is getting long.
 The comment does not exist yet.
 

--- a/.claude/commands/iris-review.md
+++ b/.claude/commands/iris-review.md
@@ -1,5 +1,5 @@
 ---
-allowed-tools: Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr checks:*),Bash(gh pr comment:*),Bash(gh search:*),Bash(git log:*),Bash(git show:*),Bash(git blame:*),Bash(git diff:*),Bash(git rev-parse:*),Bash(git merge-base:*),Bash(git ls-files:*),Bash(wc:*),Bash(rg:*),Read,Write,Glob,Grep
+allowed-tools: Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr checks:*),Bash(gh search:*),Bash(git log:*),Bash(git show:*),Bash(git blame:*),Bash(git diff:*),Bash(git rev-parse:*),Bash(git merge-base:*),Bash(git ls-files:*),Bash(wc:*),Bash(rg:*),Read,Write,Glob,Grep
 description: Review an Insights pull request or branch against this repo's standards, and report the findings in chat.
 ---
 
@@ -18,10 +18,9 @@ something small. *"don't change anything, share your feedback first"*. If a foll
 worth doing, say so in one line and stop.
 
 **Where the review goes.** If `$ARGUMENTS` contains `--ci`, you are running in CI: Write
-the review to `/tmp/review.md`, post it with `gh pr comment <N> --body-file /tmp/review.md`,
-then stop. One comment per run, always, even for "Looks good". Otherwise print it in chat
-and post nothing. Do not probe the environment to decide — the arguments are the only
-signal. When the `--ci` event is `issue_comment`, Read `/tmp/iris-comment.txt` — if it asks
+the review to `/tmp/review.md`, then stop — the workflow posts the file as the PR comment.
+Always write the file, even for "Looks good". Otherwise print it in chat and post nothing.
+Do not probe the environment to decide — the arguments are the only signal. When the `--ci` event is `issue_comment`, Read `/tmp/iris-comment.txt` — if it asks
 for a specific angle, lead with "Re-reviewing per @<author> — focused on <thing>", with the
 author from `/tmp/iris-comment-author.txt`.
 

--- a/.github/workflows/iris-review.yml
+++ b/.github/workflows/iris-review.yml
@@ -98,6 +98,7 @@ jobs:
           printf '%s\n' "$AUTHOR" > /tmp/iris-comment-author.txt
 
       - name: Run iris
+        id: iris
         uses: anthropics/claude-code-action@v1
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -107,3 +108,34 @@ jobs:
           display_report: 'true'
           prompt: "/iris-review ${{ steps.pr.outputs.number }} --ci ${{ github.event_name }}"
           claude_args: ${{ vars.IRIS_MODEL != '' && format('--model {0}', vars.IRIS_MODEL) || '' }}
+
+      - name: Bot token
+        # Optional custom identity: register a GitHub App, install it on this
+        # repo, then set the IRIS_APP_ID variable and IRIS_APP_PRIVATE_KEY
+        # secret. Without them the comment posts as github-actions.
+        id: bot
+        if: vars.IRIS_APP_ID != ''
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.IRIS_APP_ID }}
+          private-key: ${{ secrets.IRIS_APP_PRIVATE_KEY }}
+
+      - name: Post review
+        # The agent only writes /tmp/review.md — posting is the workflow's job,
+        # so the footer is reliable and the comment count is exactly one.
+        env:
+          GH_TOKEN: ${{ steps.bot.outputs.token || secrets.GITHUB_TOKEN }}
+          EXEC_FILE: ${{ steps.iris.outputs.execution_file }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          PR: ${{ steps.pr.outputs.number }}
+        run: |
+          test -s /tmp/review.md
+          model=$(jq -r 'first(.. | objects | select(has("model")) | .model) // empty' "$EXEC_FILE" || true)
+          cost=$(jq -r 'first(.. | objects | select(has("total_cost_usd")) | .total_cost_usd) // empty' "$EXEC_FILE" || true)
+          ms=$(jq -r 'first(.. | objects | select(has("duration_ms")) | .duration_ms) // empty' "$EXEC_FILE" || true)
+          footer="iris"
+          [ -n "$model" ] && footer="$footer · $model"
+          [ -n "$cost" ] && footer=$(printf '%s · $%.2f' "$footer" "$cost")
+          [ -n "$ms" ] && footer="$footer · $((ms / 60000))m $((ms / 1000 % 60))s"
+          printf '\n\n<sub>%s · [run](%s)</sub>\n' "$footer" "$RUN_URL" >> /tmp/review.md
+          gh pr comment "$PR" -R "${{ github.repository }}" --body-file /tmp/review.md

--- a/.github/workflows/iris-review.yml
+++ b/.github/workflows/iris-review.yml
@@ -75,6 +75,14 @@ jobs:
         # For git merge-base and three-dot diffs against the target branch.
         run: git fetch --depth=200 origin develop:refs/remotes/origin/develop
 
+      - name: Use trusted agent config
+        # The checkout is the PR head, so a fork PR controls every file in it —
+        # including the command's allowed-tools and CLAUDE.md. The agent's
+        # instructions and permissions must come from develop, not the PR.
+        run: |
+          rm -rf .claude .mcp.json CLAUDE.md AGENTS.md
+          git checkout origin/develop -- .claude CLAUDE.md AGENTS.md
+
       - name: Save comment
         # The agent cannot read env vars — its Bash permissions deny variable
         # expansion. Files reach it through the Read tool instead.

--- a/.github/workflows/iris-review.yml
+++ b/.github/workflows/iris-review.yml
@@ -77,11 +77,14 @@ jobs:
 
       - name: Use trusted agent config
         # The checkout is the PR head, so a fork PR controls every file in it —
-        # including the command's allowed-tools and CLAUDE.md. The agent's
-        # instructions and permissions must come from develop, not the PR.
+        # including the command's allowed-tools and CLAUDE.md. Restore the agent
+        # config from the ref this workflow file ran from: develop on
+        # issue_comment, the dispatched branch on workflow_dispatch, and the
+        # merge commit on pull_request (same-repo authors only).
         run: |
+          git fetch --depth=1 origin ${{ github.sha }}
           rm -rf .claude .mcp.json CLAUDE.md AGENTS.md
-          git checkout origin/develop -- .claude CLAUDE.md AGENTS.md
+          git checkout ${{ github.sha }} -- .claude CLAUDE.md AGENTS.md
 
       - name: Save comment
         # The agent cannot read env vars — its Bash permissions deny variable

--- a/.github/workflows/iris-review.yml
+++ b/.github/workflows/iris-review.yml
@@ -55,11 +55,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
-        with:
-          # History so iris can inspect recent commits near the changed files.
-          fetch-depth: 200
-
       - name: Resolve PR number
         id: pr
         env:
@@ -68,16 +63,36 @@ jobs:
           FROM_ISSUE: ${{ github.event.issue.number }}
         run: echo "number=${DISPATCH:-${FROM_PR:-$FROM_ISSUE}}" >> "$GITHUB_OUTPUT"
 
+      - uses: actions/checkout@v4
+        with:
+          # issue_comment and workflow_dispatch check out the default branch by
+          # default; the head ref exists in the base repo for fork PRs too.
+          ref: refs/pull/${{ steps.pr.outputs.number }}/head
+          # History so iris can inspect recent commits near the changed files.
+          fetch-depth: 200
+
+      - name: Fetch develop
+        # For git merge-base and three-dot diffs against the target branch.
+        run: git fetch --depth=200 origin develop:refs/remotes/origin/develop
+
+      - name: Save comment
+        # The agent cannot read env vars — its Bash permissions deny variable
+        # expansion. Files reach it through the Read tool instead.
+        if: github.event_name == 'issue_comment'
+        env:
+          BODY: ${{ github.event.comment.body }}
+          AUTHOR: ${{ github.event.comment.user.login }}
+        run: |
+          printf '%s\n' "$BODY" > /tmp/iris-comment.txt
+          printf '%s\n' "$AUTHOR" > /tmp/iris-comment-author.txt
+
       - name: Run iris
         uses: anthropics/claude-code-action@v1
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          IRIS_EVENT: ${{ github.event_name }}
-          IRIS_COMMENT_BODY: ${{ github.event.comment.body }}
-          IRIS_COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           display_report: 'true'
-          prompt: "/iris-review ${{ steps.pr.outputs.number }}"
+          prompt: "/iris-review ${{ steps.pr.outputs.number }} --ci ${{ github.event_name }}"
           claude_args: ${{ vars.IRIS_MODEL != '' && format('--model {0}', vars.IRIS_MODEL) || '' }}


### PR DESCRIPTION
The first CI run reviewed but posted nothing. Fixes:

- The agent probed `$IRIS_EVENT` with Bash, and CI denies commands with variable expansion. The event name now rides in the prompt, the comment body and author in files under `/tmp`.
- `issue_comment` and `workflow_dispatch` checked out the default branch. Checkout now uses `refs/pull/N/head`, which exists for fork PRs too.
- The agent config (`.claude`, `CLAUDE.md`, `AGENTS.md`) is restored from the workflow's own ref, so a fork PR cannot rewrite the command or its allowed-tools.
- The workflow posts the review, not the agent. The post step appends model, cost and duration from the execution log, and posts with a GitHub App token when `IRIS_APP_ID` is set, so the comment can carry a bot identity. `gh pr comment` left the agent's allowed-tools.
- Phase 2 confirms by reading. The runner has no interpreter, so an unrunnable check becomes a "worth checking" question, never an assertion.

Tested: dispatch run [32709009225](https://github.com/frappe/insights/actions/runs/32709009225) posted one review comment on #896. The footer step landed after that run and is untested — worst case it degrades to a bare run link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)