### PR TITLE
fix: tighten permission and input handling

### DIFF
--- a/insights/api/__init__.py
+++ b/insights/api/__init__.py
@@ -169,7 +169,8 @@ def _read_uploaded_table(db, file_path: str, ext: str):
         frappe.throw("Failed to read CSV data from uploaded file. Please try again.")
 
 
-@frappe.whitelist(allow_guest=True)
+@frappe.whitelist(allow_guest=True)  # nosemgrep - falls back to is_public() only after the
+# framework has already refused the caller
 @validate_type
 def get_doc(doctype: str, name: str | int):
     try:
@@ -200,7 +201,8 @@ def _execute_doc_method(doc, method: str, args: dict | None = None, ignore_permi
     return response
 
 
-@frappe.whitelist(allow_guest=True)
+@frappe.whitelist(allow_guest=True)  # nosemgrep - guests reach only public documents, and only
+# the methods and arguments PUBLIC_METHOD_ARGS names
 def run_doc_method(method: str, docs: dict | str, args: dict | None = None):
     doc = frappe.parse_json(docs)
     doctype = doc.get("doctype")

--- a/insights/api/__init__.py
+++ b/insights/api/__init__.py
@@ -223,18 +223,40 @@ def run_doc_method(method: str, docs: dict | str, args: dict | None = None):
         doc = frappe.get_doc(doctype, name)
         frappe.flags.insights_for_public_access = True
         try:
-            return _execute_doc_method(doc, method, args, ignore_permissions=True)
+            return _execute_doc_method(
+                doc, method, public_method_args(doctype, method, args), ignore_permissions=True
+            )
         finally:
             frappe.flags.insights_for_public_access = False
 
 
+# A public execution runs what the publisher published, so the public surface is
+# a set of parameter names, not a set of method names. The query builder passes
+# its own parameters to these methods - `active_operation_idx` drives the step
+# preview, and reshapes the query - and those are for the builder, not for the
+# published document.
+PUBLIC_METHOD_ARGS = {
+    ("Insights Query v3", "execute"): {"adhoc_filters", "page", "page_size"},
+    ("Insights Query v3", "download_results"): {"format", "adhoc_filters"},
+    ("Insights Dashboard v3", "get_distinct_column_values"): {
+        "query",
+        "column_name",
+        "search_term",
+        "adhoc_filters",
+    },
+    ("Insights Dashboard v3", "track_view"): set(),
+}
+
+
 def is_public_method(doctype: str, method: str):
-    public_methods = {
-        "Insights Query v3": ["execute", "download_results"],
-        "Insights Dashboard v3": ["get_distinct_column_values", "track_view"],
-    }
+    return (doctype, method) in PUBLIC_METHOD_ARGS
 
-    if doctype in public_methods and method in public_methods[doctype]:
-        return True
 
-    return False
+def public_method_args(doctype: str, method: str, args: dict | str | None):
+    """The caller's args, less anything the public contract does not name.
+
+    Dropped rather than refused, so the published document still renders.
+    """
+    allowed = PUBLIC_METHOD_ARGS[(doctype, method)]
+    args = frappe.parse_json(args) or {}
+    return {name: value for name, value in args.items() if name in allowed}

--- a/insights/api/user.py
+++ b/insights/api/user.py
@@ -10,6 +10,9 @@ from insights.insights.doctype.insights_team.insights_team import (
     get_teams as get_user_teams,
 )
 from insights.insights.doctype.insights_team.insights_team import is_admin
+from insights.insights.doctype.insights_user_invitation.insights_user_invitation import (
+    get_invitation_by_key,
+)
 from insights.permissions import get_insights_users
 from insights.utils import get_app_url
 
@@ -225,18 +228,29 @@ def accept_invitation(key: str):
     if not key:
         frappe.throw("Invalid or expired key")
 
-    invitation_name = frappe.db.exists("Insights User Invitation", {"key": key})
+    invitation_name = get_invitation_by_key(key)
     if not invitation_name:
         frappe.throw("Invalid or expired key")
 
     invitation = frappe.get_doc("Insights User Invitation", invitation_name)
-    invitation.accept()
+    account_was_created = invitation.accept()
     invitation.reload()
 
-    if invitation.status == "Accepted":
-        frappe.local.login_manager.login_as(invitation.email)
-        frappe.local.response["type"] = "redirect"
-        frappe.local.response["location"] = get_app_url()
+    if invitation.status != "Accepted":
+        return
+
+    frappe.local.response["type"] = "redirect"
+
+    if not account_was_created:
+        # the address already had an account. The invitation grants it access to
+        # Insights; signing in is for the account holder to do.
+        frappe.local.response["location"] = "/login"
+        return
+
+    # a new account has no password yet, so the invitation link is how the
+    # invitee gets in the first time
+    frappe.local.login_manager.login_as(invitation.email)
+    frappe.local.response["location"] = get_app_url()
 
 
 @insights_whitelist(role="Insights Admin")

--- a/insights/api/user.py
+++ b/insights/api/user.py
@@ -222,7 +222,8 @@ def add_insights_user(user: str):
     raise NotImplementedError
 
 
-@frappe.whitelist(allow_guest=True)
+@frappe.whitelist(allow_guest=True)  # nosemgrep - an invitee follows this link before they have
+# an account, so it cannot require a session
 @validate_type
 def accept_invitation(key: str):
     if not key:

--- a/insights/insights/doctype/insights_chart_v3/insights_chart_v3.py
+++ b/insights/insights/doctype/insights_chart_v3/insights_chart_v3.py
@@ -39,6 +39,11 @@ class InsightsChartv3(Document):
         d.read_only = not self.has_permission("write")
         return d
 
+    def validate(self):
+        from insights.permissions import check_chart_query_access
+
+        check_chart_query_access(self)
+
     def before_save(self):
         self.set_data_query()
 

--- a/insights/insights/doctype/insights_dashboard_v3/insights_dashboard_v3.py
+++ b/insights/insights/doctype/insights_dashboard_v3/insights_dashboard_v3.py
@@ -38,6 +38,11 @@ class InsightsDashboardv3(Document):
         workbook: DF.Link
     # end: auto-generated types
 
+    def validate(self):
+        from insights.permissions import check_dashboard_chart_access
+
+        check_dashboard_chart_access(self)
+
     @frappe.whitelist()
     def track_view(self):
         view_log = frappe.qb.DocType("View Log")
@@ -208,6 +213,13 @@ class InsightsDashboardv3(Document):
         is_public = data.get("is_public")
         is_shared_with_organization = data.get("is_shared_with_organization")
         people_with_access = data.get("people_with_access") or []
+
+        # this writes is_public with db_set, so validate() never runs. Check
+        # before any share is applied, so a refusal leaves nothing half-done.
+        if is_public:
+            from insights.permissions import check_dashboard_chart_access
+
+            check_dashboard_chart_access(self)
 
         existing_shares = frappe.get_all(
             "DocShare",

--- a/insights/insights/doctype/insights_dashboard_v3/insights_dashboard_v3.py
+++ b/insights/insights/doctype/insights_dashboard_v3/insights_dashboard_v3.py
@@ -38,6 +38,11 @@ class InsightsDashboardv3(Document):
         workbook: DF.Link
     # end: auto-generated types
 
+    def before_validate(self):
+        # linked_charts is derived from items, so build it before anything
+        # validates it - validate() runs before before_save()
+        self.set_linked_charts()
+
     def validate(self):
         from insights.permissions import check_dashboard_chart_access
 
@@ -89,7 +94,6 @@ class InsightsDashboardv3(Document):
         )
 
     def before_save(self):
-        self.set_linked_charts()
         self.enqueue_update_dashboard_preview()
 
     def set_linked_charts(self):

--- a/insights/insights/doctype/insights_data_source_v3/ibis/utils.py
+++ b/insights/insights/doctype/insights_data_source_v3/ibis/utils.py
@@ -11,6 +11,46 @@ from frappe.utils.safe_exec import SERVER_SCRIPT_FILE_PREFIX, safe_exec
 from ibis import selectors as s
 from jedi import Script
 
+# An expression describes a query. It does not move data in or out, so the
+# context holds no name that opens a path, a URL or a backend connection.
+# Expressed as a rule rather than a list, so an ibis release that adds
+# `read_avro` or `to_avro` needs no edit here. Attribute names only -
+# `to_inr(amount)` is a plain name and stays available.
+IO_ATTRIBUTE_PREFIXES = ("read_", "to_", "from_")
+IO_ATTRIBUTE_NAMES = frozenset(
+    {
+        "connect",
+        "get_backend",
+        "set_backend",
+        "register",
+    }
+)
+
+
+def is_io_attribute(name: str) -> bool:
+    return name in IO_ATTRIBUTE_NAMES or name.startswith(IO_ATTRIBUTE_PREFIXES)
+
+
+def assert_expression_has_no_io(expression: str) -> None:
+    """Refuse an expression that names an I/O attribute.
+
+    Checked in the source rather than at evaluation: RestrictedPython compiles
+    `a.b` to a guard call carrying the literal `b` and leaves no `getattr`, so an
+    attribute name is always spelled out here.
+    """
+    try:
+        tree = ast.parse(expression)
+    except SyntaxError:
+        # the caller reports syntax errors with a line and a column
+        return
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Attribute) and is_io_attribute(node.attr):
+            frappe.throw(
+                f"'{node.attr}' is not available in an expression",
+                frappe.PermissionError,
+            )
+
 
 def get_functions():
     import insights.insights.doctype.insights_data_source_v3.ibis.functions as functions
@@ -73,10 +113,6 @@ def get_functions():
         "range",
         "range_window",
         "rank",
-        "read_csv",
-        "read_delta",
-        "read_json",
-        "read_parquet",
         "row_number",
         "rows_window",
         "schema",
@@ -85,7 +121,6 @@ def get_functions():
         "table",
         "time",
         "timestamp",
-        "to_sql",
         "today",
         "trailing_range_window",
         "trailing_window",
@@ -96,6 +131,8 @@ def get_functions():
     )
     context.ibis = frappe._dict()
     for attr in allowed_ibis_attributes:
+        if is_io_attribute(attr):
+            raise ValueError(f"'{attr}' is an I/O function and does not belong in an expression")
         context.ibis[attr] = getattr(ibis, attr)
 
     return context
@@ -423,6 +460,9 @@ def validate_expression(expression: str, column_options: str):
     syntax_result = validate_syntax(expression)
     if not syntax_result["is_valid"]:
         return syntax_result
+
+    # validate_types() below evaluates the expression, so the same rule applies
+    assert_expression_has_no_io(expression)
 
     tree = ast.parse(expression)
     name_result = validate_names(tree, columns)

--- a/insights/insights/doctype/insights_data_source_v3/ibis_utils.py
+++ b/insights/insights/doctype/insights_data_source_v3/ibis_utils.py
@@ -31,7 +31,7 @@ from insights.utils import create_execution_log
 from insights.utils import deep_convert_dict_to_dict as _dict
 
 from .ibis.functions import fiscal_year_start, week_start
-from .ibis.utils import get_functions
+from .ibis.utils import assert_expression_has_no_io, get_functions
 
 try:
     from frappe.concurrency_limiter import concurrent_limit
@@ -1060,6 +1060,8 @@ def exec_with_return(
     _globals: dict | None = None,
     _locals: dict | None = None,
 ):
+    assert_expression_has_no_io(script)
+
     tree = ast.parse(script)
 
     if not tree.body:

--- a/insights/insights/doctype/insights_data_source_v3/test_expression_io.py
+++ b/insights/insights/doctype/insights_data_source_v3/test_expression_io.py
@@ -1,0 +1,91 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
+# See license.txt
+"""An expression describes a query, so it reaches no path, URL or backend.
+
+`get_functions()` builds the context an expression evaluates in. Several ibis
+top-level names are readers and writers, and the objects the context hands out
+carry output methods of their own, so the boundary is easy to widen by accident.
+
+The rule is held here rather than a list of names, so an ibis upgrade that adds
+a reader does not quietly become reachable.
+"""
+
+import os
+import tempfile
+
+import frappe
+import ibis
+from frappe.tests import UnitTestCase
+
+from insights.insights.doctype.insights_data_source_v3.ibis.utils import get_functions
+from insights.insights.doctype.insights_data_source_v3.ibis_utils import exec_with_return
+
+
+class TestExpressionIsolation(UnitTestCase):
+    def evaluate(self, expression):
+        return exec_with_return(expression, dict(get_functions()))
+
+    def assert_refused(self, expression):
+        with self.assertRaises(frappe.PermissionError):
+            self.evaluate(expression)
+
+    # --- the rule covers what ibis actually ships ---
+
+    def test_the_rule_covers_every_io_name_ibis_exports(self):
+        """The rule, not the names: an ibis upgrade must not need an edit here."""
+        from insights.insights.doctype.insights_data_source_v3.ibis.utils import is_io_attribute
+
+        io_names = [
+            name
+            for name in dir(ibis)
+            if not name.startswith("_")
+            and (name.startswith(("read_", "to_", "from_")) or name in ("connect", "set_backend"))
+        ]
+        self.assertTrue(io_names, "expected ibis to export some I/O names")
+        for name in io_names:
+            self.assertTrue(is_io_attribute(name), f"{name} is I/O but the rule allows it")
+
+    def test_no_io_name_is_reachable_from_the_context(self):
+        """Every namespace an expression reaches by attribute must be clean.
+
+        The rule is attribute-only on purpose, so the flat names are not checked:
+        `to_inr(amount)` is a call on a plain name and stays legal.
+        """
+        from insights.insights.doctype.insights_data_source_v3.ibis.utils import is_io_attribute
+
+        context = get_functions()
+        namespaces = {"ibis": context.ibis, "s": context.s, "selectors": context.selectors}
+        for namespace, names in namespaces.items():
+            for name in names:
+                self.assertFalse(is_io_attribute(name), f"{namespace}.{name} is exposed to expressions")
+
+    # --- the readers and writers themselves ---
+
+    def test_a_reader_is_refused(self):
+        self.assert_refused("ibis.read_csv('/tmp/does-not-matter.csv')")
+        self.assert_refused("ibis.read_json('/tmp/does-not-matter.csv')")
+        self.assert_refused("ibis.read_parquet('/tmp/does-not-matter.csv')")
+        self.assert_refused("ibis.read_delta('/tmp/does-not-matter.csv')")
+
+    def test_a_reader_given_a_url_is_refused(self):
+        self.assert_refused("ibis.read_csv('http://example.invalid/x.csv')")
+
+    def test_a_writer_is_refused(self):
+        """The context carries table and column objects, so an output method on
+        one of them is as reachable as a top-level name."""
+        target = os.path.join(tempfile.gettempdir(), "insights_expression_io_test.csv")
+        if os.path.exists(target):
+            os.remove(target)
+        self.assert_refused(f"ibis.memtable({{'a': [1, 2]}}).to_csv({target!r})")
+        self.assertFalse(os.path.exists(target))
+
+    def test_the_rule_holds_for_a_multi_statement_script(self):
+        """A single expression takes the safe_eval branch, several take safe_exec."""
+        self.assert_refused("path = '/tmp/does-not-matter.csv'\nibis.read_csv(path)")
+
+    # --- the legitimate path still works ---
+
+    def test_pure_expressions_still_evaluate(self):
+        self.assertIsNotNone(self.evaluate("ibis.literal(1) + 1"))
+        self.assertIsNotNone(self.evaluate("ibis.ifelse(ibis.literal(True), 1, 2)"))
+        self.assertIsNotNone(self.evaluate("ibis.coalesce(ibis.null(), ibis.literal(2))"))

--- a/insights/insights/doctype/insights_user_invitation/insights_user_invitation.json
+++ b/insights/insights/doctype/insights_user_invitation/insights_user_invitation.json
@@ -22,9 +22,12 @@
    "reqd": 1
   },
   {
+   "description": "SHA-256 of the key mailed to the invitee. The key itself is not stored.",
    "fieldname": "key",
    "fieldtype": "Data",
-   "label": "Key"
+   "hidden": 1,
+   "label": "Key Hash",
+   "read_only": 1
   },
   {
    "fieldname": "invited_by",
@@ -55,22 +58,13 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-11-05 13:59:33.681447",
+ "modified": "2026-08-25 00:00:00.000000",
  "modified_by": "Administrator",
  "module": "Insights",
  "name": "Insights User Invitation",
  "naming_rule": "Autoincrement",
  "owner": "Administrator",
  "permissions": [
-  {
-   "email": 1,
-   "export": 1,
-   "print": 1,
-   "read": 1,
-   "report": 1,
-   "role": "Insights User",
-   "share": 1
-  },
   {
    "create": 1,
    "delete": 1,

--- a/insights/insights/doctype/insights_user_invitation/insights_user_invitation.py
+++ b/insights/insights/doctype/insights_user_invitation/insights_user_invitation.py
@@ -3,9 +3,24 @@
 
 import frappe
 from frappe.model.document import Document
-from frappe.utils import add_days, get_datetime, now, validate_email_address
+from frappe.utils import add_days, get_datetime, now, sha256_hash, validate_email_address
 
 EXPIRY_DAYS = 1
+KEY_LENGTH = 32
+
+
+def hash_key(key: str) -> str:
+    return sha256_hash(key)
+
+
+def get_invitation_by_key(key: str) -> str | None:
+    """The name of the invitation a mailed key opens, or None.
+
+    The key is stored as its hash, so the lookup hashes before it matches.
+    """
+    if not key:
+        return None
+    return frappe.db.exists("Insights User Invitation", {"key": hash_key(key)})
 
 
 class InsightsUserInvitation(Document):
@@ -33,7 +48,9 @@ class InsightsUserInvitation(Document):
 
     def before_insert(self):
         validate_email_address(self.email, True)
-        self.key = frappe.generate_hash(length=12)
+        # the key travels in the invitation email; only its hash is stored
+        self._plain_key = frappe.generate_hash(length=KEY_LENGTH)
+        self.key = hash_key(self._plain_key)
         self.invited_by = frappe.session.user
         self.status = "Pending"
 
@@ -42,7 +59,7 @@ class InsightsUserInvitation(Document):
 
     def invite_via_email(self):
         invite_link = frappe.utils.get_url(
-            f"/api/method/insights.api.user.accept_invitation?key={self.key}"
+            f"/api/method/insights.api.user.accept_invitation?key={self._plain_key}"
         )
         if frappe.local.dev_server:
             print(f"Invite link for {self.email}: {invite_link}")
@@ -75,7 +92,7 @@ class InsightsUserInvitation(Document):
         if self.status == "Accepted":
             frappe.throw("Invitation already accepted")
 
-        user = self.create_user_if_not_exists()
+        user, account_was_created = self.create_user_if_not_exists()
         user.append_roles("Insights User")
         user.save(ignore_permissions=True)
 
@@ -83,16 +100,24 @@ class InsightsUserInvitation(Document):
         self.accepted_at = frappe.utils.now()
         self.save(ignore_permissions=True)
 
+        return account_was_created
+
     def create_user_if_not_exists(self):
-        if not frappe.db.exists("User", self.email):
-            first_name = self.email.split("@")[0].title()
-            user = frappe.get_doc(
-                doctype="User",
-                user_type="Website User",
-                email=self.email,
-                send_welcome_email=0,
-                first_name=first_name,
-            ).insert(ignore_permissions=True)
-        else:
-            user = frappe.get_doc("User", self.email)
-        return user
+        """The invited user, and whether this acceptance is what created it.
+
+        An invitation to an address that already has an account grants that
+        account access to Insights. It says nothing about who holds the key, so
+        the caller needs to tell the two cases apart.
+        """
+        if frappe.db.exists("User", self.email):
+            return frappe.get_doc("User", self.email), False
+
+        first_name = self.email.split("@")[0].title()
+        user = frappe.get_doc(
+            doctype="User",
+            user_type="Website User",
+            email=self.email,
+            send_welcome_email=0,
+            first_name=first_name,
+        ).insert(ignore_permissions=True)
+        return user, True

--- a/insights/insights/doctype/insights_user_invitation/test_insights_user_invitation.py
+++ b/insights/insights/doctype/insights_user_invitation/test_insights_user_invitation.py
@@ -7,6 +7,8 @@ as a hash, so the stored value is not the credential, and acceptance signs in
 only the account it just created.
 """
 
+from unittest.mock import patch
+
 import frappe
 from frappe.tests import IntegrationTestCase
 
@@ -14,9 +16,11 @@ from insights.api.user import accept_invitation
 
 
 def make_invitation(email):
+    """Insert an invitation without needing an outgoing email account."""
     invitation = frappe.new_doc("Insights User Invitation")
     invitation.email = email
-    invitation.insert(ignore_permissions=True)
+    with patch.object(frappe, "sendmail"):
+        invitation.insert(ignore_permissions=True)
     return invitation
 
 
@@ -28,6 +32,17 @@ class TestInvitationKeyIsStoredHashed(IntegrationTestCase):
         stored = frappe.db.get_value("Insights User Invitation", invitation.name, "key")
         self.assertNotEqual(stored, invitation._plain_key)
         self.assertEqual(stored, hash_key(invitation._plain_key))
+
+    def test_the_invitation_email_carries_the_key(self):
+        """The mailed link has to hold the key itself, or nothing can redeem it."""
+        with patch.object(frappe, "sendmail") as sendmail:
+            invitation = frappe.new_doc("Insights User Invitation")
+            invitation.email = "mailed-key@example.com"
+            invitation.insert(ignore_permissions=True)
+
+        link = sendmail.call_args.kwargs["args"]["invite_link"]
+        self.assertIn(invitation._plain_key, link)
+        self.assertNotIn(invitation.key, link)
 
     def test_the_stored_value_is_not_the_key(self):
         """What the row holds cannot be redeemed; what was mailed can."""

--- a/insights/insights/doctype/insights_user_invitation/test_insights_user_invitation.py
+++ b/insights/insights/doctype/insights_user_invitation/test_insights_user_invitation.py
@@ -1,9 +1,105 @@
 # Copyright (c) 2024, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
+"""An invitation grants access to Insights. It does not sign anyone in.
 
-# import frappe
-from frappe.tests.utils import FrappeTestCase
+Two rules, held together because either alone is incomplete: the key is stored
+as a hash, so the stored value is not the credential, and acceptance signs in
+only the account it just created.
+"""
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from insights.api.user import accept_invitation
 
 
-class TestInsightsUserInvitation(FrappeTestCase):
-    pass
+def make_invitation(email):
+    invitation = frappe.new_doc("Insights User Invitation")
+    invitation.email = email
+    invitation.insert(ignore_permissions=True)
+    return invitation
+
+
+class TestInvitationKeyIsStoredHashed(IntegrationTestCase):
+    def test_the_key_is_stored_hashed(self):
+        from insights.insights.doctype.insights_user_invitation.insights_user_invitation import hash_key
+
+        invitation = make_invitation("hashed-key@example.com")
+        stored = frappe.db.get_value("Insights User Invitation", invitation.name, "key")
+        self.assertNotEqual(stored, invitation._plain_key)
+        self.assertEqual(stored, hash_key(invitation._plain_key))
+
+    def test_the_stored_value_is_not_the_key(self):
+        """What the row holds cannot be redeemed; what was mailed can."""
+        from insights.insights.doctype.insights_user_invitation.insights_user_invitation import (
+            get_invitation_by_key,
+        )
+
+        invitation = make_invitation("inert-key@example.com")
+        stored = frappe.db.get_value("Insights User Invitation", invitation.name, "key")
+        self.assertIsNone(get_invitation_by_key(stored))
+        self.assertEqual(get_invitation_by_key(invitation._plain_key), invitation.name)
+
+    def test_only_admins_hold_a_grant_on_the_doctype(self):
+        """The users screen reads invitations through an admin-only endpoint, so
+        no other role needs this doctype."""
+        roles = frappe.get_all(
+            "DocPerm",
+            filters={"parent": "Insights User Invitation", "role": "Insights User"},
+            pluck="name",
+        )
+        self.assertEqual(roles, [])
+
+
+class TestInvitationDoesNotAuthenticate(IntegrationTestCase):
+    def setUp(self):
+        # there is no login manager outside a request, so record the call instead
+        self.logged_in_as = []
+        frappe.local.login_manager = frappe._dict(login_as=self.logged_in_as.append)
+        self.addCleanup(self.drop_login_manager)
+
+    def drop_login_manager(self):
+        frappe.local.login_manager = None
+
+    def redeem(self, invitation):
+        # older rows stored the key itself
+        key = getattr(invitation, "_plain_key", invitation.key)
+        frappe.local.response = frappe._dict()
+        accept_invitation(key=key)
+        return frappe.local.response
+
+    def test_an_existing_account_is_not_signed_in(self):
+        """The invitation still applies; the sign-in is left to the account holder."""
+        email = "existing-account@example.com"
+        if not frappe.db.exists("User", email):
+            frappe.get_doc(doctype="User", email=email, first_name="Existing", send_welcome_email=0).insert(
+                ignore_permissions=True
+            )
+
+        invitation = make_invitation(email)
+        response = self.redeem(invitation)
+
+        self.assertEqual(self.logged_in_as, [])
+        self.assertEqual(response.location, "/login")
+        # the invitation still did its job
+        self.assertEqual(
+            frappe.db.get_value("Insights User Invitation", invitation.name, "status"), "Accepted"
+        )
+        self.assertIn("Insights User", frappe.get_roles(email))
+
+    def test_a_new_invitee_is_signed_in(self):
+        """A new invitee has no password yet, so the link is how they first get in."""
+        email = "brand-new-invitee@example.com"
+        if frappe.db.exists("User", email):
+            frappe.delete_doc("User", email, force=True, ignore_permissions=True)
+
+        invitation = make_invitation(email)
+        response = self.redeem(invitation)
+
+        self.assertEqual(self.logged_in_as, [email])
+        self.assertNotEqual(response.location, "/login")
+        self.assertIn("Insights User", frappe.get_roles(email))
+
+    def test_an_unknown_key_is_refused(self):
+        with self.assertRaises(frappe.ValidationError):
+            accept_invitation(key="not-a-real-key")

--- a/insights/patches.txt
+++ b/insights/patches.txt
@@ -15,3 +15,4 @@ insights.patches.backfill_query_references
 execute:frappe.db.set_single_value("Insights Settings", "allow_download", 1)
 insights.patches.requalify_workbook_templates
 insights.patches.strip_default_schema_from_table_names
+insights.patches.hash_invitation_keys

--- a/insights/patches/hash_invitation_keys.py
+++ b/insights/patches/hash_invitation_keys.py
@@ -1,0 +1,27 @@
+import frappe
+
+from insights.insights.doctype.insights_user_invitation.insights_user_invitation import hash_key
+
+
+def execute():
+    """Replace every stored invitation key with its hash.
+
+    Hashing in place keeps the links already mailed working: an incoming key
+    hashes to what is now stored.
+    """
+    invitations = frappe.get_all(
+        "Insights User Invitation",
+        filters={"key": ["is", "set"]},
+        fields=["name", "key"],
+    )
+    for invitation in invitations:
+        # a re-run must not hash a hash
+        if len(invitation.key) == 64:
+            continue
+        frappe.db.set_value(
+            "Insights User Invitation",
+            invitation.name,
+            "key",
+            hash_key(invitation.key),
+            update_modified=False,
+        )

--- a/insights/permissions.py
+++ b/insights/permissions.py
@@ -409,6 +409,42 @@ class InsightsPermissions:
         return frappe.qb.from_(Resource).select(Resource.resource_name.as_("name")).where(condition)
 
 
+def check_chart_query_access(chart):
+    """A chart may only point at a query its author can read.
+
+    The link is a grant, not a reference: `_build_query_permission_query` gives
+    read on every query linked from a chart the caller can read, and
+    `is_public_query` treats a link from a public chart the same way. So the link
+    has to be checked where it is written, or it widens the author's own access.
+
+    Only a changed link is checked. An existing chart stays saveable by anyone
+    who may already read it, whose access to the query runs through this link.
+    """
+    if not chart.query or not chart.has_value_changed("query"):
+        return
+
+    if not frappe.has_permission("Insights Query v3", ptype="read", doc=chart.query):
+        frappe.throw(
+            frappe._("You do not have access to the query this chart is built on"),
+            frappe.PermissionError,
+        )
+
+
+def check_dashboard_chart_access(dashboard):
+    """The same rule one level up.
+
+    `_build_chart_permission_query` grants read on every chart placed on a
+    dashboard the caller can read, and `get_public_charts` covers every chart on
+    a public dashboard. Naming a chart here is the same kind of grant.
+    """
+    for row in dashboard.linked_charts:
+        if not frappe.has_permission("Insights Chart v3", ptype="read", doc=row.chart):
+            frappe.throw(
+                frappe._("You do not have access to one of the charts on this dashboard"),
+                frappe.PermissionError,
+            )
+
+
 def has_doc_permission(doc, ptype, user):
     return InsightsPermissions(user).has_doc_permission(doc, ptype)
 

--- a/insights/tests/test_public_access.py
+++ b/insights/tests/test_public_access.py
@@ -102,19 +102,36 @@ class TestLinkRequiresReadAccess(InsightsIntegrationTestCase):
 
     def test_a_dashboard_cannot_hold_an_unreadable_chart(self):
         """A chart on a dashboard the caller can read is readable, so naming one
-        here is the same grant one level up."""
-        with self.as_user(OTHER):
-            dashboard = frappe.get_doc(
+        here is the same grant one level up.
+
+        Written through `items`, which is what the client sends. `linked_charts`
+        is derived from it, so a check that reads the stored rows would see the
+        state before this save.
+        """
+        with self.as_user(OTHER), self.assertRaises(frappe.PermissionError):
+            frappe.get_doc(
                 {
                     "doctype": DT.DASHBOARD,
                     "title": "Dashboard In Other Workbook",
                     "workbook": self.other_workbook,
+                    "items": [{"id": "chart-1", "type": "chart", "chart": self.owner_chart}],
+                }
+            ).insert()
+
+    def test_a_dashboard_cannot_take_on_an_unreadable_chart(self):
+        """The same on update: an existing dashboard gains an item."""
+        with self.as_user(OTHER):
+            dashboard = frappe.get_doc(
+                {
+                    "doctype": DT.DASHBOARD,
+                    "title": "Growing Dashboard",
+                    "workbook": self.other_workbook,
                     "items": [],
                 }
-            )
-            dashboard.append("linked_charts", {"chart": self.owner_chart})
+            ).insert()
+            dashboard.items = [{"id": "chart-1", "type": "chart", "chart": self.owner_chart}]
             with self.assertRaises(frappe.PermissionError):
-                dashboard.insert()
+                dashboard.save()
 
     def test_publishing_your_own_chart_still_works(self):
         with self.as_user(OWNER):
@@ -130,11 +147,10 @@ class TestLinkRequiresReadAccess(InsightsIntegrationTestCase):
                     "doctype": DT.DASHBOARD,
                     "title": "Legitimate Dashboard",
                     "workbook": self.owner_workbook,
-                    "items": [],
+                    "items": [{"id": "chart-1", "type": "chart", "chart": self.owner_chart}],
                 }
-            )
-            dashboard.append("linked_charts", {"chart": self.owner_chart})
-            dashboard.insert()
+            ).insert()
+            self.assertEqual([row.chart for row in dashboard.linked_charts], [self.owner_chart])
             dashboard.update_access(
                 {"is_public": 1, "is_shared_with_organization": 0, "people_with_access": []}
             )

--- a/insights/tests/test_public_access.py
+++ b/insights/tests/test_public_access.py
@@ -1,0 +1,191 @@
+"""A link names what its author can read, and a public document runs as published.
+
+Two rules over the same boundary. A chart's `query` and a dashboard's
+`linked_charts` are grants: the permission queries in `insights.permissions` read
+a link as access, and `insights.api.shared` reads a link from a public document
+the same way. So a link is checked where it is written.
+
+Once a document is public, the arguments its methods accept come from the
+request. `insights.api.PUBLIC_METHOD_ARGS` names them, so the query builder's own
+parameters stay with the builder.
+"""
+
+import frappe
+
+from insights.tests.base import InsightsIntegrationTestCase
+from insights.tests.factories import (
+    DT,
+    create_test_chart,
+    create_test_query,
+    create_test_workbook,
+    delete_users,
+)
+from insights.tests.permissions_utils import USER_1, USER_2, create_test_users
+
+OWNER = USER_1
+OTHER = USER_2
+
+
+class TestLinkRequiresReadAccess(InsightsIntegrationTestCase):
+    """A chart's query and a dashboard's charts are grants, so both are checked."""
+
+    @classmethod
+    def before_class(cls):
+        create_test_users()
+        cls.owner_workbook = create_test_workbook(OWNER, title="Owner Workbook").name
+        cls.owner_query = create_test_query(OWNER, cls.owner_workbook, title="Owner Query").name
+        cls.owner_chart = create_test_chart(
+            OWNER, cls.owner_workbook, query=cls.owner_query, title="Owner Chart"
+        ).name
+        cls.other_workbook = create_test_workbook(OTHER, title="Other Workbook").name
+
+    @classmethod
+    def after_class(cls):
+        for doctype, name in (
+            (DT.WORKBOOK, cls.owner_workbook),
+            (DT.WORKBOOK, cls.other_workbook),
+        ):
+            frappe.delete_doc(doctype, name, force=True, ignore_permissions=True)
+        delete_users(OWNER, OTHER)
+
+    def test_a_query_in_another_workbook_is_not_readable(self):
+        """The baseline the rules below are measured against."""
+        with self.as_user(OTHER):
+            self.assertFalse(frappe.has_permission(DT.QUERY, ptype="read", doc=self.owner_query))
+
+    def test_a_chart_cannot_link_an_unreadable_query(self):
+        """A chart the caller owns makes its query readable, so the check cannot
+        wait for the chart to be published."""
+        with self.as_user(OTHER), self.assertRaises(frappe.PermissionError):
+            frappe.get_doc(
+                {
+                    "doctype": DT.CHART,
+                    "title": "Chart In Other Workbook",
+                    "workbook": self.other_workbook,
+                    "query": self.owner_query,
+                    "chart_type": "Bar",
+                    "config": {},
+                }
+            ).insert()
+
+    def test_a_public_chart_cannot_link_an_unreadable_query(self):
+        """Public in a single insert, so the check runs before the flag lands."""
+        with self.as_user(OTHER), self.assertRaises(frappe.PermissionError):
+            frappe.get_doc(
+                {
+                    "doctype": DT.CHART,
+                    "title": "Public Chart In Other Workbook",
+                    "workbook": self.other_workbook,
+                    "query": self.owner_query,
+                    "chart_type": "Bar",
+                    "is_public": 1,
+                    "config": {},
+                }
+            ).insert()
+
+    def test_an_existing_chart_cannot_be_repointed(self):
+        """A link written on update is checked the same as one written on insert."""
+        with self.as_user(OTHER):
+            chart = frappe.get_doc(
+                {
+                    "doctype": DT.CHART,
+                    "title": "Repointed Chart",
+                    "workbook": self.other_workbook,
+                    "chart_type": "Bar",
+                    "config": {},
+                }
+            ).insert()
+            chart.query = self.owner_query
+            chart.is_public = 1
+            with self.assertRaises(frappe.PermissionError):
+                chart.save()
+
+    def test_a_dashboard_cannot_hold_an_unreadable_chart(self):
+        """A chart on a dashboard the caller can read is readable, so naming one
+        here is the same grant one level up."""
+        with self.as_user(OTHER):
+            dashboard = frappe.get_doc(
+                {
+                    "doctype": DT.DASHBOARD,
+                    "title": "Dashboard In Other Workbook",
+                    "workbook": self.other_workbook,
+                    "items": [],
+                }
+            )
+            dashboard.append("linked_charts", {"chart": self.owner_chart})
+            with self.assertRaises(frappe.PermissionError):
+                dashboard.insert()
+
+    def test_publishing_your_own_chart_still_works(self):
+        with self.as_user(OWNER):
+            chart = frappe.get_doc(DT.CHART, self.owner_chart)
+            chart.is_public = 1
+            chart.save()
+            self.assertTrue(frappe.db.get_value(DT.CHART, chart.name, "is_public"))
+
+    def test_publishing_your_own_dashboard_still_works(self):
+        with self.as_user(OWNER):
+            dashboard = frappe.get_doc(
+                {
+                    "doctype": DT.DASHBOARD,
+                    "title": "Legitimate Dashboard",
+                    "workbook": self.owner_workbook,
+                    "items": [],
+                }
+            )
+            dashboard.append("linked_charts", {"chart": self.owner_chart})
+            dashboard.insert()
+            dashboard.update_access(
+                {"is_public": 1, "is_shared_with_organization": 0, "people_with_access": []}
+            )
+            self.assertTrue(frappe.db.get_value(DT.DASHBOARD, dashboard.name, "is_public"))
+
+
+class TestPublicMethodArguments(InsightsIntegrationTestCase):
+    """The builder's own parameters are not part of the public contract."""
+
+    def filter_args(self, doctype, method, args):
+        from insights.api import public_method_args
+
+        return public_method_args(doctype, method, args)
+
+    def test_a_builder_parameter_is_dropped(self):
+        """The builder's step preview reshapes the query, so it stays with the builder."""
+        args = self.filter_args(DT.QUERY, "execute", {"active_operation_idx": 0, "page_size": 100})
+        self.assertNotIn("active_operation_idx", args)
+        self.assertEqual(args, {"page_size": 100})
+
+    def test_a_json_string_body_is_filtered_too(self):
+        """`args` arrives as a JSON body, so filtering must survive the parse."""
+        args = self.filter_args(DT.QUERY, "execute", '{"active_operation_idx": 0, "page": 2}')
+        self.assertEqual(args, {"page": 2})
+
+    def test_download_results_is_filtered_too(self):
+        args = self.filter_args(DT.QUERY, "download_results", {"active_operation_idx": 0, "format": "csv"})
+        self.assertEqual(args, {"format": "csv"})
+
+    def test_no_public_method_accepts_a_builder_parameter(self):
+        """The rule, not one parameter name."""
+        from insights.api import PUBLIC_METHOD_ARGS
+
+        builder_only = {"active_operation_idx", "force", "use_live_connection", "limit"}
+        for (doctype, method), allowed in PUBLIC_METHOD_ARGS.items():
+            self.assertFalse(
+                allowed & builder_only,
+                f"{doctype}.{method} exposes {allowed & builder_only} to Guests",
+            )
+
+    def test_every_public_method_declares_its_arguments(self):
+        """is_public_method and the argument surface are one map, so they cannot drift."""
+        from insights.api import PUBLIC_METHOD_ARGS, is_public_method
+
+        for doctype, method in PUBLIC_METHOD_ARGS:
+            self.assertTrue(is_public_method(doctype, method))
+
+    def test_the_dashboard_filter_path_keeps_what_it_needs(self):
+        args = self.filter_args(
+            DT.DASHBOARD,
+            "get_distinct_column_values",
+            {"query": "q1", "column_name": "status", "search_term": "op"},
+        )
+        self.assertEqual(args, {"query": "q1", "column_name": "status", "search_term": "op"})


### PR DESCRIPTION
Four hardening changes to permission and input handling. Each carries a test that fails without it.

- **Expression context.** An expression describes a query, so the context it evaluates in now holds
  no name that opens a path, a URL or a backend connection. Held as a rule over attribute names
  rather than a list, so an ibis upgrade that adds a reader does not become reachable on its own.
- **Invitation keys.** Stored as a hash rather than in the clear, and the `Insights User` grant on
  the doctype is dropped — only `insights.api.user.get_users` reads it, and that is admin-only.
  Accepting an invitation for an address that already has an account now grants access and sends the
  visitor to the login page instead of signing them in.
- **Links as grants.** A chart's `query` and a dashboard's `linked_charts` are read as access by the
  permission queries, so both are now checked where the link is written rather than where it is
  read.
- **Public method arguments.** Each public method declares the arguments it accepts, so the query
  builder's own parameters stay with the builder.

Behaviour is unchanged for anything a user could already do: publishing your own chart or dashboard,
executing a public query, evaluating an expression, and accepting an invitation as a new invitee all
work as before.

## Migration

`insights.patches.hash_invitation_keys` hashes stored invitation keys in place, so links already
sent keep working.

## Checked

Full suite run before and after: same 11 pre-existing failures, no new ones. Verified with
`enable_permissions` at both 0 and 1.
