### PR TITLE
fix: read a currency symbol from the site, not from the template

### DIFF
--- a/frontend/src2/charts/components/MeasurePicker.vue
+++ b/frontend/src2/charts/components/MeasurePicker.vue
@@ -26,6 +26,7 @@ const props = defineProps<{
 const formatOptions = [
 	{ label: __('Normal'), value: '' },
 	{ label: __('Percent'), value: 'percent' },
+	{ label: __('Currency'), value: 'currency' },
 ]
 
 // True when at least one available column is a pre-aggregated measure (i.e. it

--- a/frontend/src2/charts/components/NumberChart.vue
+++ b/frontend/src2/charts/components/NumberChart.vue
@@ -54,8 +54,9 @@ const cards = computed(() => {
 		const format = config.value.number_columns.find((c) => c.measure_name === measure_name)
 			?.format
 
-		// The measure's format states the unit; a prefix or suffix set on the card
-		// overrides it, because a chart that spelled out its own unit meant it.
+		// The measure's format states the unit. A prefix set on the card replaces
+		// it — a card that spelled out its own symbol meant that one. A suffix
+		// sits after the unit instead, the way "12.5% of target" reads.
 		const units = getFormatUnits(format)
 		const prefix = getNumberOption(idx, 'prefix') || units.prefix
 		const suffix = `${units.suffix}${getNumberOption(idx, 'suffix') || ''}`

--- a/frontend/src2/charts/components/NumberChart.vue
+++ b/frontend/src2/charts/components/NumberChart.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue'
-import { formatNumber, getShortNumber } from '../../helpers'
+import { formatNumber, getFormatUnits, getShortNumber } from '../../helpers'
 import { NumberChartConfig, NumberColumnOptions } from '../../types/chart.types'
 import { DataFormat, QueryResult, QueryResultColumn, QueryResultRow } from '../../types/query.types'
 import Sparkline from './Sparkline.vue'
@@ -48,13 +48,17 @@ const cards = computed(() => {
 			: currentValue - previousValue
 		const percentDelta = (delta / Math.abs(previousValue)) * 100
 
-		const prefix = getNumberOption(idx, 'prefix')
-		const suffix = getNumberOption(idx, 'suffix')
 		const decimal = getNumberOption(idx, 'decimal')
 		const color = getNumberOption(idx, 'color')
 		const shorten_numbers = getNumberOption(idx, 'shorten_numbers')
 		const format = config.value.number_columns.find((c) => c.measure_name === measure_name)
 			?.format
+
+		// The measure's format states the unit; a prefix or suffix set on the card
+		// overrides it, because a chart that spelled out its own unit meant it.
+		const units = getFormatUnits(format)
+		const prefix = getNumberOption(idx, 'prefix') || units.prefix
+		const suffix = `${units.suffix}${getNumberOption(idx, 'suffix') || ''}`
 
 		return {
 			measure_name,
@@ -78,13 +82,12 @@ const getFormattedValue = (
 	format?: DataFormat,
 ) => {
 	if (isNaN(value)) return 0
-	if (format === 'percent') {
-		return `${formatNumber(value * 100, decimal)}%`
-	}
+	// the number alone — its unit prints around it, from the same format
+	const scaled = value * getFormatUnits(format).scale
 	if (shorten_numbers) {
-		return getShortNumber(value, decimal)
+		return getShortNumber(scaled, decimal)
 	}
-	return formatNumber(value, decimal)
+	return formatNumber(scaled, decimal)
 }
 
 function getNumberOption(index: number, option: keyof NumberColumnOptions) {

--- a/frontend/src2/components/DataTable.vue
+++ b/frontend/src2/components/DataTable.vue
@@ -4,7 +4,7 @@ import { Button, LoadingIndicator } from 'frappe-ui'
 import { Plus, Search, Table2Icon } from 'lucide-vue-next'
 import { computed, nextTick, ref } from 'vue'
 import { usePagination } from '../composables/usePagination'
-import { createHeaders, formatNumber, getShortNumber } from '../helpers'
+import { createHeaders, formatNumber, getFormatUnits, getShortNumber } from '../helpers'
 import { FIELDTYPES } from '../helpers/constants'
 import {
 	applyDateRule,
@@ -529,10 +529,12 @@ function _formatNumber(value: any, columnName?: string) {
 	if (isNull) {
 		return props.replaceNullsWithZeros ? 0 : 'null'
 	}
-	if (columnName && props.columnFormats?.[columnName] === 'percent') {
-		return `${formatNumber(value * 100)}%`
-	}
-	return props.compactNumbers ? getShortNumber(value) : formatNumber(value)
+	const { scale, prefix, suffix } = getFormatUnits(
+		columnName ? props.columnFormats?.[columnName] : undefined,
+	)
+	const scaled = value * scale
+	const printed = props.compactNumbers ? getShortNumber(scaled) : formatNumber(scaled)
+	return `${prefix}${printed}${suffix}`
 }
 
 const showNewColumn = ref(false)

--- a/frontend/src2/helpers/index.ts
+++ b/frontend/src2/helpers/index.ts
@@ -174,7 +174,7 @@ export function downloadImage(element: HTMLElement, filename: string, scale = 2,
 export function formatNumber(number: number, precision = 0) {
 	if (isNaN(number)) return number
 	precision = precision || guessPrecision(number)
-	const locale = session.user?.country == 'India' ? 'en-IN' : session.user?.locale
+	const locale = session.site?.country == 'India' ? 'en-IN' : session.user?.locale
 	return new Intl.NumberFormat(locale || 'en-US', {
 		minimumFractionDigits: precision,
 		maximumFractionDigits: precision,
@@ -219,7 +219,7 @@ export function guessPrecision(number: number) {
 
 
 export function getShortNumber(number: number, precision = 0) {
-	const locale = session.user?.country == 'India' ? 'en-IN' : session.user?.locale
+	const locale = session.site?.country == 'India' ? 'en-IN' : session.user?.locale
 	let formatted = new Intl.NumberFormat(locale || 'en-US', {
 		notation: 'compact',
 		maximumFractionDigits: precision,

--- a/frontend/src2/helpers/index.ts
+++ b/frontend/src2/helpers/index.ts
@@ -17,6 +17,7 @@ import { getFormattedDate } from '../query/helpers'
 import session from '../session'
 import {
 	ColumnDataType,
+	DataFormat,
 	DropdownOption,
 	GroupedDropdownOption,
 	QueryResultColumn,
@@ -178,6 +179,33 @@ export function formatNumber(number: number, precision = 0) {
 		minimumFractionDigits: precision,
 		maximumFractionDigits: precision,
 	}).format(number)
+}
+
+export type FormatUnits = {
+	// what the stored number must be multiplied by to reach the printed one
+	scale: number
+	prefix: string
+	suffix: string
+}
+
+const NO_UNITS: FormatUnits = { scale: 1, prefix: '', suffix: '' }
+
+// A measure states its unit once, and every reading of it prints that unit the
+// same way. A currency reads the site's symbol rather than carrying one, so the
+// same shipped chart is right on a site in dollars and a site in rupees. The
+// symbol sits where fmt_money puts it, so Insights and desk agree.
+export function getFormatUnits(format?: DataFormat): FormatUnits {
+	if (format === 'percent') {
+		return { scale: 100, prefix: '', suffix: '%' }
+	}
+	if (format === 'currency') {
+		const symbol = session.user?.currency_symbol
+		if (!symbol) return NO_UNITS
+		return session.user.currency_symbol_on_right
+			? { scale: 1, prefix: '', suffix: ` ${symbol}` }
+			: { scale: 1, prefix: `${symbol} `, suffix: '' }
+	}
+	return NO_UNITS
 }
 
 export function guessPrecision(number: number) {

--- a/frontend/src2/helpers/index.ts
+++ b/frontend/src2/helpers/index.ts
@@ -199,9 +199,9 @@ export function getFormatUnits(format?: DataFormat): FormatUnits {
 		return { scale: 100, prefix: '', suffix: '%' }
 	}
 	if (format === 'currency') {
-		const symbol = session.user?.currency_symbol
+		const symbol = session.site?.currency_symbol
 		if (!symbol) return NO_UNITS
-		return session.user.currency_symbol_on_right
+		return session.site.currency_symbol_on_right
 			? { scale: 1, prefix: '', suffix: ` ${symbol}` }
 			: { scale: 1, prefix: `${symbol} `, suffix: '' }
 	}

--- a/frontend/src2/session.ts
+++ b/frontend/src2/session.ts
@@ -12,6 +12,9 @@ type SessionUser = {
 	can_download: boolean
 	country: string
 	locale: string
+	currency: string | null
+	currency_symbol: string
+	currency_symbol_on_right: boolean
 	has_desk_access?: boolean
 	has_demo_data: boolean
 	fiscal_year_start: string
@@ -28,6 +31,9 @@ const emptyUser: SessionUser = {
 	can_download: true,
 	country: '',
 	locale: 'en-US',
+	currency: null,
+	currency_symbol: '',
+	currency_symbol_on_right: false,
 	has_demo_data: false,
 	fiscal_year_start: '01-04-2020',
 }
@@ -65,6 +71,7 @@ async function fetchSessionInfo() {
 		is_user: Boolean(userInfo.is_user),
 		has_desk_access: Boolean(userInfo.has_desk_access),
 		has_demo_data: Boolean(userInfo.has_demo_data),
+		currency_symbol_on_right: Boolean(userInfo.currency_symbol_on_right),
 		can_download: Boolean(userInfo.can_download),
 	})
 }

--- a/frontend/src2/session.ts
+++ b/frontend/src2/session.ts
@@ -12,12 +12,24 @@ type SessionUser = {
 	can_download: boolean
 	country: string
 	locale: string
-	currency: string | null
-	currency_symbol: string
-	currency_symbol_on_right: boolean
 	has_desk_access?: boolean
 	has_demo_data: boolean
 	fiscal_year_start: string
+}
+
+// Settings of the site, not of whoever is reading it. A guest opening a public
+// dashboard gets these and nothing else, so a shared chart prints its amounts
+// the same way the workbook does.
+type SiteInfo = {
+	currency: string | null
+	currency_symbol: string
+	currency_symbol_on_right: boolean
+}
+
+const emptySite: SiteInfo = {
+	currency: null,
+	currency_symbol: '',
+	currency_symbol_on_right: false,
 }
 
 const emptyUser: SessionUser = {
@@ -31,20 +43,19 @@ const emptyUser: SessionUser = {
 	can_download: true,
 	country: '',
 	locale: 'en-US',
-	currency: null,
-	currency_symbol: '',
-	currency_symbol_on_right: false,
 	has_demo_data: false,
 	fiscal_year_start: '01-04-2020',
 }
 
 const session = reactive({
 	user: { ...emptyUser },
+	site: { ...emptySite },
 	initialized: false,
 	isLoggedIn: computed(() => false),
 	isAuthorized: computed(() => false),
 	initialize,
 	fetchSessionInfo,
+	fetchSiteInfo,
 	login,
 	logout,
 	resetSession,
@@ -58,7 +69,9 @@ session.isAuthorized = computed(() => session.user.is_admin || session.user.is_u
 async function initialize(force: boolean = false) {
 	if (session.initialized && !force) return
 	Object.assign(session.user, getSessionFromCookies())
-	session.isLoggedIn && (await fetchSessionInfo())
+	// the site's own settings reach a guest too, so they are fetched apart from
+	// the user's, and alongside them rather than after
+	await Promise.all([fetchSiteInfo(), session.isLoggedIn ? fetchSessionInfo() : null])
 	session.initialized = true
 }
 
@@ -71,8 +84,15 @@ async function fetchSessionInfo() {
 		is_user: Boolean(userInfo.is_user),
 		has_desk_access: Boolean(userInfo.has_desk_access),
 		has_demo_data: Boolean(userInfo.has_demo_data),
-		currency_symbol_on_right: Boolean(userInfo.currency_symbol_on_right),
 		can_download: Boolean(userInfo.can_download),
+	})
+}
+
+async function fetchSiteInfo() {
+	const siteInfo: SiteInfo = await call('insights.api.get_site_info')
+	Object.assign(session.site, {
+		...siteInfo,
+		currency_symbol_on_right: Boolean(siteInfo.currency_symbol_on_right),
 	})
 }
 

--- a/frontend/src2/session.ts
+++ b/frontend/src2/session.ts
@@ -10,7 +10,6 @@ type SessionUser = {
 	is_admin: boolean
 	is_user: boolean
 	can_download: boolean
-	country: string
 	locale: string
 	has_desk_access?: boolean
 	has_demo_data: boolean
@@ -21,12 +20,14 @@ type SessionUser = {
 // dashboard gets these and nothing else, so a shared chart prints its amounts
 // the same way the workbook does.
 type SiteInfo = {
+	country: string
 	currency: string | null
 	currency_symbol: string
 	currency_symbol_on_right: boolean
 }
 
 const emptySite: SiteInfo = {
+	country: '',
 	currency: null,
 	currency_symbol: '',
 	currency_symbol_on_right: false,
@@ -41,7 +42,6 @@ const emptyUser: SessionUser = {
 	is_admin: false,
 	is_user: false,
 	can_download: true,
-	country: '',
 	locale: 'en-US',
 	has_demo_data: false,
 	fiscal_year_start: '01-04-2020',

--- a/insights/api/__init__.py
+++ b/insights/api/__init__.py
@@ -6,6 +6,7 @@ import os
 import frappe
 from frappe.handler import is_valid_http_method, is_whitelisted
 from frappe.monitor import add_data_to_monitor
+from frappe.utils import cint
 
 from insights.api.shared import is_public
 from insights.decorators import insights_whitelist, validate_type
@@ -31,7 +32,10 @@ def get_site_info():
     """Settings of the site, not of whoever reads it. A guest opening a public
     dashboard needs them to print an amount the way the workbook does, and they
     say nothing a public dashboard does not already show."""
-    return get_currency_info()
+    return {
+        "country": frappe.db.get_single_value("System Settings", "country"),
+        **get_currency_info(),
+    }
 
 
 def get_currency_info():
@@ -48,7 +52,7 @@ def get_currency_info():
     if not currency:
         return {"currency": None, "currency_symbol": "", "currency_symbol_on_right": False}
 
-    hidden = frappe.defaults.get_global_default("hide_currency_symbol") in ("1", "Yes")
+    hidden = cint(frappe.defaults.get_global_default("hide_currency_symbol"))
     symbol, on_right = frappe.db.get_value("Currency", currency, ["symbol", "symbol_on_right"]) or (
         None,
         None,
@@ -86,8 +90,6 @@ def get_user_info():
         "is_admin": is_admin,
         "is_user": is_user or frappe.session.user == "Administrator",
         "can_download": is_admin or bool(frappe.db.get_single_value("Insights Settings", "allow_download")),
-        # TODO: move to `get_session_info` since not user specific
-        "country": frappe.db.get_single_value("System Settings", "country"),
         "locale": locale,
         "has_desk_access": user.get("user_type") == "System User",
         "has_demo_data": has_demo_data,

--- a/insights/api/__init__.py
+++ b/insights/api/__init__.py
@@ -26,6 +26,14 @@ def get_app_version():
     return frappe.get_attr("insights" + ".__version__")
 
 
+@frappe.whitelist(allow_guest=True, methods=["GET"])
+def get_site_info():
+    """Settings of the site, not of whoever reads it. A guest opening a public
+    dashboard needs them to print an amount the way the workbook does, and they
+    say nothing a public dashboard does not already show."""
+    return get_currency_info()
+
+
 def get_currency_info():
     """The site's display currency, as the client needs it to print an amount.
 
@@ -81,7 +89,6 @@ def get_user_info():
         # TODO: move to `get_session_info` since not user specific
         "country": frappe.db.get_single_value("System Settings", "country"),
         "locale": locale,
-        **get_currency_info(),
         "has_desk_access": user.get("user_type") == "System User",
         "has_demo_data": has_demo_data,
         "fiscal_year_start": frappe.db.get_single_value("Insights Settings", "fiscal_year_start")

--- a/insights/api/__init__.py
+++ b/insights/api/__init__.py
@@ -26,6 +26,33 @@ def get_app_version():
     return frappe.get_attr("insights" + ".__version__")
 
 
+def get_currency_info():
+    """The site's display currency, as the client needs it to print an amount.
+
+    The `currency` global default covers a site with ERPNext and one without:
+    ERPNext's Global Defaults writes `default_currency` into it, and plain Frappe
+    writes `System Settings.currency` into it. `hide_currency_symbol` empties the
+    symbol, which is how a site says amounts print bare.
+    """
+    # System Settings writes the default only when the field changes, so read the
+    # field too — a site installed with a currency has never "changed" it
+    currency = frappe.db.get_default("currency") or frappe.db.get_single_value("System Settings", "currency")
+    if not currency:
+        return {"currency": None, "currency_symbol": "", "currency_symbol_on_right": False}
+
+    hidden = frappe.defaults.get_global_default("hide_currency_symbol") in ("1", "Yes")
+    symbol, on_right = frappe.db.get_value("Currency", currency, ["symbol", "symbol_on_right"]) or (
+        None,
+        None,
+    )
+    return {
+        "currency": currency,
+        # a currency with no symbol of its own prints as its code, the way fmt_money does
+        "currency_symbol": "" if hidden else (symbol or currency),
+        "currency_symbol_on_right": bool(on_right),
+    }
+
+
 @insights_whitelist()
 def get_user_info():
     roles = frappe.get_roles()
@@ -54,6 +81,7 @@ def get_user_info():
         # TODO: move to `get_session_info` since not user specific
         "country": frappe.db.get_single_value("System Settings", "country"),
         "locale": locale,
+        **get_currency_info(),
         "has_desk_access": user.get("user_type") == "System User",
         "has_demo_data": has_demo_data,
         "fiscal_year_start": frappe.db.get_single_value("Insights Settings", "fiscal_year_start")

--- a/insights/tests/test_currency_info.py
+++ b/insights/tests/test_currency_info.py
@@ -17,6 +17,9 @@ def _defaults(currency=None, hide_symbol=None):
 
 
 class TestCurrencyInfo(InsightsIntegrationTestCase):
+    # two tests edit a Currency record to state a shape the site does not have
+    SAVEPOINT = "test_currency_info"
+
     def test_symbol_comes_from_the_site_currency(self):
         currency, hidden = _defaults("USD")
         with currency, hidden:

--- a/insights/tests/test_currency_info.py
+++ b/insights/tests/test_currency_info.py
@@ -1,0 +1,54 @@
+from unittest.mock import patch
+
+import frappe
+
+from insights.api import get_currency_info
+from insights.tests.base import InsightsIntegrationTestCase
+
+
+def _defaults(currency=None, hide_symbol=None):
+    """Stand in for the two default reads get_currency_info makes, so a test
+    states a site's currency without writing the shared site's defaults."""
+    return (
+        patch.object(frappe.db, "get_default", return_value=currency),
+        patch.object(frappe.defaults, "get_global_default", return_value=hide_symbol),
+    )
+
+
+class TestCurrencyInfo(InsightsIntegrationTestCase):
+    def test_symbol_comes_from_the_site_currency(self):
+        currency, hidden = _defaults("USD")
+        with currency, hidden:
+            self.assertEqual(
+                get_currency_info(),
+                {"currency": "USD", "currency_symbol": "$", "currency_symbol_on_right": False},
+            )
+
+    def test_symbol_sits_on_the_right_when_the_currency_says_so(self):
+        frappe.db.set_value("Currency", "SEK", "symbol_on_right", 1)
+        currency, hidden = _defaults("SEK")
+        with currency, hidden:
+            info = get_currency_info()
+        self.assertEqual(info["currency"], "SEK")
+        self.assertTrue(info["currency_symbol_on_right"])
+
+    def test_a_currency_without_a_symbol_prints_as_its_code(self):
+        frappe.db.set_value("Currency", "XAF", "symbol", "")
+        currency, hidden = _defaults("XAF")
+        with currency, hidden:
+            self.assertEqual(get_currency_info()["currency_symbol"], "XAF")
+
+    def test_hide_currency_symbol_empties_the_symbol(self):
+        currency, hidden = _defaults("INR", hide_symbol="1")
+        with currency, hidden:
+            info = get_currency_info()
+        self.assertEqual(info["currency"], "INR")
+        self.assertEqual(info["currency_symbol"], "")
+
+    def test_a_site_without_a_currency_prints_amounts_bare(self):
+        currency, hidden = _defaults(None)
+        with currency, hidden, patch.object(frappe.db, "get_single_value", return_value=""):
+            self.assertEqual(
+                get_currency_info(),
+                {"currency": None, "currency_symbol": "", "currency_symbol_on_right": False},
+            )

--- a/insights/tests/test_currency_info.py
+++ b/insights/tests/test_currency_info.py
@@ -2,8 +2,9 @@ from unittest.mock import patch
 
 import frappe
 
-from insights.api import get_currency_info
+from insights.api import get_currency_info, get_site_info
 from insights.tests.base import InsightsIntegrationTestCase
+from insights.tests.factories import as_user
 
 
 def _defaults(currency=None, hide_symbol=None):
@@ -52,3 +53,11 @@ class TestCurrencyInfo(InsightsIntegrationTestCase):
                 get_currency_info(),
                 {"currency": None, "currency_symbol": "", "currency_symbol_on_right": False},
             )
+
+    def test_a_guest_reading_a_public_dashboard_gets_the_symbol(self):
+        # the guest whitelist is the point of the endpoint: a shared chart is
+        # read by nobody in particular, and it still has to print its amounts
+        self.assertIn(get_site_info, frappe.guest_methods)
+        currency, hidden = _defaults("USD")
+        with as_user("Guest"), currency, hidden:
+            self.assertEqual(get_site_info()["currency_symbol"], "$")

--- a/insights/workbook_templates/accounting/manifest.json
+++ b/insights/workbook_templates/accounting/manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": 2,
+	"version": 3,
 	"title": "Receivables, Payables & Cash",
 	"description": "AR/AP ageing, a collections worklist and a cash-flow view for receivables, payables and cash.",
 	"notes": "Built from submitted Sales/Purchase Invoices, Payment Entries and the Payment Ledger (delinked=0), so payment-rounding residuals don't inflate receivables/payables. AR/AP outstanding is read from the Payment Ledger Entry rather than reconstructed from GL, which is far cheaper on large sites. Snapshot figures are as-of-today in the company's base currency; the date filter drives the cash-flow trends.",

--- a/insights/workbook_templates/accounting/workbook.json
+++ b/insights/workbook_templates/accounting/workbook.json
@@ -676,8 +676,7 @@
 									"measure_name": "Outstanding",
 									"column_name": "outstanding",
 									"data_type": "Decimal",
-									"aggregation": "sum",
-									"format": "currency"
+									"aggregation": "sum"
 								}
 							}
 						],
@@ -717,8 +716,7 @@
 									"measure_name": "Outstanding",
 									"column_name": "outstanding",
 									"data_type": "Decimal",
-									"aggregation": "sum",
-									"format": "currency"
+									"aggregation": "sum"
 								}
 							}
 						],

--- a/insights/workbook_templates/accounting/workbook.json
+++ b/insights/workbook_templates/accounting/workbook.json
@@ -546,7 +546,8 @@
 							"measure_name": "Total AR",
 							"column_name": "outstanding",
 							"data_type": "Decimal",
-							"aggregation": "sum"
+							"aggregation": "sum",
+							"format": "currency"
 						}
 					],
 					"comparison": false,
@@ -568,7 +569,8 @@
 							"measure_name": "Total AP",
 							"column_name": "outstanding",
 							"data_type": "Decimal",
-							"aggregation": "sum"
+							"aggregation": "sum",
+							"format": "currency"
 						}
 					],
 					"comparison": false,
@@ -642,7 +644,8 @@
 							"measure_name": "Net Cash Flow",
 							"column_name": "net_amount",
 							"data_type": "Decimal",
-							"aggregation": "sum"
+							"aggregation": "sum",
+							"format": "currency"
 						}
 					],
 					"comparison": false,
@@ -673,7 +676,8 @@
 									"measure_name": "Outstanding",
 									"column_name": "outstanding",
 									"data_type": "Decimal",
-									"aggregation": "sum"
+									"aggregation": "sum",
+									"format": "currency"
 								}
 							}
 						],
@@ -713,7 +717,8 @@
 									"measure_name": "Outstanding",
 									"column_name": "outstanding",
 									"data_type": "Decimal",
-									"aggregation": "sum"
+									"aggregation": "sum",
+									"format": "currency"
 								}
 							}
 						],
@@ -752,13 +757,15 @@
 							"measure_name": "Outstanding",
 							"column_name": "outstanding",
 							"data_type": "Decimal",
-							"aggregation": "sum"
+							"aggregation": "sum",
+							"format": "currency"
 						},
 						{
 							"measure_name": "Overdue",
 							"column_name": "overdue_outstanding",
 							"data_type": "Decimal",
-							"aggregation": "sum"
+							"aggregation": "sum",
+							"format": "currency"
 						},
 						{
 							"measure_name": "Oldest Days",
@@ -811,7 +818,8 @@
 							"measure_name": "Outstanding",
 							"column_name": "outstanding",
 							"data_type": "Decimal",
-							"aggregation": "sum"
+							"aggregation": "sum",
+							"format": "currency"
 						}
 					],
 					"filters": {

--- a/insights/workbook_templates/purchasing/manifest.json
+++ b/insights/workbook_templates/purchasing/manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": 1,
+	"version": 2,
 	"title": "Purchasing Overview",
 	"description": "Supplier spend, order workload and receiving risk at a glance — spend trend with month-on-month KPIs, spend by item group, top suppliers, purchase-order status mix and an overdue-POs list.",
 	"notes": "Built from submitted Purchase Invoices and Purchase Orders. Amounts are in the company's base currency and net of returns (debit notes ride along as negative rows). Order count and average order value are measured on Purchase Orders by transaction date.",

--- a/insights/workbook_templates/purchasing/workbook.json
+++ b/insights/workbook_templates/purchasing/workbook.json
@@ -353,8 +353,7 @@
 									"measure_name": "Spend",
 									"column_name": "base_net_total",
 									"data_type": "Decimal",
-									"aggregation": "sum",
-									"format": "currency"
+									"aggregation": "sum"
 								}
 							}
 						],
@@ -394,8 +393,7 @@
 						"measure_name": "Spend",
 						"column_name": "base_net_amount",
 						"data_type": "Decimal",
-						"aggregation": "sum",
-						"format": "currency"
+						"aggregation": "sum"
 					},
 					"legend_position": "bottom",
 					"order_by": [],
@@ -429,8 +427,7 @@
 									"measure_name": "Spend",
 									"column_name": "base_net_total",
 									"data_type": "Decimal",
-									"aggregation": "sum",
-									"format": "currency"
+									"aggregation": "sum"
 								}
 							}
 						]

--- a/insights/workbook_templates/purchasing/workbook.json
+++ b/insights/workbook_templates/purchasing/workbook.json
@@ -229,7 +229,8 @@
 							"measure_name": "Spend",
 							"column_name": "base_net_total",
 							"data_type": "Decimal",
-							"aggregation": "sum"
+							"aggregation": "sum",
+							"format": "currency"
 						},
 						{
 							"measure_name": "Active Suppliers",
@@ -240,7 +241,6 @@
 					],
 					"number_column_options": [
 						{
-							"prefix": "₹ ",
 							"decimal": 2,
 							"shorten_numbers": true
 						},
@@ -292,7 +292,8 @@
 							"measure_name": "Avg PO Value",
 							"column_name": "base_grand_total",
 							"data_type": "Decimal",
-							"aggregation": "avg"
+							"aggregation": "avg",
+							"format": "currency"
 						}
 					],
 					"number_column_options": [
@@ -300,7 +301,6 @@
 							"shorten_numbers": false
 						},
 						{
-							"prefix": "₹ ",
 							"decimal": 2,
 							"shorten_numbers": true
 						}
@@ -353,7 +353,8 @@
 									"measure_name": "Spend",
 									"column_name": "base_net_total",
 									"data_type": "Decimal",
-									"aggregation": "sum"
+									"aggregation": "sum",
+									"format": "currency"
 								}
 							}
 						],
@@ -393,7 +394,8 @@
 						"measure_name": "Spend",
 						"column_name": "base_net_amount",
 						"data_type": "Decimal",
-						"aggregation": "sum"
+						"aggregation": "sum",
+						"format": "currency"
 					},
 					"legend_position": "bottom",
 					"order_by": [],
@@ -427,7 +429,8 @@
 									"measure_name": "Spend",
 									"column_name": "base_net_total",
 									"data_type": "Decimal",
-									"aggregation": "sum"
+									"aggregation": "sum",
+									"format": "currency"
 								}
 							}
 						]
@@ -515,7 +518,8 @@
 							"measure_name": "Order Value",
 							"column_name": "base_grand_total",
 							"data_type": "Decimal",
-							"aggregation": "sum"
+							"aggregation": "sum",
+							"format": "currency"
 						}
 					],
 					"order_by": [

--- a/insights/workbook_templates/sales/manifest.json
+++ b/insights/workbook_templates/sales/manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": 2,
+	"version": 3,
 	"title": "Sales Performance",
 	"description": "Revenue, customers and fulfilment at a glance — revenue trend with month-on-month KPIs, top customers and items, a quotation-to-order funnel and an overdue-deliveries list.",
 	"notes": "Built from submitted Sales Invoices, Quotations and Sales Orders. Amounts are in the company's base currency and net of returns. POS invoices are reflected only after POS closing.",

--- a/insights/workbook_templates/sales/workbook.json
+++ b/insights/workbook_templates/sales/workbook.json
@@ -358,7 +358,8 @@
 							"measure_name": "Revenue",
 							"column_name": "base_net_total",
 							"data_type": "Decimal",
-							"aggregation": "sum"
+							"aggregation": "sum",
+							"format": "currency"
 						},
 						{
 							"measure_name": "Invoices",
@@ -370,7 +371,8 @@
 							"measure_name": "Avg Invoice Value",
 							"column_name": "base_net_total",
 							"data_type": "Decimal",
-							"aggregation": "avg"
+							"aggregation": "avg",
+							"format": "currency"
 						},
 						{
 							"measure_name": "Active Customers",
@@ -381,7 +383,6 @@
 					],
 					"number_column_options": [
 						{
-							"prefix": "\u20b9 ",
 							"decimal": 2,
 							"shorten_numbers": true
 						},
@@ -389,7 +390,6 @@
 							"shorten_numbers": false
 						},
 						{
-							"prefix": "\u20b9 ",
 							"decimal": 2,
 							"shorten_numbers": true
 						},
@@ -445,7 +445,8 @@
 									"measure_name": "Revenue",
 									"column_name": "base_net_total",
 									"data_type": "Decimal",
-									"aggregation": "sum"
+									"aggregation": "sum",
+									"format": "currency"
 								}
 							}
 						],
@@ -485,7 +486,8 @@
 						"measure_name": "Revenue",
 						"column_name": "base_net_amount",
 						"data_type": "Decimal",
-						"aggregation": "sum"
+						"aggregation": "sum",
+						"format": "currency"
 					},
 					"legend_position": "bottom",
 					"order_by": [],
@@ -519,7 +521,8 @@
 									"measure_name": "Revenue",
 									"column_name": "base_net_total",
 									"data_type": "Decimal",
-									"aggregation": "sum"
+									"aggregation": "sum",
+									"format": "currency"
 								}
 							}
 						]
@@ -563,7 +566,8 @@
 									"measure_name": "Revenue",
 									"column_name": "base_net_amount",
 									"data_type": "Decimal",
-									"aggregation": "sum"
+									"aggregation": "sum",
+									"format": "currency"
 								}
 							}
 						]
@@ -693,7 +697,8 @@
 							"measure_name": "Order Value",
 							"column_name": "base_grand_total",
 							"data_type": "Decimal",
-							"aggregation": "sum"
+							"aggregation": "sum",
+							"format": "currency"
 						}
 					],
 					"order_by": [

--- a/insights/workbook_templates/sales/workbook.json
+++ b/insights/workbook_templates/sales/workbook.json
@@ -445,8 +445,7 @@
 									"measure_name": "Revenue",
 									"column_name": "base_net_total",
 									"data_type": "Decimal",
-									"aggregation": "sum",
-									"format": "currency"
+									"aggregation": "sum"
 								}
 							}
 						],
@@ -486,8 +485,7 @@
 						"measure_name": "Revenue",
 						"column_name": "base_net_amount",
 						"data_type": "Decimal",
-						"aggregation": "sum",
-						"format": "currency"
+						"aggregation": "sum"
 					},
 					"legend_position": "bottom",
 					"order_by": [],
@@ -521,8 +519,7 @@
 									"measure_name": "Revenue",
 									"column_name": "base_net_total",
 									"data_type": "Decimal",
-									"aggregation": "sum",
-									"format": "currency"
+									"aggregation": "sum"
 								}
 							}
 						]
@@ -566,8 +563,7 @@
 									"measure_name": "Revenue",
 									"column_name": "base_net_amount",
 									"data_type": "Decimal",
-									"aggregation": "sum",
-									"format": "currency"
+									"aggregation": "sum"
 								}
 							}
 						]

--- a/insights/workbook_templates/stock/manifest.json
+++ b/insights/workbook_templates/stock/manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": 1,
+	"version": 2,
 	"title": "Inventory Health",
 	"description": "Stock value, ageing and reorder health — value by warehouse and item group, incoming vs outgoing movement, a reorder alert list and top items by value.",
 	"notes": "Built from live Bin balances and Stock Ledger Entries. Values are in the company's base currency and reflect the site's current valuation state (backdated or un-reposted entries can skew Bin values). Stock ageing and dead-stock use an item-level last-movement proxy, not FIFO lot ageing.",

--- a/insights/workbook_templates/stock/workbook.json
+++ b/insights/workbook_templates/stock/workbook.json
@@ -493,8 +493,7 @@
 									"measure_name": "stock_value",
 									"column_name": "stock_value",
 									"data_type": "Decimal",
-									"aggregation": "sum",
-									"format": "currency"
+									"aggregation": "sum"
 								}
 							}
 						]
@@ -533,8 +532,7 @@
 									"measure_name": "stock_value",
 									"column_name": "stock_value",
 									"data_type": "Decimal",
-									"aggregation": "sum",
-									"format": "currency"
+									"aggregation": "sum"
 								}
 							}
 						]
@@ -573,8 +571,7 @@
 									"measure_name": "stock_value",
 									"column_name": "stock_value",
 									"data_type": "Decimal",
-									"aggregation": "sum",
-									"format": "currency"
+									"aggregation": "sum"
 								}
 							}
 						]

--- a/insights/workbook_templates/stock/workbook.json
+++ b/insights/workbook_templates/stock/workbook.json
@@ -360,7 +360,8 @@
 							"measure_name": "Total Stock Value",
 							"column_name": "stock_value",
 							"data_type": "Decimal",
-							"aggregation": "sum"
+							"aggregation": "sum",
+							"format": "currency"
 						}
 					],
 					"number_column_options": [
@@ -387,7 +388,8 @@
 							"measure_name": "Stock Value Change",
 							"column_name": "stock_value_difference",
 							"data_type": "Decimal",
-							"aggregation": "sum"
+							"aggregation": "sum",
+							"format": "currency"
 						}
 					],
 					"number_column_options": [
@@ -441,7 +443,8 @@
 							"measure_name": "Dead Stock (90d+)",
 							"column_name": "stock_value",
 							"data_type": "Decimal",
-							"aggregation": "sum"
+							"aggregation": "sum",
+							"format": "currency"
 						}
 					],
 					"number_column_options": [
@@ -490,7 +493,8 @@
 									"measure_name": "stock_value",
 									"column_name": "stock_value",
 									"data_type": "Decimal",
-									"aggregation": "sum"
+									"aggregation": "sum",
+									"format": "currency"
 								}
 							}
 						]
@@ -529,7 +533,8 @@
 									"measure_name": "stock_value",
 									"column_name": "stock_value",
 									"data_type": "Decimal",
-									"aggregation": "sum"
+									"aggregation": "sum",
+									"format": "currency"
 								}
 							}
 						]
@@ -568,7 +573,8 @@
 									"measure_name": "stock_value",
 									"column_name": "stock_value",
 									"data_type": "Decimal",
-									"aggregation": "sum"
+									"aggregation": "sum",
+									"format": "currency"
 								}
 							}
 						]
@@ -714,7 +720,8 @@
 							"measure_name": "stock_value",
 							"column_name": "stock_value",
 							"data_type": "Decimal",
-							"aggregation": "sum"
+							"aggregation": "sum",
+							"format": "currency"
 						},
 						{
 							"measure_name": "days_since_movement",


### PR DESCRIPTION
Fixes #1318.

The shipped workbooks carried `"prefix": "₹ "`, so every site printed the rupee sign.

`DataFormat` already declared a `currency` format that nothing implemented. This fills it: the symbol comes from the site's `currency` global default, which ERPNext's Global Defaults and plain System Settings both write. Number cards and tables read it through one `getFormatUnits`, which also takes over the `percent` case each of them handled alone. The templates mark their money measures instead of spelling a symbol out.

Nothing draws a measure's format on a line, bar or donut chart, so only the number-card and table measures are marked. Teaching the axis and tooltip formatters is a separate change.

One behaviour change: a percent measure with **Shorten numbers** on now shortens.

The issue also asks for a company currency and for picking a non-base currency. Neither is a formatting problem — the measures aggregate `base_*` columns, so a multi-company site with different base currencies sums incompatible amounts, and a non-base currency needs an exchange-rate join.

🤖 Generated with [Claude Code](https://claude.com/claude-code)