### PR TITLE
ci: pin the release tooling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,18 @@ jobs:
         with:
           node-version: 24
       - name: Setup dependencies
+        # Pinned. Unpinned installs resolve the latest release on every run, so an
+        # upstream publish breaks the workflow with no commit on our side. It happened
+        # on 2026-08-24: conventionalcommits 10.4.0 needs conventional-changelog-writer
+        # 9, which release-notes-generator 14 does not ship. Preset 10 renders an empty
+        # body under writer 8, so the pin is on 9.
         run: |
-          npm install @semantic-release/git @semantic-release/exec @semantic-release/release-notes-generator conventional-changelog-conventionalcommits --no-save
+          npm install --no-save \
+            semantic-release@25.0.9 \
+            @semantic-release/git@11.0.1 \
+            @semantic-release/exec@7.1.0 \
+            @semantic-release/release-notes-generator@14.1.1 \
+            conventional-changelog-conventionalcommits@9.3.1
       - name: Record pre-release state
         id: pre_release
         env:
@@ -31,7 +41,7 @@ jobs:
       - name: Create Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npx semantic-release
+        run: npx --no semantic-release
       - name: Enrich release notes with author mentions
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The release workflow has failed since 2026-08-24 with `Missing helper: "conventional-changelog-conventionalcommits requires conventional-changelog-writer@9 or newer"` ([run](https://github.com/frappe/insights/actions/runs/32714347222)). `v3.12.6` was never cut, so #1308 and #1311 sit on `version-3` unreleased.

No commit of ours caused it. Every dependency was installed unpinned, so each run resolved whatever was latest that day. `conventionalcommits@10.4.0` was published seven hours after the last green run and needs `conventional-changelog-writer@9`, which `release-notes-generator@14` does not ship.

This pins all five, including `semantic-release` itself — `npx` was resolving that at run time too.

The preset pin is `9.3.1`, not `10.3.0`. Preset 10 does not fail under writer 8, but it renders an empty body. That has been true since 10.0.0 landed in June and went unnoticed because `enrich_release_notes.sh` replaces the body from the PR list.

Verified with `semantic-release --dry-run` against `version-3`: `generateNotes` completes, next version is `3.12.6`, and both pending fixes are listed.

Transitive dependencies still float. A lockfile the workflow installs from would close that, and is worth doing separately.