### PR TITLE
fix: check the referenced document, not the one that names it

### DIFF
--- a/insights/api/__init__.py
+++ b/insights/api/__init__.py
@@ -235,6 +235,20 @@ def _execute_doc_method(doc, method: str, args: dict | None = None, ignore_permi
     return response
 
 
+def check_stored_document(doctype: str, name: str):
+    """Decide access against the stored document, not the caller's copy of it.
+
+    A method runs on a document built from the request body, so every field the
+    permission rules read is whatever the caller sent. A name with no row behind
+    it is a document the client has not saved, and discloses nothing.
+    """
+    if not frappe.db.exists(doctype, name):
+        return
+
+    if not frappe.has_permission(doctype, ptype="read", doc=name):
+        raise frappe.PermissionError("You don't have permission to access this document")
+
+
 @frappe.whitelist(allow_guest=True)  # nosemgrep - guests reach only public documents, and only
 # the methods and arguments PUBLIC_METHOD_ARGS names
 def run_doc_method(method: str, docs: dict | str, args: dict | None = None):
@@ -242,10 +256,13 @@ def run_doc_method(method: str, docs: dict | str, args: dict | None = None):
     doctype = doc.get("doctype")
     name = doc.get("name")
 
-    if not doctype or not name:
+    # a name is one document's identity. A dict is a filter set to `frappe.db`,
+    # so it is not a name.
+    if not doctype or not name or not isinstance(name, str):
         raise frappe.ValidationError("Invalid document")
 
     try:
+        check_stored_document(doctype, name)
         docs = frappe.parse_json(docs)
         doc = frappe.get_doc(docs)
         return _execute_doc_method(doc, method, args)

--- a/insights/api/workbooks.py
+++ b/insights/api/workbooks.py
@@ -315,20 +315,25 @@ ITEM_DOCTYPES = {
 }
 
 
-def check_belongs_to_workbook(doctype: str, name, workbook: str):
-    """`name` names one document, and that document lives in `workbook`.
+def item_workbook(doctype: str, name) -> str | None:
+    """The workbook holding this row, or None if the row is gone.
 
-    Write access is held on the workbook, so it reaches the workbook's own items
-    and no further. The write goes straight to the row, so the permission query
-    that scopes the read never sees it - this is what scopes the write.
+    The write goes straight to the row, so the permission query that scopes the
+    read never sees it - this read is what scopes the write. A dict is not a
+    name: `frappe.db` reads one as a filter set and would match every row.
 
-    A dict is not a name. `frappe.db` reads one as a filter set and would update
-    every row that matches.
+    Gone and held by someone else are different answers, and the callers want
+    different things from each, so this reports and they decide.
     """
     if not isinstance(name, str):
         frappe.throw(_("{0} is not the name of a {1}").format(name, doctype))
 
-    if frappe.db.get_value(doctype, name, "workbook") != workbook:
+    return frappe.db.get_value(doctype, name, "workbook")
+
+
+def refuse_another_workbooks_item(doctype: str, name, holder: str | None, workbook: str) -> None:
+    """A row this workbook does not hold is not this caller's to write."""
+    if holder != workbook:
         frappe.throw(
             _("{0} {1} does not belong to this workbook").format(doctype, name),
             frappe.PermissionError,
@@ -348,7 +353,10 @@ def move_item_to_folder(item_type: str, item_name: str, folder_name: str | None 
         frappe.throw(_("You do not have permission to modify this workbook"), frappe.PermissionError)
 
     if folder_name:
-        check_belongs_to_workbook("Insights Folder", folder_name, item.workbook)
+        holder = item_workbook("Insights Folder", folder_name)
+        if holder is None:
+            frappe.throw(_("Insights Folder {0} not found").format(folder_name))
+        refuse_another_workbooks_item("Insights Folder", folder_name, holder, item.workbook)
 
     item.db_set("folder", folder_name, update_modified=False)
 
@@ -360,17 +368,34 @@ def update_sort_orders(workbook: str, items: list):
         frappe.throw(_("You do not have permission to modify this workbook"), frappe.PermissionError)
 
     for item in items:
-        doctype = ITEM_DOCTYPES.get(item["type"])
+        doctype = ITEM_DOCTYPES.get(item.get("type"))
         if not doctype:
+            frappe.throw(_("{0} is not a workbook item type").format(item.get("type")))
+
+        sort_order = item.get("sort_order")
+        if not isinstance(sort_order, int):
+            frappe.throw(_("{0} is not a sort order").format(sort_order))
+
+        # the client sends the whole list after a drag, so it can name an item
+        # someone else has since deleted. That item has nothing to order.
+        holder = item_workbook(doctype, item.get("name"))
+        if holder is None:
             continue
 
-        check_belongs_to_workbook(doctype, item["name"], workbook)
+        refuse_another_workbooks_item(doctype, item["name"], holder, workbook)
 
-        values = {"sort_order": item["sort_order"]}
+        values = {"sort_order": sort_order}
         if doctype != "Insights Folder":
             folder = item.get("folder")
             if folder:
-                check_belongs_to_workbook("Insights Folder", folder, workbook)
+                # a deleted folder leaves its items at the root, which is what
+                # `delete_folder` does. One held by another workbook is refused,
+                # because dropping the item at the root would hide the refusal.
+                folder_holder = item_workbook("Insights Folder", folder)
+                if folder_holder is None:
+                    folder = None
+                else:
+                    refuse_another_workbooks_item("Insights Folder", folder, folder_holder, workbook)
             values["folder"] = folder
 
         frappe.db.set_value(doctype, item["name"], values, update_modified=False)

--- a/insights/api/workbooks.py
+++ b/insights/api/workbooks.py
@@ -308,26 +308,6 @@ def toggle_folder_expanded(folder_name: str, is_expanded: bool):
     folder.db_set("is_expanded", is_expanded, update_modified=False)
 
 
-@insights_whitelist()
-def move_item_to_folder(item_type: str, item_name: str, folder_name: str | None = None):
-    """Move a query/chart to a folder"""
-    doctype = ITEM_DOCTYPES.get(item_type)
-    if not doctype or doctype == "Insights Folder":
-        frappe.throw(_("{0} is not a movable item type").format(item_type))
-
-    item = frappe.get_doc(doctype, item_name)
-
-    if not frappe.has_permission("Insights Workbook", ptype="write", doc=item.workbook):
-        frappe.throw(_("You do not have permission to modify this workbook"), frappe.PermissionError)
-
-    if folder_name:
-        folder = frappe.get_doc("Insights Folder", folder_name)
-        if folder.workbook != item.workbook:
-            frappe.throw(_("Folder and item must belong to the same workbook"))
-
-    item.db_set("folder", folder_name, update_modified=False)
-
-
 ITEM_DOCTYPES = {
     "folder": "Insights Folder",
     "query": "Insights Query v3",
@@ -353,6 +333,24 @@ def check_belongs_to_workbook(doctype: str, name, workbook: str):
             _("{0} {1} does not belong to this workbook").format(doctype, name),
             frappe.PermissionError,
         )
+
+
+@insights_whitelist()
+def move_item_to_folder(item_type: str, item_name: str, folder_name: str | None = None):
+    """Move a query/chart to a folder"""
+    doctype = ITEM_DOCTYPES.get(item_type)
+    if not doctype or doctype == "Insights Folder":
+        frappe.throw(_("{0} is not a movable item type").format(item_type))
+
+    item = frappe.get_doc(doctype, item_name)
+
+    if not frappe.has_permission("Insights Workbook", ptype="write", doc=item.workbook):
+        frappe.throw(_("You do not have permission to modify this workbook"), frappe.PermissionError)
+
+    if folder_name:
+        check_belongs_to_workbook("Insights Folder", folder_name, item.workbook)
+
+    item.db_set("folder", folder_name, update_modified=False)
 
 
 @insights_whitelist()

--- a/insights/api/workbooks.py
+++ b/insights/api/workbooks.py
@@ -311,7 +311,10 @@ def toggle_folder_expanded(folder_name: str, is_expanded: bool):
 @insights_whitelist()
 def move_item_to_folder(item_type: str, item_name: str, folder_name: str | None = None):
     """Move a query/chart to a folder"""
-    doctype = "Insights Query v3" if item_type == "query" else "Insights Chart v3"
+    doctype = ITEM_DOCTYPES.get(item_type)
+    if not doctype or doctype == "Insights Folder":
+        frappe.throw(_("{0} is not a movable item type").format(item_type))
+
     item = frappe.get_doc(doctype, item_name)
 
     if not frappe.has_permission("Insights Workbook", ptype="write", doc=item.workbook):
@@ -325,41 +328,53 @@ def move_item_to_folder(item_type: str, item_name: str, folder_name: str | None 
     item.db_set("folder", folder_name, update_modified=False)
 
 
+ITEM_DOCTYPES = {
+    "folder": "Insights Folder",
+    "query": "Insights Query v3",
+    "chart": "Insights Chart v3",
+}
+
+
+def check_belongs_to_workbook(doctype: str, name, workbook: str):
+    """`name` names one document, and that document lives in `workbook`.
+
+    Write access is held on the workbook, so it reaches the workbook's own items
+    and no further. The write goes straight to the row, so the permission query
+    that scopes the read never sees it - this is what scopes the write.
+
+    A dict is not a name. `frappe.db` reads one as a filter set and would update
+    every row that matches.
+    """
+    if not isinstance(name, str):
+        frappe.throw(_("{0} is not the name of a {1}").format(name, doctype))
+
+    if frappe.db.get_value(doctype, name, "workbook") != workbook:
+        frappe.throw(
+            _("{0} {1} does not belong to this workbook").format(doctype, name),
+            frappe.PermissionError,
+        )
+
+
 @insights_whitelist()
 def update_sort_orders(workbook: str, items: list):
-    """Bulk update sort orders"""
+    """Order a workbook's own queries, charts and folders"""
     if not frappe.has_permission("Insights Workbook", ptype="write", doc=workbook):
         frappe.throw(_("You do not have permission to modify this workbook"), frappe.PermissionError)
 
     for item in items:
-        if item["type"] == "folder":
-            frappe.db.set_value(
-                "Insights Folder",
-                item["name"],
-                {
-                    "sort_order": item["sort_order"],
-                },
-                update_modified=False,
-            )
-        elif item["type"] == "query":
-            frappe.db.set_value(
-                "Insights Query v3",
-                item["name"],
-                {
-                    "sort_order": item["sort_order"],
-                    "folder": item.get("folder"),
-                },
-                update_modified=False,
-            )
-        elif item["type"] == "chart":
-            frappe.db.set_value(
-                "Insights Chart v3",
-                item["name"],
-                {
-                    "sort_order": item["sort_order"],
-                    "folder": item.get("folder"),
-                },
-                update_modified=False,
-            )
+        doctype = ITEM_DOCTYPES.get(item["type"])
+        if not doctype:
+            continue
+
+        check_belongs_to_workbook(doctype, item["name"], workbook)
+
+        values = {"sort_order": item["sort_order"]}
+        if doctype != "Insights Folder":
+            folder = item.get("folder")
+            if folder:
+                check_belongs_to_workbook("Insights Folder", folder, workbook)
+            values["folder"] = folder
+
+        frappe.db.set_value(doctype, item["name"], values, update_modified=False)
 
     frappe.db.commit()

--- a/insights/insights/doctype/insights_chart_v3/insights_chart_v3.py
+++ b/insights/insights/doctype/insights_chart_v3/insights_chart_v3.py
@@ -120,12 +120,24 @@ class InsightsChartv3(Document):
 
 
 def import_chart(chart, workbook):
+    """Copy an exported chart into `workbook`, with the query it is built on.
+
+    The query goes in first, so the chart is inserted already pointing at the
+    copy. `validate` reads the link, and a link to the exporting site's query is
+    a state it would read as the real one.
+    """
+    from insights.insights.doctype.insights_query_v3.insights_query_v3 import already_in_workbook
+
     chart = frappe.parse_json(chart)
     chart = deep_convert_dict_to_dict(chart)
 
     new_chart = frappe.new_doc("Insights Chart v3")
     new_chart.update(chart.doc)
     new_chart.workbook = workbook
+
+    exported = (chart.get("dependencies") or {}).get("queries") or {}
+    if chart.doc.query in exported and not already_in_workbook(chart.doc.query, workbook):
+        new_chart.query = import_query(exported[chart.doc.query], workbook)
 
     if not hasattr(new_chart, "sort_order") or new_chart.sort_order is None:
         max_sort_order = (
@@ -138,12 +150,5 @@ def import_chart(chart, workbook):
         )
         new_chart.sort_order = max_sort_order + 1
     new_chart.insert()
-
-    if workbook == chart.doc.workbook or not chart.dependencies.queries:
-        return new_chart.name
-
-    for _, exported_query in chart.dependencies.queries.items():
-        name = import_query(exported_query, workbook=new_chart.workbook)
-        new_chart.db_set("query", name, update_modified=False)
 
     return new_chart.name

--- a/insights/insights/doctype/insights_chart_v3/insights_chart_v3.py
+++ b/insights/insights/doctype/insights_chart_v3/insights_chart_v3.py
@@ -84,6 +84,8 @@ class InsightsChartv3(Document):
 
     @frappe.whitelist()
     def export(self):
+        from insights.permissions import check_referenced_query_access
+
         chart = {
             "version": "1.0",
             "timestamp": frappe.utils.now(),
@@ -102,6 +104,7 @@ class InsightsChartv3(Document):
             },
         }
 
+        check_referenced_query_access(self.query)
         exported_query = frappe.get_doc("Insights Query v3", self.query).export()
         chart["dependencies"]["queries"][self.query] = exported_query
 

--- a/insights/insights/doctype/insights_dashboard_v3/insights_dashboard_v3.py
+++ b/insights/insights/doctype/insights_dashboard_v3/insights_dashboard_v3.py
@@ -106,6 +106,8 @@ class InsightsDashboardv3(Document):
     def get_distinct_column_values(
         self, query: str, column_name: str, search_term: str | None = None, adhoc_filters: dict | None = None
     ):
+        from insights.permissions import check_referenced_query_access
+
         is_guest = frappe.session.user == "Guest"
         if is_guest and not self.is_public:
             raise frappe.PermissionError
@@ -115,6 +117,8 @@ class InsightsDashboardv3(Document):
                 frappe._("This column is not available as a filter on this dashboard"),
                 frappe.PermissionError,
             )
+
+        check_referenced_query_access(query)
 
         doc = frappe.get_cached_doc("Insights Query v3", query)
         return doc.get_distinct_column_values(

--- a/insights/insights/doctype/insights_data_source_v3/ibis_utils.py
+++ b/insights/insights/doctype/insights_data_source_v3/ibis_utils.py
@@ -164,6 +164,9 @@ class IbisQueryBuilder:
                 use_live_connection=self.use_live_connection,
             )
         if table_args.type == "query":
+            from insights.permissions import check_referenced_query_access
+
+            check_referenced_query_access(table_args.query_name)
             q = frappe.get_doc("Insights Query v3", table_args.query_name)
             _table = q.build(use_live_connection=self.use_live_connection)
 

--- a/insights/insights/doctype/insights_data_source_v3/ibis_utils.py
+++ b/insights/insights/doctype/insights_data_source_v3/ibis_utils.py
@@ -3,6 +3,7 @@ import re
 import time
 from contextlib import contextmanager
 from datetime import date
+from functools import cached_property
 
 import frappe
 import ibis
@@ -26,7 +27,7 @@ from insights.insights.doctype.insights_table_v3.insights_table_v3 import (
     InsightsTablev3,
 )
 from insights.insights.query_builders.sql_functions import handle_timespan
-from insights.insights.query_utils import extract_sql_table_refs
+from insights.insights.query_utils import extract_sql_table_refs, get_direct_dependencies
 from insights.utils import create_execution_log
 from insights.utils import deep_convert_dict_to_dict as _dict
 
@@ -154,6 +155,31 @@ class IbisQueryBuilder:
             return self.apply_code(operation)
         return self.query
 
+    @cached_property
+    def saved_references(self):
+        """The query references saved on the document being built.
+
+        A saved reference passed the check in `InsightsQueryv3.validate`, so it
+        carries the authorisation it was granted then. Operations sent with the
+        request carry none, and this is what tells the two apart: the document
+        this builder runs on may be built from a request body, and only the row
+        says what was actually saved.
+        """
+        name = self.doc.get("name")
+        if not name or not frappe.db.exists("Insights Query v3", name):
+            return set()
+
+        return set(get_direct_dependencies(name))
+
+    def check_query_reference(self, query_name):
+        """A saved reference is authorised. Anything else is checked now."""
+        if query_name in self.saved_references:
+            return
+
+        from insights.permissions import check_referenced_query_access
+
+        check_referenced_query_access(query_name)
+
     def get_table_or_query(self, table_args):
         _table = None
 
@@ -164,9 +190,7 @@ class IbisQueryBuilder:
                 use_live_connection=self.use_live_connection,
             )
         if table_args.type == "query":
-            from insights.permissions import check_referenced_query_access
-
-            check_referenced_query_access(table_args.query_name)
+            self.check_query_reference(table_args.query_name)
             q = frappe.get_doc("Insights Query v3", table_args.query_name)
             _table = q.build(use_live_connection=self.use_live_connection)
 

--- a/insights/insights/doctype/insights_data_source_v3/ibis_utils.py
+++ b/insights/insights/doctype/insights_data_source_v3/ibis_utils.py
@@ -27,7 +27,7 @@ from insights.insights.doctype.insights_table_v3.insights_table_v3 import (
     InsightsTablev3,
 )
 from insights.insights.query_builders.sql_functions import handle_timespan
-from insights.insights.query_utils import extract_sql_table_refs, referenced_queries
+from insights.insights.query_utils import extract_sql_table_refs, get_direct_dependencies
 from insights.utils import create_execution_log
 from insights.utils import deep_convert_dict_to_dict as _dict
 
@@ -159,13 +159,10 @@ class IbisQueryBuilder:
     def saved_references(self):
         """The references stored on this query, which `validate` authorised.
 
-        Read from the stored `operations` column: the document being built may
-        have come from a request body, and `Insights Query Reference` is rebuilt
-        by a background job that runs after the save commits.
+        Read from the row, not from the document being built: that one may have
+        come from a request body, which authorises nothing.
         """
-        name = self.doc.get("name")
-        operations = frappe.db.get_value("Insights Query v3", name, "operations") if name else None
-        return referenced_queries(operations)
+        return set(get_direct_dependencies(self.doc.get("name")))
 
     def check_query_reference(self, query_name):
         """A saved reference is authorised. Anything else is checked now."""

--- a/insights/insights/doctype/insights_data_source_v3/ibis_utils.py
+++ b/insights/insights/doctype/insights_data_source_v3/ibis_utils.py
@@ -27,7 +27,7 @@ from insights.insights.doctype.insights_table_v3.insights_table_v3 import (
     InsightsTablev3,
 )
 from insights.insights.query_builders.sql_functions import handle_timespan
-from insights.insights.query_utils import extract_sql_table_refs, get_direct_dependencies
+from insights.insights.query_utils import extract_sql_table_refs, referenced_queries
 from insights.utils import create_execution_log
 from insights.utils import deep_convert_dict_to_dict as _dict
 
@@ -157,19 +157,15 @@ class IbisQueryBuilder:
 
     @cached_property
     def saved_references(self):
-        """The query references saved on the document being built.
+        """The references stored on this query, which `validate` authorised.
 
-        A saved reference passed the check in `InsightsQueryv3.validate`, so it
-        carries the authorisation it was granted then. Operations sent with the
-        request carry none, and this is what tells the two apart: the document
-        this builder runs on may be built from a request body, and only the row
-        says what was actually saved.
+        Read from the stored `operations` column: the document being built may
+        have come from a request body, and `Insights Query Reference` is rebuilt
+        by a background job that runs after the save commits.
         """
         name = self.doc.get("name")
-        if not name or not frappe.db.exists("Insights Query v3", name):
-            return set()
-
-        return set(get_direct_dependencies(name))
+        operations = frappe.db.get_value("Insights Query v3", name, "operations") if name else None
+        return referenced_queries(operations)
 
     def check_query_reference(self, query_name):
         """A saved reference is authorised. Anything else is checked now."""

--- a/insights/insights/doctype/insights_query_v3/insights_query_v3.py
+++ b/insights/insights/doctype/insights_query_v3/insights_query_v3.py
@@ -24,6 +24,7 @@ from insights.insights.query_utils import (
     extract_query_deps_from_operations,
     find_cycle,
     get_direct_dependencies,
+    referenced_queries,
     sync_query_references,
     transitive_closure,
 )
@@ -85,23 +86,14 @@ class InsightsQueryv3(Document):
     def _validate_referenced_queries(self):
         """A query may only reference a query its author can read.
 
-        A reference resolves to the whole referenced query, so naming one asks for
-        a read of it. Checked once, here, where it is written - execution then
-        trusts the saved reference.
-
-        Only a new reference is checked. An existing one stays runnable by anyone
-        who may already read this query, whose access to the referenced query runs
-        through it. A name with no row behind it resolves to nothing: a workbook
-        import inserts a query before the queries it references.
+        Only a newly added reference is checked, so an existing one stays saveable
+        by anyone who may already read this query.
         """
         from insights.permissions import check_referenced_query_access
 
-        operations = frappe.parse_json(self.operations) or []
-        new_deps = set(extract_query_deps_from_operations(operations))
-        if not new_deps:
-            return
-
-        for dep in new_deps - set(get_direct_dependencies(self.name)):
+        before = self.get_doc_before_save()
+        existing = referenced_queries(before.operations) if before else set()
+        for dep in referenced_queries(self.operations) - existing:
             check_referenced_query_access(dep)
 
     def _validate_no_circular_dependency(self):

--- a/insights/insights/doctype/insights_query_v3/insights_query_v3.py
+++ b/insights/insights/doctype/insights_query_v3/insights_query_v3.py
@@ -80,6 +80,29 @@ class InsightsQueryv3(Document):
 
     def validate(self):
         self._validate_no_circular_dependency()
+        self._validate_referenced_queries()
+
+    def _validate_referenced_queries(self):
+        """A query may only reference a query its author can read.
+
+        A reference resolves to the whole referenced query, so naming one asks for
+        a read of it. Checked once, here, where it is written - execution then
+        trusts the saved reference.
+
+        Only a new reference is checked. An existing one stays runnable by anyone
+        who may already read this query, whose access to the referenced query runs
+        through it. A name with no row behind it resolves to nothing: a workbook
+        import inserts a query before the queries it references.
+        """
+        from insights.permissions import check_referenced_query_access
+
+        operations = frappe.parse_json(self.operations) or []
+        new_deps = set(extract_query_deps_from_operations(operations))
+        if not new_deps:
+            return
+
+        for dep in new_deps - set(get_direct_dependencies(self.name)):
+            check_referenced_query_access(dep)
 
     def _validate_no_circular_dependency(self):
         """Raise an error if the current operations would create a circular query reference."""

--- a/insights/insights/doctype/insights_query_v3/insights_query_v3.py
+++ b/insights/insights/doctype/insights_query_v3/insights_query_v3.py
@@ -427,13 +427,47 @@ def _sql_has_group_by(sql: str) -> bool:
     return False
 
 
-def import_query(query, workbook):
+def already_in_workbook(query_name, workbook) -> bool:
+    """Whether `query_name` is a query the target workbook already holds.
+
+    A reference that resolves here needs no copy, and the copy would be a second
+    row for one query. The file cannot answer this: it carries the exporting
+    site's workbook name, and `autoname` makes those a bare counter, so every
+    site has a workbook "1". Ask the row.
+    """
+    if not query_name:
+        return False
+
+    return frappe.db.get_value("Insights Query v3", query_name, "workbook") == workbook
+
+
+def import_query(query, workbook, id_map=None):
+    """Copy an exported query into `workbook`, references and all.
+
+    The dependencies go in first, so the query is inserted already naming the
+    copies that replace them. It is never stored naming the exporting site's
+    queries, which is a state `validate` would read as the real one.
+
+    `export` nests, so a query two branches both build on appears once per branch.
+    `id_map` is shared down the recursion, so it is imported once.
+    """
+    from insights.insights.doctype.insights_workbook.insights_workbook import (
+        _rewrite_query_references,
+    )
+
     query = frappe.parse_json(query)
     query = deep_convert_dict_to_dict(query)
+
+    id_map = {} if id_map is None else id_map
+    for name, dependency in ((query.get("dependencies") or {}).get("queries") or {}).items():
+        if name in id_map or already_in_workbook(name, workbook):
+            continue
+        id_map[name] = import_query(dependency, workbook, id_map)
 
     new_query = frappe.new_doc("Insights Query v3")
     new_query.update(query.doc)
     new_query.workbook = workbook
+    new_query.operations = _rewrite_query_references(query.doc.operations, id_map)
 
     if not hasattr(new_query, "sort_order") or new_query.sort_order is None:
         max_sort_order = (
@@ -445,39 +479,8 @@ def import_query(query, workbook):
             or -1
         )
         new_query.sort_order = max_sort_order + 1
+
     new_query.insert()
-
-    if workbook == query.doc.workbook or not query.dependencies.queries:
-        return new_query.name
-
-    # if query is copied to a new workbook, all the dependencies will be copied as well
-    # so we create a new query in the workbook for each dependency
-    # and replace the old query names with the new query names
-
-    id_map = {}
-    for q, exported_query in query.dependencies.queries.items():
-        id_map[q] = import_query(exported_query, workbook=new_query.workbook)
-
-    # replace the old query names with the new query names
-    operations = frappe.parse_json(new_query.operations)
-    operations = deep_convert_dict_to_dict(operations)
-
-    should_update = False
-    for op in operations:
-        if not op.get("table") or not op.get("table").get("type") or not op.get("table").get("query_name"):
-            continue
-
-        ref_query = op.table.query_name
-        if ref_query in id_map:
-            op.table.query_name = id_map[ref_query]
-            should_update = True
-
-    if should_update:
-        new_query.db_set(
-            "operations",
-            frappe.as_json(operations),
-            update_modified=False,
-        )
 
     return new_query.name
 

--- a/insights/insights/doctype/insights_query_v3/insights_query_v3.py
+++ b/insights/insights/doctype/insights_query_v3/insights_query_v3.py
@@ -321,6 +321,8 @@ class InsightsQueryv3(Document):
 
     @insights_whitelist()
     def export(self):
+        from insights.permissions import check_referenced_query_access
+
         query = {
             "version": "1.0",
             "timestamp": frappe.utils.now(),
@@ -344,11 +346,7 @@ class InsightsQueryv3(Document):
         linked_queries = get_direct_dependencies(self.name)
         for q in linked_queries:
             # export() recurses, so this covers the whole dependency tree
-            if not frappe.has_permission("Insights Query v3", ptype="read", doc=q):
-                frappe.throw(
-                    frappe._("You do not have access to one of the linked queries"),
-                    frappe.PermissionError,
-                )
+            check_referenced_query_access(q)
             exported_query = frappe.get_doc("Insights Query v3", q).export()
             query["dependencies"]["queries"][q] = exported_query
 

--- a/insights/insights/doctype/insights_query_v3/insights_query_v3.py
+++ b/insights/insights/doctype/insights_query_v3/insights_query_v3.py
@@ -26,6 +26,7 @@ from insights.insights.query_utils import (
     get_direct_dependencies,
     referenced_queries,
     sync_query_references,
+    table_references,
     transitive_closure,
 )
 from insights.utils import deep_convert_dict_to_dict
@@ -141,17 +142,22 @@ class InsightsQueryv3(Document):
             frappe.delete_doc("Insights Folder", folder_name, force=True, ignore_permissions=True)
 
     def get_source_tables(self):
-        """Collect all leaf table references from this query and its transitive dependencies."""
-        all_query_names = {self.name} | transitive_closure(self.name)
-        Ref = frappe.qb.DocType("Insights Query Reference")
-        rows = (
-            frappe.qb.from_(Ref)
-            .select(Ref.data_source, Ref.table_name)
-            .where((Ref.query.isin(list(all_query_names))) & (Ref.ref_type == "Table"))
-            .distinct()
-            .run(as_dict=True)
-        )
-        return [{"data_source": r.data_source, "table_name": r.table_name} for r in rows]
+        """Collect all leaf table references from this query and its transitive dependencies.
+
+        Which tables a query reads is a forward question, so each row answers its
+        own. The edge table lags every write, and this runs right after a save.
+        """
+        seen: set[tuple] = set()
+        tables = []
+        for name in {self.name} | transitive_closure(self.name):
+            operations = frappe.db.get_value("Insights Query v3", name, "operations")
+            for ref in table_references(operations):
+                key = (ref["data_source"], ref["table_name"])
+                if key in seen:
+                    continue
+                seen.add(key)
+                tables.append(ref)
+        return tables
 
     def build(self, active_operation_idx=None, use_live_connection=None):
         builder = IbisQueryBuilder(self, active_operation_idx)
@@ -360,6 +366,11 @@ class InsightsQueryv3(Document):
 
         linked_queries = get_direct_dependencies(self.name)
         for q in linked_queries:
+            # `on_trash` drops the edge rows but not the operations that name the
+            # query, so a deleted reference is a name that resolves to nothing.
+            if not frappe.db.exists("Insights Query v3", q):
+                continue
+
             # export() recurses, so this covers the whole dependency tree
             check_referenced_query_access(q)
             exported_query = frappe.get_doc("Insights Query v3", q).export()

--- a/insights/insights/doctype/insights_table_v3/insights_table_v3.py
+++ b/insights/insights/doctype/insights_table_v3/insights_table_v3.py
@@ -271,16 +271,28 @@ def get_table_stats(data_source: str, table_name: str) -> dict:
 
 
 def _get_referencing_queries(data_source: str, table_name: str) -> list[dict]:
-    """Find all Insights Query v3 docs that reference this table via the edge table."""
+    """The queries that reference this table and that the caller may read.
+
+    `Insights Query Reference` is an edge table. It is granted to Administrator
+    and System Manager alone, and a join over it carries the joined query's title
+    and workbook out with it. Reading a table says nothing about who may see the
+    queries built on it, so each one is asked for by name.
+    """
     Ref = frappe.qb.DocType("Insights Query Reference")
-    Query = frappe.qb.DocType("Insights Query v3")
-    return (
+    referencing = (
         frappe.qb.from_(Ref)
-        .join(Query)
-        .on(Query.name == Ref.query)
-        .select(Query.name, Query.title, Query.workbook)
+        .select(Ref.query)
         .where((Ref.ref_type == "Table") & (Ref.data_source == data_source) & (Ref.table_name == table_name))
-        .run(as_dict=True)
+        .run(pluck=True)
+    )
+    if not referencing:
+        return []
+
+    return frappe.get_list(
+        "Insights Query v3",
+        filters={"name": ("in", referencing)},
+        fields=["name", "title", "workbook"],
+        limit_page_length=0,
     )
 
 

--- a/insights/insights/doctype/insights_table_v3/insights_table_v3.py
+++ b/insights/insights/doctype/insights_table_v3/insights_table_v3.py
@@ -154,15 +154,24 @@ class InsightsTablev3(Document):
         t = apply_user_permissions(t, data_source, table_name)
         return t
 
+    def check_identity(self):
+        """`autoname` builds the name out of the data source and the table, so the
+        pair is this row's identity. A whitelisted method runs on a document built
+        from the request body, where the two can be made to disagree."""
+        if get_table_name(self.data_source or "", self.table or "") != self.name:
+            frappe.throw(frappe._("Table {0} is not {1}.{2}").format(self.name, self.data_source, self.table))
+
     @frappe.whitelist()
     def import_to_warehouse(self):
         frappe.only_for("Insights Admin")
+        self.check_identity()
         wt = insights.warehouse.get_table(self.data_source, self.table)
         wt.enqueue_import()
 
     @frappe.whitelist()
     def clear_warehouse_data(self):
         frappe.only_for("Insights Admin")
+        self.check_identity()
         insights.warehouse.get_table(self.data_source, self.table).drop()
         self.db_set(
             {
@@ -175,17 +184,9 @@ class InsightsTablev3(Document):
 
     @frappe.whitelist()
     def get_stats(self):
-        """Return usage and sync statistics for this table.
-
-        The pair comes from the stored row. `autoname` builds the name out of it,
-        so the pair is this row's identity, and access was decided on the name.
-        The numbers have to answer for the same table that name does.
-        """
-        stored = frappe.db.get_value("Insights Table v3", self.name, ["data_source", "table"], as_dict=True)
-        if not stored:
-            frappe.throw(frappe._("Table {0} not found").format(self.name), frappe.DoesNotExistError)
-
-        return get_table_stats(stored.data_source, stored.table)
+        """Return usage and sync statistics for this table."""
+        self.check_identity()
+        return get_table_stats(self.data_source, self.table)
 
 
 def get_table_name(data_source, table):

--- a/insights/insights/doctype/insights_table_v3/insights_table_v3.py
+++ b/insights/insights/doctype/insights_table_v3/insights_table_v3.py
@@ -190,9 +190,9 @@ def get_table_stats(data_source: str, table_name: str) -> dict:
         - last_synced_on: last successful import timestamp
         - last_import_rows: row count from the most recent import
         - last_import_duration: duration (seconds) of the most recent import
-        - referencing_queries: list of query names/titles that currently reference this table
-        - last_executed_on: when the most recent referencing query was last executed
-        - execution_count: total executions across all referencing queries
+        - referencing_queries: the queries referencing this table that the caller may read
+        - last_executed_on: when the most recent of those queries was last executed
+        - execution_count: total executions across those queries
         - total_syncs: total number of import attempts
         - total_sync_time: sum of all import durations (seconds)
         - failed_syncs: number of failed imports

--- a/insights/insights/doctype/insights_table_v3/insights_table_v3.py
+++ b/insights/insights/doctype/insights_table_v3/insights_table_v3.py
@@ -175,8 +175,17 @@ class InsightsTablev3(Document):
 
     @frappe.whitelist()
     def get_stats(self):
-        """Return usage and sync statistics for this table."""
-        return get_table_stats(self.data_source, self.table)
+        """Return usage and sync statistics for this table.
+
+        The pair comes from the stored row. `autoname` builds the name out of it,
+        so the pair is this row's identity, and access was decided on the name.
+        The numbers have to answer for the same table that name does.
+        """
+        stored = frappe.db.get_value("Insights Table v3", self.name, ["data_source", "table"], as_dict=True)
+        if not stored:
+            frappe.throw(frappe._("Table {0} not found").format(self.name), frappe.DoesNotExistError)
+
+        return get_table_stats(stored.data_source, stored.table)
 
 
 def get_table_name(data_source, table):

--- a/insights/insights/doctype/insights_workbook/insights_workbook.py
+++ b/insights/insights/doctype/insights_workbook/insights_workbook.py
@@ -12,6 +12,7 @@ from frappe.query_builder import Interval
 from frappe.query_builder.functions import Now
 from frappe.utils.telemetry import capture
 
+from insights.insights.query_utils import extract_query_deps_from_operations
 from insights.utils import deep_convert_dict_to_dict
 
 # `tabSeries` key the workbook counter lives under.
@@ -94,12 +95,14 @@ class InsightsWorkbook(Document):
             new_folder.insert(ignore_permissions=ignore_permissions)
             id_map[old_folder_name] = new_folder.name
 
+        queries = workbook_data.get("dependencies", {}).get("queries", {})
         query_sort_order = 0
-        for name, query in workbook_data.get("dependencies", {}).get("queries", {}).items():
-            query = deep_convert_dict_to_dict(query)
+        for name in _order_by_reference(queries):
+            query = deep_convert_dict_to_dict(queries[name])
             new_query = frappe.new_doc("Insights Query v3")
             new_query.update(query)
             new_query.workbook = target_workbook_name
+            new_query.operations = _rewrite_query_references(query.get("operations"), id_map)
 
             if query.get("folder") and query.get("folder") in id_map:
                 new_query.folder = id_map[query.get("folder")]
@@ -110,27 +113,6 @@ class InsightsWorkbook(Document):
 
             new_query.insert(ignore_permissions=ignore_permissions)
             id_map[name] = new_query.name
-
-        for name, _ in workbook_data.get("dependencies", {}).get("queries", {}).items():
-            new_query = frappe.get_doc("Insights Query v3", id_map[name])
-            operations = deep_convert_dict_to_dict(frappe.parse_json(new_query.operations))
-
-            should_update = False
-            for op in operations:
-                if (
-                    not op.get("table")
-                    or not op.get("table").get("type")
-                    or not op.get("table").get("query_name")
-                ):
-                    continue
-
-                ref_query = op.table.query_name
-                if ref_query in id_map:
-                    op.table.query_name = id_map[ref_query]
-                    should_update = True
-
-            if should_update:
-                new_query.db_set("operations", frappe.as_json(operations))
 
         chart_sort_order = 0
         for name, chart in workbook_data.get("dependencies", {}).get("charts", {}).items():
@@ -483,6 +465,51 @@ class InsightsWorkbook(Document):
             "nodes": list(nodes.values()),
             "edges": edge_list,
         }
+
+
+def _order_by_reference(queries: dict) -> list[str]:
+    """The names in `queries`, each one after the queries in the file it references.
+
+    A query is inserted with its references already pointing at the copies they
+    name, so those copies have to exist first. References form a directed acyclic
+    graph, so such an order exists. A file carrying a cycle has no order, and the
+    names left over go last for the cycle check to refuse.
+    """
+    deps = {
+        name: {
+            dep
+            for dep in extract_query_deps_from_operations(frappe.parse_json(query.get("operations")) or [])
+            if dep in queries
+        }
+        for name, query in queries.items()
+    }
+
+    ordered = []
+    placed = set()
+    while len(placed) < len(deps):
+        ready = [name for name, refs in deps.items() if name not in placed and refs <= placed]
+        if not ready:
+            ordered.extend(name for name in deps if name not in placed)
+            break
+        ordered.extend(ready)
+        placed.update(ready)
+
+    return ordered
+
+
+def _rewrite_query_references(operations, id_map: dict) -> str:
+    """Point every reference in `operations` at the copy that replaces it.
+
+    A name the file does not carry belongs to a query already on this site, and
+    is left alone: the import references that one, and read access decides.
+    """
+    operations = deep_convert_dict_to_dict(frappe.parse_json(operations) or [])
+    for op in operations:
+        table = op.get("table") or {}
+        if table.get("type") == "query" and table.get("query_name") in id_map:
+            table["query_name"] = id_map[table["query_name"]]
+
+    return frappe.as_json(operations)
 
 
 def import_workbook(workbook):

--- a/insights/insights/doctype/insights_workbook/insights_workbook.py
+++ b/insights/insights/doctype/insights_workbook/insights_workbook.py
@@ -12,7 +12,7 @@ from frappe.query_builder import Interval
 from frappe.query_builder.functions import Now
 from frappe.utils.telemetry import capture
 
-from insights.insights.query_utils import extract_query_deps_from_operations
+from insights.insights.query_utils import referenced_queries
 from insights.utils import deep_convert_dict_to_dict
 
 # `tabSeries` key the workbook counter lives under.
@@ -472,16 +472,11 @@ def _order_by_reference(queries: dict) -> list[str]:
 
     A query is inserted with its references already pointing at the copies they
     name, so those copies have to exist first. References form a directed acyclic
-    graph, so such an order exists. A file carrying a cycle has no order, and the
-    names left over go last for the cycle check to refuse.
+    graph, so such an order exists. A file with no such order carries a cycle,
+    which the exporting site would not have let anyone save.
     """
     deps = {
-        name: {
-            dep
-            for dep in extract_query_deps_from_operations(frappe.parse_json(query.get("operations")) or [])
-            if dep in queries
-        }
-        for name, query in queries.items()
+        name: referenced_queries(query.get("operations")) & queries.keys() for name, query in queries.items()
     }
 
     ordered = []
@@ -489,8 +484,11 @@ def _order_by_reference(queries: dict) -> list[str]:
     while len(placed) < len(deps):
         ready = [name for name, refs in deps.items() if name not in placed and refs <= placed]
         if not ready:
-            ordered.extend(name for name in deps if name not in placed)
-            break
+            frappe.throw(
+                frappe._("Circular query reference detected in {0}").format(
+                    ", ".join(name for name in deps if name not in placed)
+                )
+            )
         ordered.extend(ready)
         placed.update(ready)
 

--- a/insights/insights/doctype/insights_workbook/insights_workbook.py
+++ b/insights/insights/doctype/insights_workbook/insights_workbook.py
@@ -472,8 +472,7 @@ def _order_by_reference(queries: dict) -> list[str]:
 
     A query is inserted with its references already pointing at the copies they
     name, so those copies have to exist first. References form a directed acyclic
-    graph, so such an order exists. A file with no such order carries a cycle,
-    which the exporting site would not have let anyone save.
+    graph, so such an order exists. A file with no such order carries a cycle.
     """
     deps = {
         name: referenced_queries(query.get("operations")) & queries.keys() for name, query in queries.items()

--- a/insights/insights/query_utils.py
+++ b/insights/insights/query_utils.py
@@ -103,6 +103,25 @@ def extract_table_deps_from_sql_operations(operations: list) -> list[dict]:
     return result
 
 
+def table_references(operations) -> list[dict]:
+    """The (data_source, table_name) pairs `operations` reads.
+
+    A builder operation names its table outright. A native SQL operation carries
+    it in the SQL, so it has to be parsed out.
+    """
+    ops = frappe.parse_json(operations) or []
+
+    seen: set[tuple] = set()
+    result = []
+    for ref in extract_table_deps_from_operations(ops) + extract_table_deps_from_sql_operations(ops):
+        key = (ref["data_source"], ref["table_name"])
+        if key in seen:
+            continue
+        seen.add(key)
+        result.append(ref)
+    return result
+
+
 def sync_query_references(query_name: str, operations) -> None:
     """Rebuild edge rows for *query_name* in Insights Query Reference.
 
@@ -114,8 +133,7 @@ def sync_query_references(query_name: str, operations) -> None:
     ops = frappe.parse_json(operations) or []
 
     docs = []
-    all_table_deps = extract_table_deps_from_operations(ops) + extract_table_deps_from_sql_operations(ops)
-    for tbl in all_table_deps:
+    for tbl in table_references(ops):
         ref = frappe.new_doc("Insights Query Reference")
         ref.name = frappe.generate_hash(length=10)
         ref.query = query_name
@@ -138,12 +156,21 @@ def sync_query_references(query_name: str, operations) -> None:
 
 
 def get_direct_dependencies(query_name: str) -> list[str]:
-    """Return the query names this query directly depends on, from the edge table."""
-    return frappe.get_all(
-        "Insights Query Reference",
-        filters={"query": query_name, "ref_type": "Query"},
-        pluck="ref_query",
-    )
+    """Return the query names this query directly depends on.
+
+    Read from the query's own `operations`, not from `Insights Query Reference`.
+    A forward edge is already in the row, and the edge table is rebuilt by a
+    background job that runs after the save commits, so it lags every write.
+
+    Only the edge table answers the reverse question - who references this query.
+    `get_lineage_graph` and `get_last_execution_per_table` still read it forwards,
+    where a report that lags one job is the whole point of the index.
+    """
+    if not query_name:
+        return []
+
+    operations = frappe.db.get_value("Insights Query v3", query_name, "operations")
+    return list(referenced_queries(operations))
 
 
 def transitive_closure(start: str) -> set[str]:

--- a/insights/insights/query_utils.py
+++ b/insights/insights/query_utils.py
@@ -52,6 +52,11 @@ def extract_query_deps_from_operations(operations: list) -> list[str]:
     ]
 
 
+def referenced_queries(operations) -> set[str]:
+    """The query names `operations` references, from a stored or parsed value."""
+    return set(extract_query_deps_from_operations(frappe.parse_json(operations) or []))
+
+
 def extract_table_deps_from_operations(operations: list) -> list[dict]:
     """Extract all unique (data_source, table_name) pairs from a list of operations."""
     seen: set[tuple] = set()

--- a/insights/permissions.py
+++ b/insights/permissions.py
@@ -426,14 +426,15 @@ def check_referenced_query_access(query_name):
     """A query named by another document is still a document you have to read.
 
     A reference resolves to the whole query - its operations, its native SQL and
-    the tables it reads - and the compiled result carries all of it back. So the
-    reference is read-checked, wherever it is named: an operation that sources,
-    joins or unions a query, or a dashboard filter that links one.
+    the tables it reads - and the compiled result carries all of it back.
 
-    A public document runs as published, so what it may reach was decided when it
-    was published, not by who is calling.
+    A public document runs as published, so what it may reach was decided then.
     """
     if frappe.flags.get("insights_for_public_access"):
+        return
+
+    # a name with no row resolves to nothing. The build says "not found" instead.
+    if not frappe.db.exists("Insights Query v3", query_name):
         return
 
     if not frappe.has_permission("Insights Query v3", ptype="read", doc=query_name):

--- a/insights/permissions.py
+++ b/insights/permissions.py
@@ -422,6 +422,27 @@ class InsightsPermissions:
         return frappe.qb.from_(Resource).select(Resource.resource_name.as_("name")).where(condition)
 
 
+def check_referenced_query_access(query_name):
+    """A query named by another document is still a document you have to read.
+
+    A reference resolves to the whole query - its operations, its native SQL and
+    the tables it reads - and the compiled result carries all of it back. So the
+    reference is read-checked, wherever it is named: an operation that sources,
+    joins or unions a query, or a dashboard filter that links one.
+
+    A public document runs as published, so what it may reach was decided when it
+    was published, not by who is calling.
+    """
+    if frappe.flags.get("insights_for_public_access"):
+        return
+
+    if not frappe.has_permission("Insights Query v3", ptype="read", doc=query_name):
+        frappe.throw(
+            frappe._("You do not have access to a query this one references"),
+            frappe.PermissionError,
+        )
+
+
 def check_chart_query_access(chart):
     """A chart may only point at a query its author can read.
 

--- a/insights/tests/base.py
+++ b/insights/tests/base.py
@@ -68,6 +68,21 @@ class InsightsIntegrationTestCase(IntegrationTestCase):
     def as_user(self, user):
         return as_user(user)
 
+    def set_team_permissions(self, enabled):
+        """Turn `enable_permissions` on or off for one test.
+
+        The setting scopes data sources and tables to teams. It has never scoped
+        a workbook's contents, so a rule over those has to hold either way. The
+        allowed-resource lookup is site-cached, so the cache goes with it.
+        """
+        from insights.insights.doctype.insights_team.insights_team import clear_cache
+
+        original = frappe.db.get_single_value("Insights Settings", "enable_permissions")
+        frappe.db.set_single_value("Insights Settings", "enable_permissions", enabled)
+        clear_cache()
+        self.addCleanup(clear_cache)
+        self.addCleanup(frappe.db.set_single_value, "Insights Settings", "enable_permissions", original)
+
     def assert_visible_to(self, user, doctype, name, message=None):
         with self.as_user(user):
             self.assertTrue(

--- a/insights/tests/test_permissions.py
+++ b/insights/tests/test_permissions.py
@@ -63,10 +63,6 @@ class TestInsightsPermissions(InsightsIntegrationTestCase):
     def after_test(self):
         clear_team_cache()
 
-    def toggle_team_permissions(self, enable):
-        frappe.db.set_single_value(DT.SETTINGS, "enable_permissions", enable)
-        clear_team_cache()
-
     def assert_no_access_to(self, user, doctype, name):
         """Both consumers of the permission query must refuse the user."""
         self.assert_not_visible_to(user, doctype, name)
@@ -111,7 +107,7 @@ class TestInsightsPermissions(InsightsIntegrationTestCase):
         create_test_data_sources()
         create_test_tables()
         create_test_teams()
-        self.toggle_team_permissions(False)
+        self.set_team_permissions(False)
 
         self.assert_visible_to(USER_2, DT.DATA_SOURCE, TEST_DS)
         self.assert_visible_to(USER_2, DT.TABLE, TEST_TABLE1)
@@ -120,7 +116,7 @@ class TestInsightsPermissions(InsightsIntegrationTestCase):
         create_test_data_sources()
         create_test_tables()
         team = create_test_teams()
-        self.toggle_team_permissions(True)
+        self.set_team_permissions(True)
 
         self.assert_not_visible_to(USER_2, DT.DATA_SOURCE, TEST_DS)
         self.assert_not_visible_to(USER_2, DT.TABLE, TEST_TABLE1)
@@ -151,7 +147,7 @@ class TestInsightsPermissions(InsightsIntegrationTestCase):
         an empty set of grants have to land on the same empty result.
         """
         granted = self.grant_every_resource_type_to_a_team()
-        self.toggle_team_permissions(True)
+        self.set_team_permissions(True)
 
         for doctype, name in granted.items():
             self.assert_visible_to(USER_1, doctype, name)
@@ -168,7 +164,7 @@ class TestInsightsPermissions(InsightsIntegrationTestCase):
         access, which the grant holder does not have either.
         """
         granted = self.grant_every_resource_type_to_a_team()
-        self.toggle_team_permissions(False)
+        self.set_team_permissions(False)
 
         for user in (USER_1, USER_2, USER_3):
             self.assert_visible_to(user, DT.DATA_SOURCE, granted[DT.DATA_SOURCE])
@@ -181,7 +177,7 @@ class TestInsightsPermissions(InsightsIntegrationTestCase):
     ):
         create_test_data_sources()
         create_test_tables()
-        self.toggle_team_permissions(True)
+        self.set_team_permissions(True)
 
         self.assert_visible_to(ADMIN, DT.DATA_SOURCE, TEST_DS)
         self.assert_visible_to(ADMIN, DT.TABLE, TEST_TABLE1)
@@ -215,7 +211,7 @@ class TestInsightsPermissions(InsightsIntegrationTestCase):
         # must find the other Insights users in it - with or without team permissions
         for team_permissions in (False, True):
             with self.subTest(team_permissions=team_permissions):
-                self.toggle_team_permissions(team_permissions)
+                self.set_team_permissions(team_permissions)
                 with self.as_user(USER_1):
                     emails = [user["email"] for user in get_users()]
 
@@ -299,7 +295,7 @@ class TestInsightsPermissions(InsightsIntegrationTestCase):
                 )
 
     def test_team_membership_is_listed_for_admins_only(self):
-        self.toggle_team_permissions(True)
+        self.set_team_permissions(True)
 
         with self.as_user(USER_1):
             self.assertNotIn("teams", get_users()[0])
@@ -457,7 +453,7 @@ class TestInsightsPermissions(InsightsIntegrationTestCase):
     def test_download_results_requires_export_permission(self):
         workbook = create_test_workbook(USER_1)
         query = create_test_query(USER_1, workbook.name)
-        self.toggle_team_permissions(False)
+        self.set_team_permissions(False)
         frappe.db.set_single_value(DT.SETTINGS, "allow_download", 1)
         self.addCleanup(frappe.clear_cache, doctype=DT.QUERY)
 
@@ -482,7 +478,7 @@ class TestInsightsPermissions(InsightsIntegrationTestCase):
         workbook = create_test_workbook(USER_1)
         query = create_test_query(USER_1, workbook.name)
         frappe.db.set_single_value(DT.SETTINGS, "allow_download", 1)
-        self.toggle_team_permissions(True)
+        self.set_team_permissions(True)
 
         # USER_2 has the role-level export permission, but no access to
         # USER_1's workbook or query, so the download must still be blocked
@@ -493,7 +489,7 @@ class TestInsightsPermissions(InsightsIntegrationTestCase):
                 query_doc.download_results(format="csv")
 
         # the owner can still download their own query
-        self.toggle_team_permissions(False)
+        self.set_team_permissions(False)
         with self.as_user(USER_1):
             query_doc = frappe.get_doc(DT.QUERY, query.name)
             with db_connections():
@@ -506,7 +502,7 @@ class TestInsightsPermissions(InsightsIntegrationTestCase):
         # keep team permissions disabled so the underlying table stays
         # accessible; the owner/share based document restriction on
         # workbooks & queries is enforced regardless of this setting
-        self.toggle_team_permissions(False)
+        self.set_team_permissions(False)
         frappe.db.set_single_value(DT.SETTINGS, "allow_download", 1)
 
         # USER_2 is given read-only access to USER_1's workbook
@@ -529,7 +525,7 @@ class TestInsightsPermissions(InsightsIntegrationTestCase):
     def test_download_results_blocked_when_globally_disabled(self):
         workbook = create_test_workbook(USER_1)
         query = create_test_query(USER_1, workbook.name)
-        self.toggle_team_permissions(False)
+        self.set_team_permissions(False)
         frappe.db.set_single_value(DT.SETTINGS, "allow_download", 0)
 
         # USER_1 has the export permission via the Insights User role,

--- a/insights/tests/test_query_references.py
+++ b/insights/tests/test_query_references.py
@@ -1,0 +1,230 @@
+"""A query reached through a reference is read like any other query.
+
+An operation may source, join or union another query, and a dashboard filter may
+link one. Either way the reference resolves to the whole query - its operations,
+its native SQL, and the tables it reads - and the compiled result carries all of
+it back. So the rule is the same as reading the query directly.
+"""
+
+import frappe
+
+from insights.insights.doctype.insights_data_source_v3.insights_data_source_v3 import (
+    db_connections,
+)
+from insights.tests.base import InsightsIntegrationTestCase
+from insights.tests.factories import (
+    DT,
+    as_user,
+    create_test_workbook,
+    delete_users,
+)
+from insights.tests.permissions_utils import USER_1, USER_2, create_test_users
+
+OWNER = USER_1
+OTHER = USER_2
+
+SECRET = "referenced query secret"
+SOURCE_ROWS = f"results = [{{'secret': '{SECRET}', 'amount': 1}}]"
+
+
+def create_source_query(owner, workbook, title):
+    """A query that stands on its own, so no table permission enters the picture."""
+    with as_user(owner):
+        return frappe.get_doc(
+            {
+                "doctype": DT.QUERY,
+                "title": title,
+                "workbook": workbook,
+                "use_live_connection": 0,
+                "is_script_query": 1,
+                "operations": [{"type": "code", "code": SOURCE_ROWS}],
+            }
+        ).insert()
+
+
+def create_referencing_query(owner, workbook, referenced, title):
+    with as_user(owner):
+        return frappe.get_doc(
+            {
+                "doctype": DT.QUERY,
+                "title": title,
+                "workbook": workbook,
+                "use_live_connection": 0,
+                "is_builder_query": 1,
+                "operations": [
+                    {
+                        "type": "source",
+                        "table": {"type": "query", "query_name": referenced},
+                    }
+                ],
+            }
+        ).insert()
+
+
+class ReferencedQueryIsReadChecked:
+    """The rules. Both `enable_permissions` settings run them.
+
+    The setting scopes data sources and tables to teams. These queries carry no
+    table, so what is left is the reference itself.
+    """
+
+    ENABLE_PERMISSIONS = 0
+
+    @classmethod
+    def before_class(cls):
+        create_test_users()
+        cls.owner_workbook = create_test_workbook(OWNER, title="Reference Owner Workbook").name
+        cls.owner_query = create_source_query(OWNER, cls.owner_workbook, "Reference Owner Source").name
+        cls.owner_reference = create_referencing_query(
+            OWNER, cls.owner_workbook, cls.owner_query, "Reference Owner Consumer"
+        ).name
+
+        cls.other_workbook = create_test_workbook(OTHER, title="Reference Other Workbook").name
+        cls.other_reference = create_referencing_query(
+            OTHER, cls.other_workbook, cls.owner_query, "Reference Other Consumer"
+        ).name
+
+    @classmethod
+    def after_class(cls):
+        for name in (cls.owner_workbook, cls.other_workbook):
+            frappe.delete_doc(DT.WORKBOOK, name, force=True, ignore_permissions=True)
+        delete_users(OWNER, OTHER)
+
+    def before_test(self):
+        self.set_team_permissions(self.ENABLE_PERMISSIONS)
+
+    def execute(self, name):
+        with db_connections():
+            return frappe.get_doc(DT.QUERY, name).execute()
+
+    def test_the_owner_cannot_be_read_by_the_other_user(self):
+        """The baseline the refusals below are measured against."""
+        with self.as_user(OTHER):
+            self.assertFalse(frappe.has_permission(DT.QUERY, ptype="read", doc=self.owner_query))
+
+    def test_a_query_reference_resolves_for_someone_who_may_read_it(self):
+        with self.as_user(OWNER):
+            result = self.execute(self.owner_reference)
+        self.assertEqual(result["rows"][0]["secret"], SECRET)
+
+    def test_a_query_reference_is_refused_to_someone_who_may_not(self):
+        with self.as_user(OTHER), self.assertRaises(frappe.PermissionError):
+            self.execute(self.other_reference)
+
+    def test_a_refused_reference_returns_no_sql(self):
+        """The compiled SQL is the query's logic, so a refusal returns none of it."""
+        with self.as_user(OTHER):
+            try:
+                result = self.execute(self.other_reference)
+            except frappe.PermissionError:
+                return
+            self.fail(f"the reference resolved and returned {result.get('sql')}")
+
+    def test_a_reference_sent_inline_is_refused_too(self):
+        """The operations arrive in the request, so the reference need not be saved."""
+        with self.as_user(OTHER):
+            doc = frappe.get_doc(
+                {
+                    "doctype": DT.QUERY,
+                    "name": "new-query-inline",
+                    "workbook": self.other_workbook,
+                    "use_live_connection": 0,
+                    "is_builder_query": 1,
+                    "__islocal": True,
+                    "operations": [
+                        {
+                            "type": "source",
+                            "table": {"type": "query", "query_name": self.owner_query},
+                        }
+                    ],
+                }
+            )
+            with self.assertRaises(frappe.PermissionError), db_connections():
+                doc.execute()
+
+
+class DashboardFilterReadsTheQuery:
+    """The same rule where a dashboard filter names a query.
+
+    A filter links a column as `` `<query>`.`<column>` ``. The dashboard says
+    which columns it filters on, so it cannot also be what says which queries the
+    caller may reach.
+    """
+
+    ENABLE_PERMISSIONS = 0
+
+    @classmethod
+    def before_class(cls):
+        create_test_users()
+        cls.owner_workbook = create_test_workbook(OWNER, title="Filter Owner Workbook").name
+        cls.owner_query = create_source_query(OWNER, cls.owner_workbook, "Filter Owner Source").name
+
+        cls.other_workbook = create_test_workbook(OTHER, title="Filter Other Workbook").name
+        cls.other_query = create_source_query(OTHER, cls.other_workbook, "Filter Other Source").name
+
+        cls.owner_dashboard = cls.create_dashboard(OWNER, cls.owner_workbook, cls.owner_query)
+        cls.other_dashboard = cls.create_dashboard(OTHER, cls.other_workbook, cls.owner_query)
+
+    @classmethod
+    def create_dashboard(cls, owner, workbook, query):
+        with as_user(owner):
+            return (
+                frappe.get_doc(
+                    {
+                        "doctype": DT.DASHBOARD,
+                        "title": f"Filter Dashboard {workbook}",
+                        "workbook": workbook,
+                        "items": [
+                            {
+                                "id": "filter-1",
+                                "type": "filter",
+                                "links": {"chart-1": f"`{query}`.`secret`"},
+                            }
+                        ],
+                    }
+                )
+                .insert()
+                .name
+            )
+
+    @classmethod
+    def after_class(cls):
+        for name in (cls.owner_workbook, cls.other_workbook):
+            frappe.delete_doc(DT.WORKBOOK, name, force=True, ignore_permissions=True)
+        delete_users(OWNER, OTHER)
+
+    def before_test(self):
+        self.set_team_permissions(self.ENABLE_PERMISSIONS)
+
+    def distinct_values(self, dashboard, query):
+        with db_connections():
+            return frappe.get_doc(DT.DASHBOARD, dashboard).get_distinct_column_values(query, "secret")
+
+    def test_a_filter_reads_a_query_its_owner_may_read(self):
+        with self.as_user(OWNER):
+            values = self.distinct_values(self.owner_dashboard, self.owner_query)
+        self.assertEqual(values, [SECRET])
+
+    def test_a_filter_cannot_read_a_query_its_owner_may_not(self):
+        with self.as_user(OTHER), self.assertRaises(frappe.PermissionError):
+            self.distinct_values(self.other_dashboard, self.owner_query)
+
+
+class TestReferencedQueryIsReadChecked(ReferencedQueryIsReadChecked, InsightsIntegrationTestCase):
+    ENABLE_PERMISSIONS = 0
+
+
+class TestReferencedQueryIsReadCheckedWithTeamPermissions(
+    ReferencedQueryIsReadChecked, InsightsIntegrationTestCase
+):
+    ENABLE_PERMISSIONS = 1
+
+
+class TestDashboardFilterReadsTheQuery(DashboardFilterReadsTheQuery, InsightsIntegrationTestCase):
+    ENABLE_PERMISSIONS = 0
+
+
+class TestDashboardFilterReadsTheQueryWithTeamPermissions(
+    DashboardFilterReadsTheQuery, InsightsIntegrationTestCase
+):
+    ENABLE_PERMISSIONS = 1

--- a/insights/tests/test_query_references.py
+++ b/insights/tests/test_query_references.py
@@ -17,6 +17,7 @@ from insights.api import run_doc_method
 from insights.insights.doctype.insights_data_source_v3.insights_data_source_v3 import (
     db_connections,
 )
+from insights.insights.query_utils import sync_query_references
 from insights.tests.base import InsightsIntegrationTestCase
 from insights.tests.factories import (
     DT,
@@ -193,6 +194,20 @@ class ASavedReferenceCarriesItsOwnAccess:
 
     def test_someone_with_the_chart_can_run_the_chain(self):
         """Running the query they may read is what the share is for."""
+        with self.as_user(VIEWER), db_connections():
+            result = frappe.get_doc(DT.QUERY, self.consumer).execute()
+        self.assertEqual(result["rows"][0]["secret"], SECRET)
+
+    def test_the_chain_runs_before_the_reference_index_is_built(self):
+        """`Insights Query Reference` is rebuilt by a background job after the save
+        commits, so it lags. What was saved is what decides, and it cannot wait."""
+        frappe.db.delete("Insights Query Reference", {"query": self.consumer})
+        self.addCleanup(
+            sync_query_references,
+            self.consumer,
+            frappe.db.get_value(DT.QUERY, self.consumer, "operations"),
+        )
+
         with self.as_user(VIEWER), db_connections():
             result = frappe.get_doc(DT.QUERY, self.consumer).execute()
         self.assertEqual(result["rows"][0]["secret"], SECRET)

--- a/insights/tests/test_query_references.py
+++ b/insights/tests/test_query_references.py
@@ -7,7 +7,9 @@ it back. So the rule is the same as reading the query directly.
 """
 
 import frappe
+from frappe.utils import set_request
 
+from insights.api import run_doc_method
 from insights.insights.doctype.insights_data_source_v3.insights_data_source_v3 import (
     db_connections,
 )
@@ -15,6 +17,7 @@ from insights.tests.base import InsightsIntegrationTestCase
 from insights.tests.factories import (
     DT,
     as_user,
+    create_test_chart,
     create_test_workbook,
     delete_users,
 )
@@ -210,6 +213,67 @@ class DashboardFilterReadsTheQuery:
             self.distinct_values(self.other_dashboard, self.owner_query)
 
 
+class ChartExportReadsTheQuery:
+    """The same rule where a chart names the query it is built on.
+
+    `Insights Chart v3.export` exports the linked query in full. The chart is
+    checked, and until now the query it named was not. A chart may only be saved
+    over a query its author can read, but a document method runs on the body the
+    client sends, so the link the method reads need never have been saved.
+    """
+
+    ENABLE_PERMISSIONS = 0
+
+    @classmethod
+    def before_class(cls):
+        create_test_users()
+        cls.owner_workbook = create_test_workbook(OWNER, title="Chart Export Owner Workbook").name
+        cls.owner_query = create_source_query(OWNER, cls.owner_workbook, "Chart Export Owner Source").name
+        cls.owner_chart = create_test_chart(
+            OWNER, cls.owner_workbook, query=cls.owner_query, title="Chart Export Owner Chart"
+        ).name
+
+        cls.other_workbook = create_test_workbook(OTHER, title="Chart Export Other Workbook").name
+        cls.other_query = create_source_query(OTHER, cls.other_workbook, "Chart Export Other Source").name
+        cls.other_chart = create_test_chart(
+            OTHER, cls.other_workbook, query=cls.other_query, title="Chart Export Other Chart"
+        ).name
+
+    @classmethod
+    def after_class(cls):
+        for name in (cls.owner_workbook, cls.other_workbook):
+            frappe.delete_doc(DT.WORKBOOK, name, force=True, ignore_permissions=True)
+        delete_users(OWNER, OTHER)
+
+    def before_test(self):
+        self.set_team_permissions(self.ENABLE_PERMISSIONS)
+        set_request(method="POST", path="/api/method/insights.api.run_doc_method")
+
+    def export_chart(self, name, **claims):
+        """The client sends the chart it holds, so the body carries its fields."""
+        chart = frappe.get_doc(DT.CHART, name)
+        body = {
+            "doctype": DT.CHART,
+            "name": chart.name,
+            "workbook": chart.workbook,
+            "query": chart.query,
+            "chart_type": chart.chart_type,
+        }
+        return run_doc_method("export", {**body, **claims})
+
+    def test_a_chart_exports_the_query_its_owner_may_read(self):
+        """The baseline: the export carries the linked query."""
+        with self.as_user(OWNER):
+            exported = self.export_chart(self.owner_chart)
+        self.assertIn(self.owner_query, exported["dependencies"]["queries"])
+
+    def test_a_chart_cannot_export_a_query_its_caller_may_not_read(self):
+        """The link is sent with the request, so the stored chart says nothing
+        about which query the export reads."""
+        with self.as_user(OTHER), self.assertRaises(frappe.PermissionError):
+            self.export_chart(self.other_chart, query=self.owner_query)
+
+
 class TestReferencedQueryIsReadChecked(ReferencedQueryIsReadChecked, InsightsIntegrationTestCase):
     ENABLE_PERMISSIONS = 0
 
@@ -227,4 +291,12 @@ class TestDashboardFilterReadsTheQuery(DashboardFilterReadsTheQuery, InsightsInt
 class TestDashboardFilterReadsTheQueryWithTeamPermissions(
     DashboardFilterReadsTheQuery, InsightsIntegrationTestCase
 ):
+    ENABLE_PERMISSIONS = 1
+
+
+class TestChartExportReadsTheQuery(ChartExportReadsTheQuery, InsightsIntegrationTestCase):
+    ENABLE_PERMISSIONS = 0
+
+
+class TestChartExportReadsTheQueryWithTeamPermissions(ChartExportReadsTheQuery, InsightsIntegrationTestCase):
     ENABLE_PERMISSIONS = 1

--- a/insights/tests/test_query_references.py
+++ b/insights/tests/test_query_references.py
@@ -27,9 +27,13 @@ from insights.tests.factories import (
     delete_users,
 )
 from insights.tests.permissions_utils import (
+    TEST_DS,
     USER_1,
     USER_2,
     USER_3,
+    cleanup_test_fixtures,
+    create_test_data_sources,
+    create_test_tables,
     create_test_users,
     share_chart,
 )
@@ -212,6 +216,32 @@ class ASavedReferenceCarriesItsOwnAccess:
             result = frappe.get_doc(DT.QUERY, self.consumer).execute()
         self.assertEqual(result["rows"][0]["secret"], SECRET)
 
+    def test_an_export_carries_its_references_before_the_index_is_built(self):
+        """An export packs the queries it is built on. Which those are comes from
+        the query, not from the index that a background job rebuilds."""
+        frappe.db.delete("Insights Query Reference", {"query": self.consumer})
+        self.addCleanup(
+            sync_query_references,
+            self.consumer,
+            frappe.db.get_value(DT.QUERY, self.consumer, "operations"),
+        )
+
+        with self.as_user(OWNER):
+            exported = frappe.get_doc(DT.QUERY, self.consumer).export()
+        self.assertIn(self.base, exported["dependencies"]["queries"])
+
+    def test_an_export_skips_a_reference_whose_query_is_gone(self):
+        """`on_trash` drops the edge rows but not the operations that name the
+        query, so the export list carries a name with no row behind it."""
+        with self.as_user(OWNER):
+            gone = create_source_query(OWNER, self.workbook, "Chain Doomed Base").name
+            orphan = create_referencing_query(OWNER, self.workbook, gone, "Chain Orphan").name
+            frappe.delete_doc(DT.QUERY, gone, force=True)
+
+            exported = frappe.get_doc(DT.QUERY, orphan).export()
+
+        self.assertEqual(exported["dependencies"]["queries"], {})
+
     def test_a_reference_cannot_be_saved_to_an_unreadable_query(self):
         """Where the check lives."""
         with self.as_user(VIEWER), self.assertRaises(frappe.PermissionError):
@@ -352,6 +382,60 @@ class ChartExportReadsTheQuery:
         about which query the export reads."""
         with self.as_user(OTHER), self.assertRaises(frappe.PermissionError):
             self.export_chart(self.other_chart, query=self.owner_query)
+
+
+def create_query_over_a_table(owner, workbook, title):
+    with as_user(owner):
+        return frappe.get_doc(
+            {
+                "doctype": DT.QUERY,
+                "title": title,
+                "workbook": workbook,
+                "use_live_connection": 1,
+                "is_builder_query": 1,
+                "operations": [
+                    {
+                        "type": "source",
+                        "table": {"type": "table", "data_source": TEST_DS, "table_name": "table1"},
+                    }
+                ],
+            }
+        ).insert()
+
+
+class TestSourceTablesComeFromTheQuery(InsightsIntegrationTestCase):
+    """Which tables a query reads is a forward question, so the row answers it.
+
+    `refresh_stored_tables` runs right after a save, and the edge table is rebuilt
+    by a background job that runs after the save commits.
+    """
+
+    @classmethod
+    def before_class(cls):
+        create_test_users()
+        create_test_data_sources()
+        create_test_tables()
+        cls.workbook = create_test_workbook(OWNER, title="Source Tables Workbook").name
+        cls.query = create_query_over_a_table(OWNER, cls.workbook, "Source Tables Query").name
+
+    @classmethod
+    def after_class(cls):
+        frappe.delete_doc(DT.WORKBOOK, cls.workbook, force=True, ignore_permissions=True)
+        cleanup_test_fixtures()
+        delete_users(OWNER)
+
+    def test_the_tables_are_found_before_the_index_is_built(self):
+        frappe.db.delete("Insights Query Reference", {"query": self.query})
+        self.addCleanup(
+            sync_query_references,
+            self.query,
+            frappe.db.get_value(DT.QUERY, self.query, "operations"),
+        )
+
+        with self.as_user(OWNER):
+            tables = frappe.get_doc(DT.QUERY, self.query).get_source_tables()
+
+        self.assertEqual(tables, [{"data_source": TEST_DS, "table_name": "table1"}])
 
 
 class TestAReferenceInTheRequestIsChecked(AReferenceInTheRequestIsChecked, InsightsIntegrationTestCase):

--- a/insights/tests/test_query_references.py
+++ b/insights/tests/test_query_references.py
@@ -1,9 +1,13 @@
 """A query reached through a reference is read like any other query.
 
-An operation may source, join or union another query, and a dashboard filter may
-link one. Either way the reference resolves to the whole query - its operations,
-its native SQL, and the tables it reads - and the compiled result carries all of
-it back. So the rule is the same as reading the query directly.
+An operation may source, join or union another query, and a dashboard filter or a
+chart may name one. Either way the reference resolves to the whole query - its
+operations, its native SQL, and the tables it reads - and the compiled result
+carries all of it back.
+
+The reference is checked once, where it is written. Execution then trusts what was
+saved, so a chain stays runnable by everyone who may read the query at its head.
+A reference that arrives with the request was never written, and is checked then.
 """
 
 import frappe
@@ -21,10 +25,17 @@ from insights.tests.factories import (
     create_test_workbook,
     delete_users,
 )
-from insights.tests.permissions_utils import USER_1, USER_2, create_test_users
+from insights.tests.permissions_utils import (
+    USER_1,
+    USER_2,
+    USER_3,
+    create_test_users,
+    share_chart,
+)
 
 OWNER = USER_1
 OTHER = USER_2
+VIEWER = USER_3
 
 SECRET = "referenced query secret"
 SOURCE_ROWS = f"results = [{{'secret': '{SECRET}', 'amount': 1}}]"
@@ -45,6 +56,10 @@ def create_source_query(owner, workbook, title):
         ).insert()
 
 
+def reference_operations(query_name):
+    return [{"type": "source", "table": {"type": "query", "query_name": query_name}}]
+
+
 def create_referencing_query(owner, workbook, referenced, title):
     with as_user(owner):
         return frappe.get_doc(
@@ -54,21 +69,16 @@ def create_referencing_query(owner, workbook, referenced, title):
                 "workbook": workbook,
                 "use_live_connection": 0,
                 "is_builder_query": 1,
-                "operations": [
-                    {
-                        "type": "source",
-                        "table": {"type": "query", "query_name": referenced},
-                    }
-                ],
+                "operations": reference_operations(referenced),
             }
         ).insert()
 
 
-class ReferencedQueryIsReadChecked:
-    """The rules. Both `enable_permissions` settings run them.
+class AReferenceInTheRequestIsChecked:
+    """The rules for a reference that was never saved.
 
-    The setting scopes data sources and tables to teams. These queries carry no
-    table, so what is left is the reference itself.
+    Operations arrive with the request, so a caller can name any query in them.
+    Nothing authorised that, and it is checked as it resolves.
     """
 
     ENABLE_PERMISSIONS = 0
@@ -83,9 +93,7 @@ class ReferencedQueryIsReadChecked:
         ).name
 
         cls.other_workbook = create_test_workbook(OTHER, title="Reference Other Workbook").name
-        cls.other_reference = create_referencing_query(
-            OTHER, cls.other_workbook, cls.owner_query, "Reference Other Consumer"
-        ).name
+        cls.other_query = create_source_query(OTHER, cls.other_workbook, "Reference Other Source").name
 
     @classmethod
     def after_class(cls):
@@ -96,34 +104,17 @@ class ReferencedQueryIsReadChecked:
     def before_test(self):
         self.set_team_permissions(self.ENABLE_PERMISSIONS)
 
-    def execute(self, name):
-        with db_connections():
-            return frappe.get_doc(DT.QUERY, name).execute()
-
-    def test_the_owner_cannot_be_read_by_the_other_user(self):
+    def test_the_owner_query_is_not_readable_by_the_other_user(self):
         """The baseline the refusals below are measured against."""
         with self.as_user(OTHER):
             self.assertFalse(frappe.has_permission(DT.QUERY, ptype="read", doc=self.owner_query))
 
-    def test_a_query_reference_resolves_for_someone_who_may_read_it(self):
-        with self.as_user(OWNER):
-            result = self.execute(self.owner_reference)
+    def test_a_saved_chain_resolves_for_its_owner(self):
+        with self.as_user(OWNER), db_connections():
+            result = frappe.get_doc(DT.QUERY, self.owner_reference).execute()
         self.assertEqual(result["rows"][0]["secret"], SECRET)
 
-    def test_a_query_reference_is_refused_to_someone_who_may_not(self):
-        with self.as_user(OTHER), self.assertRaises(frappe.PermissionError):
-            self.execute(self.other_reference)
-
-    def test_a_refused_reference_returns_no_sql(self):
-        """The compiled SQL is the query's logic, so a refusal returns none of it."""
-        with self.as_user(OTHER):
-            try:
-                result = self.execute(self.other_reference)
-            except frappe.PermissionError:
-                return
-            self.fail(f"the reference resolved and returned {result.get('sql')}")
-
-    def test_a_reference_sent_inline_is_refused_too(self):
+    def test_a_reference_sent_inline_is_refused(self):
         """The operations arrive in the request, so the reference need not be saved."""
         with self.as_user(OTHER):
             doc = frappe.get_doc(
@@ -134,16 +125,90 @@ class ReferencedQueryIsReadChecked:
                     "use_live_connection": 0,
                     "is_builder_query": 1,
                     "__islocal": True,
-                    "operations": [
-                        {
-                            "type": "source",
-                            "table": {"type": "query", "query_name": self.owner_query},
-                        }
-                    ],
+                    "operations": reference_operations(self.owner_query),
                 }
             )
             with self.assertRaises(frappe.PermissionError), db_connections():
                 doc.execute()
+
+    def test_forged_operations_on_a_saved_query_are_refused(self):
+        """What was saved is the row, not what the request says was saved."""
+        with self.as_user(OTHER):
+            doc = frappe.get_doc(DT.QUERY, self.other_query)
+            doc.operations = reference_operations(self.owner_query)
+            with self.assertRaises(frappe.PermissionError), db_connections():
+                doc.execute()
+
+    def test_a_refused_reference_returns_no_sql(self):
+        """The compiled SQL is the query's logic, so a refusal returns none of it."""
+        with self.as_user(OTHER):
+            doc = frappe.get_doc(DT.QUERY, self.other_query)
+            doc.operations = reference_operations(self.owner_query)
+            try:
+                with db_connections():
+                    result = doc.execute()
+            except frappe.PermissionError:
+                return
+            self.fail(f"the reference resolved and returned {result.get('sql')}")
+
+
+class ASavedReferenceCarriesItsOwnAccess:
+    """The rules for a reference that was saved.
+
+    A chart can be shared with someone who holds no access to the workbook behind
+    it. They read the chart and the query it is built on. When that query is built
+    on another query, the chain is the query, not a detour around it - so they have
+    to be able to run it. The reference was checked when it was written, and that
+    is what the run trusts.
+    """
+
+    ENABLE_PERMISSIONS = 0
+
+    @classmethod
+    def before_class(cls):
+        create_test_users()
+        cls.workbook = create_test_workbook(OWNER, title="Chain Owner Workbook").name
+        cls.base = create_source_query(OWNER, cls.workbook, "Chain Base").name
+        cls.consumer = create_referencing_query(OWNER, cls.workbook, cls.base, "Chain Consumer").name
+        cls.chart = create_test_chart(OWNER, cls.workbook, query=cls.consumer, title="Chain Chart").name
+        share_chart(cls.chart, VIEWER)
+
+        cls.viewer_workbook = create_test_workbook(VIEWER, title="Chain Viewer Workbook").name
+
+    @classmethod
+    def after_class(cls):
+        for name in (cls.workbook, cls.viewer_workbook):
+            frappe.delete_doc(DT.WORKBOOK, name, force=True, ignore_permissions=True)
+        delete_users(OWNER, VIEWER)
+
+    def before_test(self):
+        self.set_team_permissions(self.ENABLE_PERMISSIONS)
+
+    def test_the_share_carries_the_chart_and_its_query_only(self):
+        """The baseline: a shared chart does not carry the workbook behind it."""
+        with self.as_user(VIEWER):
+            self.assertTrue(frappe.has_permission(DT.CHART, ptype="read", doc=self.chart))
+            self.assertTrue(frappe.has_permission(DT.QUERY, ptype="read", doc=self.consumer))
+            self.assertFalse(frappe.has_permission(DT.QUERY, ptype="read", doc=self.base))
+
+    def test_someone_with_the_chart_can_run_the_chain(self):
+        """Running the query they may read is what the share is for."""
+        with self.as_user(VIEWER), db_connections():
+            result = frappe.get_doc(DT.QUERY, self.consumer).execute()
+        self.assertEqual(result["rows"][0]["secret"], SECRET)
+
+    def test_a_reference_cannot_be_saved_to_an_unreadable_query(self):
+        """Where the check lives."""
+        with self.as_user(VIEWER), self.assertRaises(frappe.PermissionError):
+            create_referencing_query(VIEWER, self.viewer_workbook, self.base, "Chain Forged Consumer")
+
+    def test_a_reference_added_on_update_is_checked_too(self):
+        """An existing query is not a way around the check."""
+        with self.as_user(VIEWER):
+            query = create_source_query(VIEWER, self.viewer_workbook, "Chain Viewer Source")
+            query.operations = reference_operations(self.base)
+            with self.assertRaises(frappe.PermissionError):
+                query.save()
 
 
 class DashboardFilterReadsTheQuery:
@@ -274,12 +339,22 @@ class ChartExportReadsTheQuery:
             self.export_chart(self.other_chart, query=self.owner_query)
 
 
-class TestReferencedQueryIsReadChecked(ReferencedQueryIsReadChecked, InsightsIntegrationTestCase):
+class TestAReferenceInTheRequestIsChecked(AReferenceInTheRequestIsChecked, InsightsIntegrationTestCase):
     ENABLE_PERMISSIONS = 0
 
 
-class TestReferencedQueryIsReadCheckedWithTeamPermissions(
-    ReferencedQueryIsReadChecked, InsightsIntegrationTestCase
+class TestAReferenceInTheRequestIsCheckedWithTeamPermissions(
+    AReferenceInTheRequestIsChecked, InsightsIntegrationTestCase
+):
+    ENABLE_PERMISSIONS = 1
+
+
+class TestASavedReferenceCarriesItsOwnAccess(ASavedReferenceCarriesItsOwnAccess, InsightsIntegrationTestCase):
+    ENABLE_PERMISSIONS = 0
+
+
+class TestASavedReferenceCarriesItsOwnAccessWithTeamPermissions(
+    ASavedReferenceCarriesItsOwnAccess, InsightsIntegrationTestCase
 ):
     ENABLE_PERMISSIONS = 1
 

--- a/insights/tests/test_run_doc_method.py
+++ b/insights/tests/test_run_doc_method.py
@@ -1,0 +1,121 @@
+"""A document method is decided against the stored document.
+
+`insights.api.run_doc_method` builds the document it runs from the request body,
+so the body cannot also be what says who may run the method. Every rule here
+names a stored document and then sends a body that claims otherwise.
+"""
+
+import frappe
+from frappe.utils import set_request
+
+from insights.api import run_doc_method
+from insights.tests.base import InsightsIntegrationTestCase
+from insights.tests.factories import (
+    DT,
+    create_test_query,
+    create_test_workbook,
+    delete_users,
+)
+from insights.tests.permissions_utils import USER_1, USER_2, create_test_users
+
+OWNER = USER_1
+OTHER = USER_2
+
+
+class StoredDocumentDecides:
+    """The rules. Both `enable_permissions` settings run them."""
+
+    ENABLE_PERMISSIONS = 0
+
+    @classmethod
+    def before_class(cls):
+        create_test_users()
+        cls.owner_workbook = create_test_workbook(OWNER, title="Doc Method Owner Workbook").name
+        cls.owner_query = create_test_query(OWNER, cls.owner_workbook, title="Doc Method Owner Query").name
+        cls.other_workbook = create_test_workbook(OTHER, title="Doc Method Other Workbook").name
+
+    @classmethod
+    def after_class(cls):
+        for name in (cls.owner_workbook, cls.other_workbook):
+            frappe.delete_doc(DT.WORKBOOK, name, force=True, ignore_permissions=True)
+        delete_users(OWNER, OTHER)
+
+    def before_test(self):
+        self.set_team_permissions(self.ENABLE_PERMISSIONS)
+        # the method surface reads the request to check the HTTP verb
+        set_request(method="POST", path="/api/method/insights.api.run_doc_method")
+
+    def export_workbook(self, name, **claims):
+        return run_doc_method("export", {"doctype": DT.WORKBOOK, "name": name, **claims})
+
+    def test_the_owner_exports_their_own_workbook(self):
+        """The baseline the refusals below are measured against."""
+        with self.as_user(OWNER):
+            exported = self.export_workbook(self.owner_workbook)
+        self.assertIn(self.owner_query, exported["dependencies"]["queries"])
+
+    def test_another_user_cannot_export_the_workbook(self):
+        with self.as_user(OTHER), self.assertRaises(frappe.PermissionError):
+            self.export_workbook(self.owner_workbook)
+
+    def test_claiming_to_own_the_workbook_does_not_grant_export(self):
+        """`owner` decides access, and the body is not where it is read from."""
+        with self.as_user(OTHER), self.assertRaises(frappe.PermissionError):
+            self.export_workbook(self.owner_workbook, owner=OTHER)
+
+    def test_claiming_a_workbook_does_not_grant_a_query_method(self):
+        """A query's access runs through its workbook, so that link is stored too."""
+        with self.as_user(OTHER), self.assertRaises(frappe.PermissionError):
+            run_doc_method(
+                "export",
+                {
+                    "doctype": DT.QUERY,
+                    "name": self.owner_query,
+                    "workbook": self.other_workbook,
+                    "owner": OTHER,
+                },
+            )
+
+    def test_calling_a_stored_document_unsaved_does_not_grant_a_method(self):
+        """`__islocal` is the client saying it has nothing saved yet. A stored row
+        under that name says otherwise."""
+        with self.as_user(OTHER), self.assertRaises(frappe.PermissionError):
+            run_doc_method(
+                "export",
+                {
+                    "doctype": DT.QUERY,
+                    "name": self.owner_query,
+                    "workbook": self.other_workbook,
+                    "__islocal": True,
+                },
+            )
+
+    def test_a_document_the_client_has_not_saved_still_runs(self):
+        """The builder runs a query before it is saved, and there is no stored
+        row to decide from."""
+        with self.as_user(OTHER):
+            formatted = run_doc_method(
+                "format",
+                {
+                    "doctype": DT.QUERY,
+                    "name": "new-query-not-saved",
+                    "workbook": self.other_workbook,
+                    "is_native_query": 1,
+                    "__islocal": True,
+                },
+                {"raw_sql": "select 1 from tabToDo"},
+            )
+        self.assertIn("select", formatted.lower())
+
+    def test_a_filter_set_is_not_a_name(self):
+        """One name is one document. A dict would reach every matching row."""
+        with self.as_user(OTHER), self.assertRaises(frappe.ValidationError):
+            self.export_workbook({"title": ["like", "%"]})
+
+
+class TestStoredDocumentDecides(StoredDocumentDecides, InsightsIntegrationTestCase):
+    ENABLE_PERMISSIONS = 0
+
+
+class TestStoredDocumentDecidesWithTeamPermissions(StoredDocumentDecides, InsightsIntegrationTestCase):
+    ENABLE_PERMISSIONS = 1

--- a/insights/tests/test_run_doc_method.py
+++ b/insights/tests/test_run_doc_method.py
@@ -107,6 +107,36 @@ class StoredDocumentDecides:
             )
         self.assertIn("select", formatted.lower())
 
+    def test_a_guest_cannot_run_a_method_on_an_unsaved_document(self):
+        """The unsaved path is not a way in.
+
+        A guest holds no permission on the doctype and no Insights role, so the
+        method surface refuses before a document is built. What a guest reaches is
+        a public document, and an unsaved one is nobody's.
+        """
+        with self.as_user("Guest"), self.assertRaises(frappe.PermissionError):
+            run_doc_method(
+                "execute",
+                {
+                    "doctype": DT.QUERY,
+                    "name": "new-query-not-saved",
+                    "workbook": self.other_workbook,
+                    "is_builder_query": 1,
+                    "use_live_connection": 1,
+                    "__islocal": True,
+                    "operations": [
+                        {
+                            "type": "source",
+                            "table": {
+                                "type": "table",
+                                "data_source": "Site DB",
+                                "table_name": "tabToDo",
+                            },
+                        }
+                    ],
+                },
+            )
+
     def test_a_filter_set_is_not_a_name(self):
         """One name is one document. A dict would reach every matching row."""
         with self.as_user(OTHER), self.assertRaises(frappe.ValidationError):

--- a/insights/tests/test_table_stats.py
+++ b/insights/tests/test_table_stats.py
@@ -1,0 +1,117 @@
+"""A table's stats name the queries the caller may read.
+
+`Insights Table v3.get_stats` reports which queries reference the table. Reading
+the table is what gets you the stats. Which queries are named is the queries' own
+question, and their workbooks answer it.
+"""
+
+import frappe
+
+from insights.insights.doctype.insights_table_v3.insights_table_v3 import get_table_name
+from insights.tests.base import InsightsIntegrationTestCase
+from insights.tests.factories import DT, as_user, create_test_workbook
+from insights.tests.permissions_utils import (
+    TEST_DS,
+    USER_1,
+    USER_2,
+    cleanup_test_fixtures,
+    create_test_data_sources,
+    create_test_tables,
+    create_test_team,
+    create_test_users,
+)
+
+OWNER = USER_1
+OTHER = USER_2
+
+TABLE = "table1"
+SECRET_TITLE = "Owner Query With A Telling Title"
+
+
+def create_query_over_the_table(owner, workbook, title):
+    with as_user(owner):
+        return frappe.get_doc(
+            {
+                "doctype": DT.QUERY,
+                "title": title,
+                "workbook": workbook,
+                "use_live_connection": 1,
+                "is_builder_query": 1,
+                "operations": [
+                    {
+                        "type": "source",
+                        "table": {
+                            "type": "table",
+                            "data_source": TEST_DS,
+                            "table_name": TABLE,
+                        },
+                    }
+                ],
+            }
+        ).insert()
+
+
+class StatsNameReadableQueriesOnly:
+    """The rules. Both `enable_permissions` settings run them.
+
+    With the setting off every table is readable, which is the shipped default and
+    the wider case. With it on, a team grant is what gets the caller to the table,
+    and the rule still has to hold past that point.
+    """
+
+    ENABLE_PERMISSIONS = 0
+
+    @classmethod
+    def before_class(cls):
+        cleanup_test_fixtures()
+        create_test_users()
+        create_test_data_sources()
+        create_test_tables()
+        cls.table = get_table_name(TEST_DS, TABLE)
+
+        cls.owner_workbook = create_test_workbook(OWNER, title="Stats Owner Workbook").name
+        cls.owner_query = create_query_over_the_table(OWNER, cls.owner_workbook, SECRET_TITLE).name
+
+        cls.other_workbook = create_test_workbook(OTHER, title="Stats Other Workbook").name
+        cls.other_query = create_query_over_the_table(OTHER, cls.other_workbook, "Other Query").name
+
+        create_test_team("team1", [OWNER, OTHER], grants=[("Insights Table v3", cls.table)])
+
+    @classmethod
+    def after_class(cls):
+        cleanup_test_fixtures()
+
+    def before_test(self):
+        self.set_team_permissions(self.ENABLE_PERMISSIONS)
+
+    def referencing_queries(self, user):
+        with self.as_user(user):
+            stats = frappe.get_doc(DT.TABLE, self.table).get_stats()
+        return [q["name"] for q in stats["referencing_queries"]]
+
+    def test_a_query_in_another_workbook_is_not_readable(self):
+        """The baseline the rule below is measured against."""
+        with self.as_user(OTHER):
+            self.assertFalse(frappe.has_permission(DT.QUERY, ptype="read", doc=self.owner_query))
+
+    def test_the_stats_name_your_own_query(self):
+        self.assertIn(self.other_query, self.referencing_queries(OTHER))
+
+    def test_the_stats_do_not_name_a_query_you_cannot_read(self):
+        self.assertNotIn(self.owner_query, self.referencing_queries(OTHER))
+
+    def test_an_administrator_still_sees_every_query(self):
+        """Narrowing is per caller, not a smaller report for everyone."""
+        names = self.referencing_queries("Administrator")
+        self.assertIn(self.owner_query, names)
+        self.assertIn(self.other_query, names)
+
+
+class TestStatsNameReadableQueriesOnly(StatsNameReadableQueriesOnly, InsightsIntegrationTestCase):
+    ENABLE_PERMISSIONS = 0
+
+
+class TestStatsNameReadableQueriesOnlyWithTeamPermissions(
+    StatsNameReadableQueriesOnly, InsightsIntegrationTestCase
+):
+    ENABLE_PERMISSIONS = 1

--- a/insights/tests/test_table_stats.py
+++ b/insights/tests/test_table_stats.py
@@ -111,8 +111,28 @@ class StatsNameReadableQueriesOnly:
     def test_the_stats_do_not_name_a_query_you_cannot_read(self):
         self.assertNotIn(self.owner_query, self.referencing_queries(OTHER))
 
-    def test_the_stats_answer_for_the_table_the_name_identifies(self):
-        """The name is the table. A different pair sent with it does not move the stats."""
+    def test_a_pair_that_disagrees_with_the_name_is_refused(self):
+        """The name is built from the pair, so the two naming different tables is
+        not a request that can be answered."""
+        with self.as_user(OTHER), self.assertRaises(frappe.ValidationError):
+            run_doc_method(
+                "get_stats",
+                docs={
+                    "doctype": DT.TABLE,
+                    "name": self.table,
+                    "data_source": TEST_DS,
+                    "table": OTHER_TABLE,
+                },
+            )
+
+    def test_a_body_that_omits_the_pair_is_refused(self):
+        """`get_table_name` concatenates the two, so a missing one has to be
+        refused before it is read, not raise `TypeError` inside the hash."""
+        with self.as_user(OTHER), self.assertRaises(frappe.ValidationError):
+            run_doc_method("get_stats", docs={"doctype": DT.TABLE, "name": self.table})
+
+    def test_the_stats_answer_when_the_pair_agrees(self):
+        """The path the client actually takes."""
         with self.as_user(OTHER):
             stats = run_doc_method(
                 "get_stats",
@@ -120,7 +140,7 @@ class StatsNameReadableQueriesOnly:
                     "doctype": DT.TABLE,
                     "name": self.table,
                     "data_source": TEST_DS,
-                    "table": OTHER_TABLE,
+                    "table": TABLE,
                 },
             )
 

--- a/insights/tests/test_table_stats.py
+++ b/insights/tests/test_table_stats.py
@@ -1,12 +1,17 @@
-"""A table's stats name the queries the caller may read.
+"""A table's stats answer for one table, and name the queries the caller may read.
 
 `Insights Table v3.get_stats` reports which queries reference the table. Reading
 the table is what gets you the stats. Which queries are named is the queries' own
 question, and their workbooks answer it.
+
+The table the stats answer for is the one the name identifies. `autoname` builds
+that name from the data source and the table, so the two cannot disagree.
 """
 
 import frappe
+from frappe.utils import set_request
 
+from insights.api import run_doc_method
 from insights.insights.doctype.insights_table_v3.insights_table_v3 import get_table_name
 from insights.tests.base import InsightsIntegrationTestCase
 from insights.tests.factories import DT, as_user, create_test_workbook
@@ -25,10 +30,11 @@ OWNER = USER_1
 OTHER = USER_2
 
 TABLE = "table1"
+OTHER_TABLE = "table2"
 SECRET_TITLE = "Owner Query With A Telling Title"
 
 
-def create_query_over_the_table(owner, workbook, title):
+def create_query_over_the_table(owner, workbook, title, table=TABLE):
     with as_user(owner):
         return frappe.get_doc(
             {
@@ -43,7 +49,7 @@ def create_query_over_the_table(owner, workbook, title):
                         "table": {
                             "type": "table",
                             "data_source": TEST_DS,
-                            "table_name": TABLE,
+                            "table_name": table,
                         },
                     }
                 ],
@@ -54,9 +60,8 @@ def create_query_over_the_table(owner, workbook, title):
 class StatsNameReadableQueriesOnly:
     """The rules. Both `enable_permissions` settings run them.
 
-    With the setting off every table is readable, which is the shipped default and
-    the wider case. With it on, a team grant is what gets the caller to the table,
-    and the rule still has to hold past that point.
+    Off, every table is readable. On, a team grant is what reaches the table, and
+    the rule still has to hold past that point.
     """
 
     ENABLE_PERMISSIONS = 0
@@ -75,6 +80,11 @@ class StatsNameReadableQueriesOnly:
         cls.other_workbook = create_test_workbook(OTHER, title="Stats Other Workbook").name
         cls.other_query = create_query_over_the_table(OTHER, cls.other_workbook, "Other Query").name
 
+        cls.other_table = get_table_name(TEST_DS, OTHER_TABLE)
+        cls.query_on_other_table = create_query_over_the_table(
+            OTHER, cls.other_workbook, "Other Table Query", table=OTHER_TABLE
+        ).name
+
         create_test_team("team1", [OWNER, OTHER], grants=[("Insights Table v3", cls.table)])
 
     @classmethod
@@ -83,6 +93,7 @@ class StatsNameReadableQueriesOnly:
 
     def before_test(self):
         self.set_team_permissions(self.ENABLE_PERMISSIONS)
+        set_request(method="POST", path="/api/method/insights.api.run_doc_method")
 
     def referencing_queries(self, user):
         with self.as_user(user):
@@ -99,6 +110,23 @@ class StatsNameReadableQueriesOnly:
 
     def test_the_stats_do_not_name_a_query_you_cannot_read(self):
         self.assertNotIn(self.owner_query, self.referencing_queries(OTHER))
+
+    def test_the_stats_answer_for_the_table_the_name_identifies(self):
+        """The name is the table. A different pair sent with it does not move the stats."""
+        with self.as_user(OTHER):
+            stats = run_doc_method(
+                "get_stats",
+                docs={
+                    "doctype": DT.TABLE,
+                    "name": self.table,
+                    "data_source": TEST_DS,
+                    "table": OTHER_TABLE,
+                },
+            )
+
+        names = [q["name"] for q in stats["referencing_queries"]]
+        self.assertIn(self.other_query, names)
+        self.assertNotIn(self.query_on_other_table, names)
 
     def test_an_administrator_still_sees_every_query(self):
         """Narrowing is per caller, not a smaller report for everyone."""

--- a/insights/tests/test_workbook_import.py
+++ b/insights/tests/test_workbook_import.py
@@ -1,0 +1,332 @@
+"""An import references its own copies, not the exporter's queries.
+
+A file names its queries as the exporting site named them. Import rewrites every
+name the file carries to the copy that replaces it, so importing asks for no
+access to the queries the file was exported from.
+
+A whole workbook, a single query and a single chart are all imported this way.
+"""
+
+import frappe
+
+from insights.insights.doctype.insights_chart_v3.insights_chart_v3 import import_chart
+from insights.insights.doctype.insights_query_v3.insights_query_v3 import (
+    extract_query_deps_from_operations,
+    import_query,
+)
+from insights.insights.doctype.insights_workbook.insights_workbook import import_workbook
+from insights.tests.base import InsightsIntegrationTestCase
+from insights.tests.factories import DT, as_user, create_test_workbook, delete_users
+from insights.tests.permissions_utils import USER_1, USER_2, create_test_users
+
+OWNER = USER_1
+IMPORTER = USER_2
+
+SOURCE_ROWS = "results = [{'amount': 1}]"
+
+
+def create_source_query(owner, workbook, title):
+    with as_user(owner):
+        return frappe.get_doc(
+            {
+                "doctype": DT.QUERY,
+                "title": title,
+                "workbook": workbook,
+                "use_live_connection": 0,
+                "is_script_query": 1,
+                "operations": [{"type": "code", "code": SOURCE_ROWS}],
+            }
+        ).insert()
+
+
+class ImportedReferencesPointAtTheNewCopies(InsightsIntegrationTestCase):
+    """A workbook file is importable by anyone who may make a workbook."""
+
+    @classmethod
+    def before_class(cls):
+        create_test_users()
+
+        cls.workbook = create_test_workbook(OWNER, "import source").name
+        cls.source = create_source_query(OWNER, cls.workbook, "source").name
+
+        with as_user(OWNER):
+            cls.consumer = (
+                frappe.get_doc(
+                    {
+                        "doctype": DT.QUERY,
+                        "title": "consumer",
+                        "workbook": cls.workbook,
+                        "use_live_connection": 0,
+                        "operations": [
+                            {"type": "source", "table": {"type": "query", "query_name": cls.source}}
+                        ],
+                    }
+                )
+                .insert()
+                .name
+            )
+
+            cls.file = frappe.get_doc(DT.WORKBOOK, cls.workbook).export()
+
+        cls.made_workbooks = [cls.workbook]
+
+    @classmethod
+    def after_class(cls):
+        for workbook in frappe.get_all(
+            DT.WORKBOOK, filters={"name": ("in", cls.made_workbooks)}, pluck="name"
+        ):
+            frappe.delete_doc(DT.WORKBOOK, workbook, force=True, delete_permanently=True)
+        delete_users(OWNER, IMPORTER)
+
+    def test_a_workbook_file_imports_for_someone_who_cannot_read_its_queries(self):
+        with as_user(IMPORTER):
+            self.assertFalse(
+                frappe.has_permission(DT.QUERY, ptype="read", doc=self.source),
+                "the fixture needs the importer to have no access to the exported queries",
+            )
+            imported = import_workbook(self.file)
+        self.made_workbooks.append(imported)
+
+        queries = frappe.get_all(DT.QUERY, filters={"workbook": imported}, pluck="name")
+        self.assertEqual(len(queries), 2)
+
+    def test_an_imported_reference_names_the_imported_copy(self):
+        with as_user(IMPORTER):
+            imported = import_workbook(self.file)
+        self.made_workbooks.append(imported)
+
+        deps = set()
+        for name in frappe.get_all(DT.QUERY, filters={"workbook": imported}, pluck="name"):
+            operations = frappe.parse_json(frappe.db.get_value(DT.QUERY, name, "operations"))
+            deps |= set(extract_query_deps_from_operations(operations or []))
+
+        self.assertTrue(deps, "the imported workbook should still hold a reference")
+        self.assertNotIn(self.source, deps, "a reference must not point back at the source site")
+
+
+class ImportingOneQueryCarriesItsReferences(InsightsIntegrationTestCase):
+    """A single query is imported the same way a workbook is.
+
+    `import_query` is what the UI calls to paste a query into another workbook.
+    The file names the exporter's queries, so the copies go in first.
+    """
+
+    @classmethod
+    def before_class(cls):
+        create_test_users()
+
+        cls.workbook = create_test_workbook(OWNER, "one query source").name
+        cls.source = create_source_query(OWNER, cls.workbook, "one query source query").name
+
+        with as_user(OWNER):
+            consumer = frappe.get_doc(
+                {
+                    "doctype": DT.QUERY,
+                    "title": "one query consumer",
+                    "workbook": cls.workbook,
+                    "use_live_connection": 0,
+                    "operations": [{"type": "source", "table": {"type": "query", "query_name": cls.source}}],
+                }
+            ).insert()
+            cls.file = consumer.export()
+
+        cls.target = create_test_workbook(IMPORTER, "one query target").name
+
+    @classmethod
+    def after_class(cls):
+        for workbook in (cls.workbook, cls.target):
+            frappe.delete_doc(DT.WORKBOOK, workbook, force=True, delete_permanently=True)
+        delete_users(OWNER, IMPORTER)
+
+    def test_a_query_file_imports_for_someone_who_cannot_read_its_reference(self):
+        with as_user(IMPORTER):
+            self.assertFalse(
+                frappe.has_permission(DT.QUERY, ptype="read", doc=self.source),
+                "the fixture needs the importer to have no access to the referenced query",
+            )
+            imported = import_query(self.file, self.target)
+
+        self.assertTrue(frappe.db.exists(DT.QUERY, imported))
+
+    def test_the_imported_reference_names_the_imported_copy(self):
+        with as_user(IMPORTER):
+            imported = import_query(self.file, self.target)
+
+        operations = frappe.parse_json(frappe.db.get_value(DT.QUERY, imported, "operations"))
+        deps = set(extract_query_deps_from_operations(operations or []))
+
+        self.assertTrue(deps, "the imported query should still hold a reference")
+        self.assertNotIn(self.source, deps, "a reference must not point back at the source site")
+
+
+class ImportingOneQueryCopiesAReferenceOnce(InsightsIntegrationTestCase):
+    """`export` nests, so a query two branches both build on appears twice in the
+    file. The import has to recognise it as one query, not copy it per path."""
+
+    @classmethod
+    def before_class(cls):
+        create_test_users()
+
+        cls.workbook = create_test_workbook(OWNER, "diamond source").name
+        cls.base = create_source_query(OWNER, cls.workbook, "diamond base").name
+        left = cls.reference(OWNER, cls.workbook, "diamond left", cls.base)
+        right = cls.reference(OWNER, cls.workbook, "diamond right", cls.base)
+
+        with as_user(OWNER):
+            top = frappe.get_doc(
+                {
+                    "doctype": DT.QUERY,
+                    "title": "diamond top",
+                    "workbook": cls.workbook,
+                    "use_live_connection": 0,
+                    "operations": [
+                        {"type": "source", "table": {"type": "query", "query_name": left}},
+                        {"type": "union", "table": {"type": "query", "query_name": right}},
+                    ],
+                }
+            ).insert()
+            cls.file = top.export()
+
+        cls.target = create_test_workbook(IMPORTER, "diamond target").name
+
+    @classmethod
+    def reference(cls, owner, workbook, title, referenced):
+        with as_user(owner):
+            return (
+                frappe.get_doc(
+                    {
+                        "doctype": DT.QUERY,
+                        "title": title,
+                        "workbook": workbook,
+                        "use_live_connection": 0,
+                        "operations": [
+                            {"type": "source", "table": {"type": "query", "query_name": referenced}}
+                        ],
+                    }
+                )
+                .insert()
+                .name
+            )
+
+    @classmethod
+    def after_class(cls):
+        for workbook in (cls.workbook, cls.target):
+            frappe.delete_doc(DT.WORKBOOK, workbook, force=True, delete_permanently=True)
+        delete_users(OWNER, IMPORTER)
+
+    def test_a_query_reached_by_two_branches_is_imported_once(self):
+        """One import, so the count is the import's own work."""
+        with as_user(IMPORTER):
+            import_query(self.file, self.target)
+
+        copies = frappe.get_all(DT.QUERY, filters={"workbook": self.target}, fields=["name", "title"])
+        base = [c.name for c in copies if c.title == "diamond base"]
+
+        self.assertEqual(len(base), 1, "the base query was copied once per path to it")
+        self.assertEqual(len(copies), 4)
+
+        deps = set()
+        for copy in copies:
+            operations = frappe.parse_json(frappe.db.get_value(DT.QUERY, copy.name, "operations"))
+            deps |= set(extract_query_deps_from_operations(operations or []))
+
+        self.assertIn(base[0], deps, "both branches must name the one copy")
+
+
+class ImportingOneChartCarriesItsQuery(InsightsIntegrationTestCase):
+    """A chart is imported the same way a query and a workbook are.
+
+    `import_chart` is what the UI calls to paste a chart into another workbook.
+    `validate` reads the query link, so the copy has to exist before the insert.
+    """
+
+    @classmethod
+    def before_class(cls):
+        create_test_users()
+
+        cls.workbook = create_test_workbook(OWNER, "chart source").name
+        cls.query = create_source_query(OWNER, cls.workbook, "chart source query").name
+
+        with as_user(OWNER):
+            chart = frappe.get_doc(
+                {
+                    "doctype": DT.CHART,
+                    "title": "chart to paste",
+                    "workbook": cls.workbook,
+                    "query": cls.query,
+                    "chart_type": "Bar",
+                }
+            ).insert()
+            cls.file = chart.export()
+
+        cls.target = create_test_workbook(IMPORTER, "chart target").name
+
+    @classmethod
+    def after_class(cls):
+        for workbook in (cls.workbook, cls.target):
+            frappe.delete_doc(DT.WORKBOOK, workbook, force=True, delete_permanently=True)
+        delete_users(OWNER, IMPORTER)
+
+    def test_a_chart_file_imports_for_someone_who_cannot_read_its_query(self):
+        with as_user(IMPORTER):
+            self.assertFalse(
+                frappe.has_permission(DT.QUERY, ptype="read", doc=self.query),
+                "the fixture needs the importer to have no access to the exported query",
+            )
+            imported = import_chart(self.file, self.target)
+
+        query = frappe.db.get_value(DT.CHART, imported, "query")
+        self.assertNotEqual(query, self.query, "the chart must not point back at the source site")
+        self.assertEqual(frappe.db.get_value(DT.QUERY, query, "workbook"), self.target)
+
+
+class ImportingAcrossSitesIgnoresTheWorkbookNameInTheFile(InsightsIntegrationTestCase):
+    """Workbook names are a bare counter, so every site has a workbook "1".
+
+    A file carries the exporting site's name. Reading it as a local one made the
+    import decide it had nothing to copy, and the query saved naming queries that
+    do not exist here.
+    """
+
+    @classmethod
+    def before_class(cls):
+        create_test_users()
+
+        cls.workbook = create_test_workbook(OWNER, "collision source").name
+        cls.source = create_source_query(OWNER, cls.workbook, "collision source query").name
+
+        with as_user(OWNER):
+            consumer = frappe.get_doc(
+                {
+                    "doctype": DT.QUERY,
+                    "title": "collision consumer",
+                    "workbook": cls.workbook,
+                    "use_live_connection": 0,
+                    "operations": [{"type": "source", "table": {"type": "query", "query_name": cls.source}}],
+                }
+            ).insert()
+            cls.file = consumer.export()
+
+        cls.target = create_test_workbook(IMPORTER, "collision target").name
+
+    @classmethod
+    def after_class(cls):
+        for workbook in (cls.workbook, cls.target):
+            frappe.delete_doc(DT.WORKBOOK, workbook, force=True, delete_permanently=True)
+        delete_users(OWNER, IMPORTER)
+
+    def test_a_file_naming_the_target_workbook_still_copies_its_queries(self):
+        """The other site's workbook happened to be numbered like this one's."""
+        file = frappe.parse_json(frappe.as_json(self.file))
+        file["doc"]["workbook"] = self.target
+
+        with as_user(IMPORTER):
+            imported = import_query(file, self.target)
+
+        operations = frappe.parse_json(frappe.db.get_value(DT.QUERY, imported, "operations"))
+        deps = set(extract_query_deps_from_operations(operations or []))
+
+        self.assertTrue(deps, "the imported query should still hold a reference")
+        self.assertNotIn(self.source, deps, "a reference must not point back at the source site")
+        for dep in deps:
+            self.assertEqual(frappe.db.get_value(DT.QUERY, dep, "workbook"), self.target)

--- a/insights/tests/test_workbook_items.py
+++ b/insights/tests/test_workbook_items.py
@@ -25,11 +25,7 @@ OTHER = USER_2
 
 
 class OrderingReachesOwnItemsOnly:
-    """The rules. Both `enable_permissions` settings run them.
-
-    The setting scopes data sources and tables to teams. A workbook's items are
-    scoped by the workbook, so these rules hold either way.
-    """
+    """The rules. Both `enable_permissions` settings run them."""
 
     ENABLE_PERMISSIONS = 0
 
@@ -129,6 +125,14 @@ class OrderingReachesOwnItemsOnly:
             )
         self.assertNotEqual(frappe.db.get_value(DT.QUERY, self.other_query, "folder"), self.owner_folder)
 
+    def test_a_malformed_item_is_refused_with_a_message(self):
+        """A missing key used to raise KeyError, so one bad entry was a 500."""
+        with self.as_user(OWNER), self.assertRaises(frappe.ValidationError):
+            update_sort_orders(self.owner_workbook, [{"name": self.owner_query, "type": "query"}])
+
+        with self.as_user(OWNER), self.assertRaises(frappe.ValidationError):
+            update_sort_orders(self.owner_workbook, [{"name": self.owner_query, "sort_order": 0}])
+
     def test_a_filter_set_is_not_an_item_name(self):
         """One name is one document. A filter set would reach every row it
         matches, in any workbook."""
@@ -146,12 +150,20 @@ class OrderingReachesOwnItemsOnly:
             )
         self.assertEqual(self.sort_order_of(DT.QUERY, self.owner_query), before)
 
-    def test_an_unknown_item_is_left_alone(self):
-        with self.as_user(OTHER), self.assertRaises(frappe.PermissionError):
+    def test_an_item_that_no_longer_exists_is_skipped(self):
+        """The client sends the whole list after a drag, so one stale name in it
+        must not stop the rest of the list from being ordered."""
+        before = self.sort_order_of(DT.QUERY, self.other_query)
+        with self.as_user(OTHER):
             update_sort_orders(
                 self.other_workbook,
-                [{"type": "query", "name": "does-not-exist", "sort_order": 1}],
+                [
+                    {"type": "query", "name": "does-not-exist", "sort_order": 1},
+                    {"type": "query", "name": self.other_query, "sort_order": before + 5},
+                ],
             )
+
+        self.assertEqual(self.sort_order_of(DT.QUERY, self.other_query), before + 5)
 
 
 class TestOrderingReachesOwnItemsOnly(OrderingReachesOwnItemsOnly, InsightsIntegrationTestCase):

--- a/insights/tests/test_workbook_items.py
+++ b/insights/tests/test_workbook_items.py
@@ -1,0 +1,164 @@
+"""A workbook's ordering reaches the workbook's own items.
+
+`update_sort_orders` writes straight to the row, so the permission query that
+scopes reading a query, a chart or a folder never sees the write. Write access is
+held on the workbook, and the item named in the request is what says whether that
+access covers it.
+"""
+
+import frappe
+
+from insights.api.workbooks import create_folder, update_sort_orders
+from insights.tests.base import InsightsIntegrationTestCase
+from insights.tests.factories import (
+    DT,
+    as_user,
+    create_test_chart,
+    create_test_query,
+    create_test_workbook,
+    delete_users,
+)
+from insights.tests.permissions_utils import USER_1, USER_2, create_test_users
+
+OWNER = USER_1
+OTHER = USER_2
+
+
+class OrderingReachesOwnItemsOnly:
+    """The rules. Both `enable_permissions` settings run them.
+
+    The setting scopes data sources and tables to teams. A workbook's items are
+    scoped by the workbook, so these rules hold either way.
+    """
+
+    ENABLE_PERMISSIONS = 0
+
+    @classmethod
+    def before_class(cls):
+        create_test_users()
+        cls.owner_workbook = create_test_workbook(OWNER, title="Sorting Owner Workbook").name
+        cls.owner_query = create_test_query(OWNER, cls.owner_workbook, title="Sorting Owner Query").name
+        cls.owner_chart = create_test_chart(OWNER, cls.owner_workbook, title="Sorting Owner Chart").name
+        with as_user(OWNER):
+            cls.owner_folder = create_folder(cls.owner_workbook, "Owner Folder", "query")
+
+        cls.other_workbook = create_test_workbook(OTHER, title="Sorting Other Workbook").name
+        cls.other_query = create_test_query(OTHER, cls.other_workbook, title="Sorting Other Query").name
+        with as_user(OTHER):
+            cls.other_folder = create_folder(cls.other_workbook, "Other Folder", "query")
+
+    @classmethod
+    def after_class(cls):
+        for name in (cls.owner_workbook, cls.other_workbook):
+            frappe.delete_doc(DT.WORKBOOK, name, force=True, ignore_permissions=True)
+        delete_users(OWNER, OTHER)
+
+    def before_test(self):
+        self.set_team_permissions(self.ENABLE_PERMISSIONS)
+
+    def sort_order_of(self, doctype, name):
+        return frappe.db.get_value(doctype, name, "sort_order")
+
+    def test_a_workbook_owner_orders_their_own_items(self):
+        """The baseline the refusals below are measured against."""
+        with self.as_user(OTHER):
+            update_sort_orders(
+                self.other_workbook,
+                [
+                    {"type": "query", "name": self.other_query, "sort_order": 7},
+                    {"type": "folder", "name": self.other_folder, "sort_order": 3},
+                ],
+            )
+        self.assertEqual(self.sort_order_of(DT.QUERY, self.other_query), 7)
+        self.assertEqual(self.sort_order_of("Insights Folder", self.other_folder), 3)
+
+    def test_an_item_can_be_moved_into_a_folder_of_the_same_workbook(self):
+        with self.as_user(OTHER):
+            update_sort_orders(
+                self.other_workbook,
+                [
+                    {
+                        "type": "query",
+                        "name": self.other_query,
+                        "sort_order": 1,
+                        "folder": self.other_folder,
+                    }
+                ],
+            )
+        self.assertEqual(frappe.db.get_value(DT.QUERY, self.other_query, "folder"), self.other_folder)
+
+    def test_a_query_in_another_workbook_is_not_reordered(self):
+        before = self.sort_order_of(DT.QUERY, self.owner_query)
+        with self.as_user(OTHER), self.assertRaises(frappe.PermissionError):
+            update_sort_orders(
+                self.other_workbook,
+                [{"type": "query", "name": self.owner_query, "sort_order": 99}],
+            )
+        self.assertEqual(self.sort_order_of(DT.QUERY, self.owner_query), before)
+
+    def test_a_chart_in_another_workbook_is_not_reordered(self):
+        before = self.sort_order_of(DT.CHART, self.owner_chart)
+        with self.as_user(OTHER), self.assertRaises(frappe.PermissionError):
+            update_sort_orders(
+                self.other_workbook,
+                [{"type": "chart", "name": self.owner_chart, "sort_order": 99}],
+            )
+        self.assertEqual(self.sort_order_of(DT.CHART, self.owner_chart), before)
+
+    def test_a_folder_in_another_workbook_is_not_reordered(self):
+        before = self.sort_order_of("Insights Folder", self.owner_folder)
+        with self.as_user(OTHER), self.assertRaises(frappe.PermissionError):
+            update_sort_orders(
+                self.other_workbook,
+                [{"type": "folder", "name": self.owner_folder, "sort_order": 99}],
+            )
+        self.assertEqual(self.sort_order_of("Insights Folder", self.owner_folder), before)
+
+    def test_an_item_is_not_moved_into_a_folder_of_another_workbook(self):
+        with self.as_user(OTHER), self.assertRaises(frappe.PermissionError):
+            update_sort_orders(
+                self.other_workbook,
+                [
+                    {
+                        "type": "query",
+                        "name": self.other_query,
+                        "sort_order": 1,
+                        "folder": self.owner_folder,
+                    }
+                ],
+            )
+        self.assertNotEqual(frappe.db.get_value(DT.QUERY, self.other_query, "folder"), self.owner_folder)
+
+    def test_a_filter_set_is_not_an_item_name(self):
+        """One name is one document. A filter set would reach every row it
+        matches, in any workbook."""
+        before = self.sort_order_of(DT.QUERY, self.owner_query)
+        with self.as_user(OTHER), self.assertRaises(frappe.ValidationError):
+            update_sort_orders(
+                self.other_workbook,
+                [
+                    {
+                        "type": "query",
+                        "name": {"title": "Sorting Owner Query"},
+                        "sort_order": 99,
+                    }
+                ],
+            )
+        self.assertEqual(self.sort_order_of(DT.QUERY, self.owner_query), before)
+
+    def test_an_unknown_item_is_left_alone(self):
+        with self.as_user(OTHER), self.assertRaises(frappe.PermissionError):
+            update_sort_orders(
+                self.other_workbook,
+                [{"type": "query", "name": "does-not-exist", "sort_order": 1}],
+            )
+
+
+class TestOrderingReachesOwnItemsOnly(OrderingReachesOwnItemsOnly, InsightsIntegrationTestCase):
+    ENABLE_PERMISSIONS = 0
+
+
+class TestOrderingReachesOwnItemsOnlyWithTeamPermissions(
+    OrderingReachesOwnItemsOnly, InsightsIntegrationTestCase
+):
+    ENABLE_PERMISSIONS = 1


### PR DESCRIPTION
Five places decided access on the document in hand, then read, wrote or reported
a second document that the request named. The container's own check passed, so
the reference went unchecked.

One commit per defect, each with a test that fails without it.

`b99dadf6` is the narrow one. `run_doc_method` still runs the method on the body
it is sent; only the permission decision moved to the stored row.
`insights_for_public_access` and the permission queries are untouched.

Tests run every rule at `enable_permissions` 0 and 1, and assert on outcomes
rather than on which check fires.