### PR TITLE
docs: name ADRs by slug, and stop writing one per ticket

### DIFF
--- a/.claude/commands/iris-review.md
+++ b/.claude/commands/iris-review.md
@@ -123,11 +123,10 @@ that owns it.
   double-names (grain/`granularity`, Library/`gallery`) are the exception, not the licence.
 - **A hard-to-change name settled later.** Hook names, field names, URLs. *"changing the
   hook name would be a difficult change, so shouldn't we decide it right now?"*
-- **ADR conflict.** Name the number and say whether it is worth reopening. Three get
-  contradicted often: ADR-0001 (type-independent config — a new per-type config slot),
-  ADR-0002 (frappe-ui owns the chrome — a hand-built ECharts option for a type charts v2
-  admits), ADR-0003 (a tool declares, the loop enforces — a handler re-implementing a
-  cross-cutting rule).
+- **ADR conflict.** Name the ADR by its slug and say whether it is worth reopening.
+  Three get contradicted often: `type-independent-chart-config` (a new per-type config
+  slot), `charts-render-through-frappe-ui` (a hand-built ECharts option for a type charts v2
+  admits), `declared-tool-policy` (a handler re-implementing a cross-cutting rule).
 
 # 3. Evidence
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -71,7 +71,8 @@ The sync job that copies a source table into the Data Store.
 
 **Unexplained Orphan**:
 A Data Store table the weekly cleanup cannot show to be rebuildable. The cleanup
-keeps it and raises an `Error Log`. See ADR-0003.
+keeps it and raises an `Error Log`. See the cleanup ADR,
+`docs/adr/the-cleanup-deletes-only-what-it-can-rebuild.md`.
 _Avoid_: unknown table, stray table
 
 ### Framework integration
@@ -114,4 +115,4 @@ condition is met.
 **Channel**:
 How an alert reaches its recipients: email, Telegram or a webhook. A webhook posts to a
 URL the user supplies, which is why outbound requests carry an address policy — see
-ADR-0002.
+`docs/adr/outbound-http-to-user-chosen-urls.md`.

--- a/docs/adr/outbound-http-to-user-chosen-urls.md
+++ b/docs/adr/outbound-http-to-user-chosen-urls.md
@@ -1,4 +1,4 @@
-# 2. Outbound HTTP to user-chosen URLs
+# Outbound HTTP to user-chosen URLs
 
 Date: 2026-08-11
 

--- a/docs/adr/the-cleanup-deletes-only-what-it-can-rebuild.md
+++ b/docs/adr/the-cleanup-deletes-only-what-it-can-rebuild.md
@@ -1,4 +1,4 @@
-# 3. The cleanup deletes only what it can rebuild
+# The cleanup deletes only what it can rebuild
 
 Date: 2026-08-13
 

--- a/docs/adr/type-independent-chart-config.md
+++ b/docs/adr/type-independent-chart-config.md
@@ -1,4 +1,4 @@
-# 1. Type-independent chart config
+# Type-independent chart config
 
 Date: 2026-08-05
 

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -11,6 +11,38 @@ Do not suggest writing an ADR upfront. The `/domain-modeling` skill (reached via
 `/grill-with-docs` and `/improve-codebase-architecture`) writes them when a term
 or a decision actually gets resolved.
 
+## Most work produces no ADR
+
+The `/domain-modeling` test decides, and all three must hold: the decision is
+hard to reverse, it is surprising without context, and it is the result of a
+real trade-off. Two or three out of three is a no.
+
+Resolving a ticket is not by itself a reason to write one. Two failures this
+repo has had:
+
+- **A bug fix is not a decision.** If the fix is the only correct
+  implementation, nobody will reopen it and nothing is at stake in recording
+  it. The commit message is the record.
+- **Timing is not durable.** "There is no v1 yet", a token count, what the runs
+  said this week — that is true for a month and expires with the branch. It
+  belongs in the ticket. An ADR holds what stays true after the effort is gone.
+
+Write an ADR at the moment the decision is made, not when the ticket closes.
+Close-out is for the ones you missed, and there should be few.
+
+## Naming
+
+`docs/adr/<slug>.md`. No number.
+
+Numbers were dropped because they are allocated on a feature branch and
+collide on merge — two branches both took `0003`, and `iris-review.md` cited
+two ADR numbers that resolved to the wrong documents. The slug is the stable
+name and the `Date:` line is the ordering, so the number carried nothing and
+broke on the one operation that matters.
+
+Cite an ADR by slug, never by number: `` `declared-tool-policy` ``, or a
+relative link to the file.
+
 ## Durable documents and effort documents
 
 Two kinds of document live in this repo, and they have different lifetimes.
@@ -39,4 +71,4 @@ If the concept you need isn't in the glossary yet, that's a signal — either yo
 
 If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
 
-> _Contradicts ADR-0001 (type-independent chart config) — but worth reopening because…_
+> _Contradicts `type-independent-chart-config` — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -31,16 +31,20 @@ Don't create or triage GitHub issues unless explicitly asked.
 
 ## Closing out an effort
 
-The effort docs die with the branch. The ADR is the only durable record of why
-the work went the way it did, so write it before the branch merges.
+The effort docs die with the branch. Most of what they hold is meant to die with
+it — how the work went, what was measured this week, what was still unknown on
+Tuesday. Close-out is not a distillation of the whole effort.
 
-1. Write an ADR in `docs/adr/` for each decision the map records. Add any new
-   term to the glossary in `CONTEXT.md`.
+1. Write an ADR for each decision that passes the test in `domain.md`. **Most
+   tickets produce none**, and that is the normal outcome, not an omission. Add
+   any new term to the glossary in `CONTEXT.md`.
 2. Remove the effort with `git rm -r docs/projects/<effort-slug>/`. Put this in
-   the same commit as the ADR. A deletion with no ADR beside it is a lost
-   decision, and a reviewer can see that at a glance.
+   the same commit as any ADR it produced.
 3. Move the working copies to `docs/archive/<effort-slug>/` to keep them on the
    machine. `docs/archive/` is local-only.
+
+Close-out is a bad moment to notice a decision for the first time. Write the ADR
+when the decision is made. What is left at close-out should be nearly nothing.
 
 When a skill says "publish to the issue tracker", create the file under
 `docs/projects/<effort-slug>/`. When it says "fetch the relevant ticket", read
@@ -61,8 +65,7 @@ Used by `/wayfinder`. The **map** is a file with one **child** file per ticket.
 - **Claim**: set `Status: claimed` and save before any work.
 - **Resolve**: append the answer under an `## Answer` heading, set `Status: resolved`,
   then append a context pointer (gist + link) to the map's Decisions-so-far in `map.md`.
-  Add the ADR filename to that pointer once the decision reaches `docs/adr/`. An
-  entry with no filename marks reasoning that still has to be distilled before
-  the branch merges.
+  Add the ADR slug to that pointer if the decision produced one. Most do not, and
+  an entry with no slug is finished — it is a resolved ticket, not a debt.
 - **Research findings**: land in `docs/projects/<effort>/research/`, linked from
   the ticket's answer.


### PR DESCRIPTION
Two problems, one commit.

**The number collides.** It is allocated on a feature branch, so two branches both
took `0003`. `iris-review.md` already cited two ADR numbers that resolved to the
wrong documents, and `chat-items.ts` cites an `ADR-0008` that belongs to a
different repo's ADR set. The slug already names the file and the `Date:` line
already orders it, so the number carried nothing and broke on merge.

**The close-out asked for one ADR per decision.** It also called a deletion
without one "a lost decision", which made skipping one read as data loss. That
quota beat the `/domain-modeling` test it was meant to defer to — the result was
an ADR for a bug fix and none for a whole UI surface.

`domain.md` now carries the test and the trigger: write the ADR when the decision
is made, not when the ticket closes.

No content changes to the three ADRs themselves beyond dropping the number from
the heading.