### PR TITLE
fix: honor Frappe DB socket configuration for Site DB connections

### DIFF
--- a/insights/insights/doctype/insights_data_source_v3/connectors/frappe_db.py
+++ b/insights/insights/doctype/insights_data_source_v3/connectors/frappe_db.py
@@ -10,11 +10,11 @@ from .mariadb import get_mariadb_connection
 from .postgresql import get_postgres_connection
 
 
-def get_frappedb_connection(data_source):
+def get_frappedb_connection(data_source, socket=None):
     if data_source.database_type == "PostgreSQL":
         return get_postgres_connection(data_source)
     else:
-        return get_mariadb_connection(data_source)
+        return get_mariadb_connection(data_source, socket=socket)
 
 
 def get_primary_data_source():
@@ -80,7 +80,10 @@ def get_sitedb_connection():
             pass
 
     primary = get_primary_data_source()
-    return get_frappedb_connection(primary)
+    # frappe.conf.db_socket is Frappe's own connection metadata (e.g. set by
+    # frappe/pilot's default setup), not a persisted Data Source field, so it
+    # is passed straight through rather than stored on the document.
+    return get_frappedb_connection(primary, socket=frappe.conf.db_socket)
 
 
 def is_frappe_db(data_source):

--- a/insights/insights/doctype/insights_data_source_v3/connectors/mariadb.py
+++ b/insights/insights/doctype/insights_data_source_v3/connectors/mariadb.py
@@ -18,12 +18,9 @@ def suppress_ibis_utc_warning(func):
 
 
 @suppress_ibis_utc_warning
-def get_mariadb_connection(data_source):
+def get_mariadb_connection(data_source, socket=None):
     password = data_source.get_password(raise_exception=False)
-    data_source.port = int(data_source.port or 3306)
-    return ibis.mysql.connect(
-        host=data_source.host,
-        port=data_source.port,
+    connection_kwargs = dict(
         user=data_source.username,
         password=password,
         database=data_source.database_name,
@@ -32,3 +29,13 @@ def get_mariadb_connection(data_source):
         ssl_mode="VERIFY_CA" if data_source.use_ssl else "DISABLED",
         connect_timeout=5,
     )
+
+    if socket:
+        # When a Unix socket is configured, use it instead of TCP host/port.
+        connection_kwargs["unix_socket"] = socket
+    else:
+        data_source.port = int(data_source.port or 3306)
+        connection_kwargs["host"] = data_source.host
+        connection_kwargs["port"] = data_source.port
+
+    return ibis.mysql.connect(**connection_kwargs)

--- a/insights/insights/doctype/insights_data_source_v3/test_insights_data_source_v3.py
+++ b/insights/insights/doctype/insights_data_source_v3/test_insights_data_source_v3.py
@@ -1,9 +1,93 @@
 # Copyright (c) 2024, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
 
-# import frappe
+from unittest.mock import MagicMock, patch
+
+import frappe
+from frappe import _dict
 from frappe.tests.utils import FrappeTestCase
+
+from insights.insights.doctype.insights_data_source_v3.connectors.frappe_db import (
+    get_primary_data_source,
+    get_sitedb_connection,
+)
+from insights.insights.doctype.insights_data_source_v3.connectors.mariadb import (
+    get_mariadb_connection,
+)
 
 
 class TestInsightsDataSourcev3(FrappeTestCase):
     pass
+
+
+class TestMariaDBSocketConnection(FrappeTestCase):
+    """Layer 1: get_mariadb_connection() honors an explicit socket argument."""
+
+    def _data_source(self, **overrides):
+        base = _dict(
+            username="_testuser",
+            database_name="_testdb",
+            use_ssl=False,
+            host="127.0.0.1",
+            port=3306,
+        )
+        base.update(overrides)
+        base.get_password = MagicMock(return_value="secret")
+        return base
+
+    @patch("insights.insights.doctype.insights_data_source_v3.connectors.mariadb.ibis")
+    def test_uses_unix_socket_when_configured(self, mock_ibis):
+        data_source = self._data_source()
+
+        get_mariadb_connection(data_source, socket="/tmp/mysql.sock")
+
+        mock_ibis.mysql.connect.assert_called_once()
+        _, kwargs = mock_ibis.mysql.connect.call_args
+        self.assertEqual(kwargs.get("unix_socket"), "/tmp/mysql.sock")
+        self.assertNotIn("host", kwargs)
+        self.assertNotIn("port", kwargs)
+
+    @patch("insights.insights.doctype.insights_data_source_v3.connectors.mariadb.ibis")
+    def test_falls_back_to_host_and_port_without_socket(self, mock_ibis):
+        data_source = self._data_source(host="127.0.0.1", port=3306)
+
+        get_mariadb_connection(data_source, socket=None)
+
+        mock_ibis.mysql.connect.assert_called_once()
+        _, kwargs = mock_ibis.mysql.connect.call_args
+        self.assertEqual(kwargs.get("host"), "127.0.0.1")
+        self.assertEqual(kwargs.get("port"), 3306)
+        self.assertNotIn("unix_socket", kwargs)
+
+
+class TestSiteDBSocketWiring(FrappeTestCase):
+    """Layer 2: frappe.conf.db_socket actually reaches the mariadb connector
+    for the Site DB data source, end to end through get_sitedb_connection()."""
+
+    def test_get_primary_data_source_does_not_carry_a_socket_field(self):
+        # socket is connection metadata, not a persisted Data Source field --
+        # get_primary_data_source() must not silently invent one.
+        site_db = get_primary_data_source()
+        self.assertNotIn("socket", site_db)
+
+    @patch("insights.insights.doctype.insights_data_source_v3.connectors.mariadb.ibis")
+    def test_sitedb_connection_passes_frappe_conf_db_socket(self, mock_ibis):
+        with patch.object(frappe.conf, "db_socket", "/tmp/mysql.sock"):
+            with patch.object(frappe.conf, "db_type", "mariadb"):
+                get_sitedb_connection()
+
+        mock_ibis.mysql.connect.assert_called_once()
+        _, kwargs = mock_ibis.mysql.connect.call_args
+        self.assertEqual(kwargs.get("unix_socket"), "/tmp/mysql.sock")
+
+    @patch("insights.insights.doctype.insights_data_source_v3.connectors.mariadb.ibis")
+    def test_sitedb_connection_uses_host_port_when_no_socket_configured(self, mock_ibis):
+        with patch.object(frappe.conf, "db_socket", None):
+            with patch.object(frappe.conf, "db_type", "mariadb"):
+                get_sitedb_connection()
+
+        mock_ibis.mysql.connect.assert_called_once()
+        _, kwargs = mock_ibis.mysql.connect.call_args
+        self.assertNotIn("unix_socket", kwargs)
+        self.assertIn("host", kwargs)
+        self.assertIn("port", kwargs)


### PR DESCRIPTION
Frappe supports MariaDB connections through a Unix socket via db_socket (e.g. frappe/pilot's default setup). The Insights Site DB connector previously built the Ibis MySQL connection using only host and port, which fails when the actual reachable port doesn't match the 3306 fallback.

socket is treated as connection metadata sourced from frappe.conf.db_socket, not a persisted Insights Data Source v3 field -- it's passed explicitly through get_frappedb_connection() / get_mariadb_connection() rather than stored on the document, since no such field is declared on the DocType.

Includes two layers of regression tests: get_mariadb_connection() honoring an explicit socket argument, and frappe.conf.db_socket actually reaching the connector end-to-end through get_sitedb_connection().