### PR TITLE
fix: scope a resource grant to the teams that hold it

### DIFF
--- a/insights/permissions.py
+++ b/insights/permissions.py
@@ -6,6 +6,7 @@ from functools import cached_property
 
 import frappe
 import frappe.share
+from pypika.terms import LiteralValue
 
 from insights.insights.doctype.insights_team.insights_team import (
     get_teams,
@@ -398,13 +399,25 @@ class InsightsPermissions:
         )
 
     def _build_resource_query(self, doctype):
+        """Grants on `doctype` that the user holds through a team.
+
+        A team is the only thing that carries a grant, so a user in no team must
+        match no row. That case cannot be written as a test of a column: `parent`
+        links a grant back to its team and is set on every row, so any predicate
+        over it is true for all of them. `isin([])` is not an option either -
+        pypika renders it as the invalid `IN ()`. State the empty set as a false
+        constant, where it cannot be read as its own opposite.
+        """
         Resource = frappe.qb.DocType("Insights Resource Permission")
 
-        condition = (Resource.resource_type == doctype) & (Resource.resource_name.isnotnull())
-        if not self.user_teams:
-            condition = condition & (Resource.parent.isnotnull())
-        else:
-            condition = condition & (Resource.parent.isin(self.user_teams))
+        held_by_a_team_of_the_user = (
+            Resource.parent.isin(self.user_teams) if self.user_teams else LiteralValue("1 = 0")
+        )
+        condition = (
+            (Resource.resource_type == doctype)
+            & Resource.resource_name.isnotnull()
+            & held_by_a_team_of_the_user
+        )
 
         return frappe.qb.from_(Resource).select(Resource.resource_name.as_("name")).where(condition)
 

--- a/insights/tests/permissions_utils.py
+++ b/insights/tests/permissions_utils.py
@@ -9,6 +9,7 @@ WEB_USER_EMAIL = "web_user@test.com"
 NON_INSIGHTS_USER = "non_insights_user@test.com"
 USER_1 = "insights_user1@test.com"
 USER_2 = "insights_user2@test.com"
+USER_3 = "insights_user3@test.com"
 ADMIN = "insights_admin@test.com"
 
 TEST_DS_TITLE = "Test DuckDB"
@@ -16,6 +17,8 @@ TEST_DS = frappe.scrub(TEST_DS_TITLE)
 TEST_TABLE1 = get_table_name(TEST_DS, "table1")
 TEST_TABLE2_NAME = get_table_name(TEST_DS, "table2")
 TEST_TABLE3_NAME = get_table_name(TEST_DS, "table3")
+
+TEST_TEAMS = ("team1", "team2")
 
 
 def create_test_users():
@@ -43,6 +46,12 @@ def create_test_users():
         roles="Insights User",
     )
     create_user(
+        USER_3,
+        first_name="Insights",
+        last_name="User",
+        roles="Insights User",
+    )
+    create_user(
         ADMIN,
         first_name="Insights",
         last_name="Admin",
@@ -56,6 +65,7 @@ def delete_test_users():
         NON_INSIGHTS_USER,
         USER_1,
         USER_2,
+        USER_3,
         ADMIN,
     )
 
@@ -94,16 +104,28 @@ def delete_test_tables():
     frappe.delete_doc(DT.TABLE, TEST_TABLE3_NAME, force=True)
 
 
-def create_test_teams():
-    team = frappe.get_doc({"doctype": DT.TEAM, "team_name": "team1"})
-    team.append("team_members", {"user": USER_1})
-    team.save()
+def create_test_team(team_name, members, grants=None):
+    """A team of `members` holding a grant on each (resource_type, name) in `grants`."""
+    team = frappe.get_doc({"doctype": DT.TEAM, "team_name": team_name})
+    for member in members:
+        team.append("team_members", {"user": member})
+    for resource_type, resource_name in grants or []:
+        team.append(
+            "team_permissions",
+            {"resource_type": resource_type, "resource_name": resource_name},
+        )
+    team.save(ignore_permissions=True)
     clear_team_cache()
     return team
 
 
+def create_test_teams():
+    return create_test_team("team1", [USER_1])
+
+
 def delete_test_teams():
-    frappe.delete_doc(DT.TEAM, "team1", force=True)
+    for team_name in TEST_TEAMS:
+        frappe.delete_doc(DT.TEAM, team_name, force=True)
 
 
 def update_dashboard_access(dashboard_name, people_with_access):

--- a/insights/tests/test_permissions.py
+++ b/insights/tests/test_permissions.py
@@ -23,9 +23,11 @@ from insights.tests.permissions_utils import (
     TEST_TABLE1,
     USER_1,
     USER_2,
+    USER_3,
     cleanup_test_fixtures,
     create_test_data_sources,
     create_test_tables,
+    create_test_team,
     create_test_teams,
     create_test_users,
     share_chart,
@@ -64,6 +66,35 @@ class TestInsightsPermissions(InsightsIntegrationTestCase):
     def toggle_team_permissions(self, enable):
         frappe.db.set_single_value(DT.SETTINGS, "enable_permissions", enable)
         clear_team_cache()
+
+    def assert_no_access_to(self, user, doctype, name):
+        """Both consumers of the permission query must refuse the user."""
+        self.assert_not_visible_to(user, doctype, name)
+        with self.as_user(user):
+            for ptype in ("read", "write"):
+                self.assertFalse(
+                    frappe.has_permission(doctype, ptype=ptype, doc=name),
+                    f"{user} should not hold {ptype} on {doctype} {name}",
+                )
+
+    def grant_every_resource_type_to_a_team(self):
+        """Build one team holding a grant of each type, and one holding none."""
+        create_test_data_sources()
+        create_test_tables()
+        workbook = create_test_workbook(ADMIN)
+        query = create_test_query(ADMIN, workbook.name)
+        chart = create_test_chart(ADMIN, workbook.name, query.name)
+        dashboard = create_test_dashboard(ADMIN, workbook.name, chart.name)
+
+        granted = {
+            DT.DATA_SOURCE: TEST_DS,
+            DT.TABLE: TEST_TABLE1,
+            DT.CHART: chart.name,
+            DT.DASHBOARD: dashboard.name,
+        }
+        create_test_team("team1", [USER_1], list(granted.items()))
+        create_test_team("team2", [USER_3])
+        return granted
 
     def test_permissions_for_non_insights_user(self):
         with self.as_user(NON_INSIGHTS_USER):
@@ -111,6 +142,39 @@ class TestInsightsPermissions(InsightsIntegrationTestCase):
 
         self.assert_visible_to(USER_1, DT.DATA_SOURCE, TEST_DS)
         self.assert_visible_to(USER_1, DT.TABLE, TEST_TABLE1)
+
+    def test_resource_grant_reaches_the_granted_team_only(self):
+        """A grant is held by a team, so only that team's members may use it.
+
+        The two users without access differ, and both matter. USER_2 is in no
+        team, USER_3 is in a team that holds no grant. An empty set of teams and
+        an empty set of grants have to land on the same empty result.
+        """
+        granted = self.grant_every_resource_type_to_a_team()
+        self.toggle_team_permissions(True)
+
+        for doctype, name in granted.items():
+            self.assert_visible_to(USER_1, doctype, name)
+
+        for user in (USER_2, USER_3):
+            for doctype, name in granted.items():
+                self.assert_no_access_to(user, doctype, name)
+
+    def test_resource_grant_is_inert_while_team_permissions_are_off(self):
+        """Team membership is not read while the setting is off, so no grant applies.
+
+        Data sources and tables stay open to every Insights user - that is what
+        the setting turns off. Charts and dashboards fall back to workbook
+        access, which the grant holder does not have either.
+        """
+        granted = self.grant_every_resource_type_to_a_team()
+        self.toggle_team_permissions(False)
+
+        for user in (USER_1, USER_2, USER_3):
+            self.assert_visible_to(user, DT.DATA_SOURCE, granted[DT.DATA_SOURCE])
+            self.assert_visible_to(user, DT.TABLE, granted[DT.TABLE])
+            self.assert_no_access_to(user, DT.CHART, granted[DT.CHART])
+            self.assert_no_access_to(user, DT.DASHBOARD, granted[DT.DASHBOARD])
 
     def test_permission_for_admin_on_team_based_doctype_with_team_permissions_enabled(
         self,


### PR DESCRIPTION
`_build_resource_query` selects the `Insights Resource Permission` rows that a caller may
use. A grant row lives in the `team_permissions` child table of `Insights Team`. Its
`parent` column holds the name of the team that owns the grant.

The caller's own teams decide which rows the query selects.

### Example

Two teams each hold one dashboard grant:

| parent | resource_type | resource_name |
| --- | --- | --- |
| team1 | Insights Dashboard v3 | dash-a |
| team2 | Insights Dashboard v3 | dash-b |

The query must then select:

| the caller's teams | rows |
| --- | --- |
| `["team1"]` | dash-a |
| `["team2"]` | dash-b |
| `["team1", "team2"]` | dash-a and dash-b |
| `[]` | none |

The last row is what this PR corrects. The code wrote that case as `parent IS NOT NULL`.
Every grant row belongs to a team, so `parent` always holds a value. That condition
therefore matches both rows above, where it must match none.

### Why a constant

No test of a column can state the empty case here:

1. `parent` is set on every row.
2. `resource_type` and `resource_name` are already fixed by the caller.
3. `isin([])` is not available. pypika renders it as `IN ()`, which MariaDB rejects.

So the empty case is now the constant `1 = 0`. A reader cannot mistake it for its opposite.
The set of teams is read in one place, so the callers need no branch of their own.

### Tests

`test_resource_grant_reaches_the_granted_team_only` gives team1 a grant on each of the four
grantable doctypes. It then checks three callers:

1. A member of team1 reaches all four.
2. A user who belongs to no team reaches none.
3. A user in team2, which holds no grant, reaches none.

The third caller is the control. It shows that these doctypes are not simply open to
everybody.

`test_resource_grant_is_inert_while_team_permissions_are_off` repeats the same setup with
`Insights Settings.enable_permissions` set to 0. Data sources and tables stay open to every
Insights user, because that is what the setting turns off. Charts and dashboards fall back
to workbook access.

Both tests check `read` and `write`. They go through `frappe.get_list` for the permission
query and through `frappe.has_permission` for the document check.
