### PR TITLE
feat(iris): read the PR thread, answer questions, review the delta

### DIFF
--- a/.claude/commands/iris-review.md
+++ b/.claude/commands/iris-review.md
@@ -18,9 +18,27 @@ worth doing, say so in one line and stop.
 **Where the review goes.** If `$ARGUMENTS` contains `--ci`, you are running in CI: Write
 the review to `/tmp/review.md`, then stop — the workflow posts the file as the PR comment.
 Always write the file, even for "Looks good". Otherwise print it in chat and post nothing.
-Do not probe the environment to decide — the arguments are the only signal. When the `--ci` event is `issue_comment`, Read `/tmp/iris-comment.txt` — if it asks
-for a specific angle, lead with "Re-reviewing per @<author> — focused on <thing>", with the
-author from `/tmp/iris-comment-author.txt`.
+Do not probe the environment to decide — the arguments are the only signal.
+
+**The comment picks the mode.** When the `--ci` event is `issue_comment`, Read
+`/tmp/iris-comment.txt` (its author is in `/tmp/iris-comment-author.txt`).
+
+- `/iris review` → a review. If it names an angle, lead with "Re-reviewing per @<author>
+  — focused on <thing>."
+- `/iris` with anything else → an answer, not a review. Reply in a few sentences, reading
+  only what the answer needs. No phases, no verdict, no score. Defend a finding the way
+  you made it — with evidence — and concede it plainly when the reply refutes it.
+
+**The PR thread is your memory.** Before phase 1, read the conversation with
+`gh pr view <N> --comments`. Your earlier reviews and the replies to them are input.
+
+- A decision in the thread stands. If the maintainer called a finding an accepted
+  tradeoff, or declared a scope punt, do not re-raise it — one "Settled:" line names it.
+- On re-review, give each earlier finding a status: resolved (name the commit), stands,
+  or settled. Verify "resolved" like any other claim — read the code, not the reply.
+- Your last review's footer names the commit it reviewed. Spend phase 1 on
+  `git diff <that-sha>..HEAD` and what it touches; code you already reviewed and that did
+  not move gets no second pass. No footer sha, or a force-push broke the range → full pass.
 
 This command is already running — never call the Skill tool.
 

--- a/.claude/commands/iris-review.md
+++ b/.claude/commands/iris-review.md
@@ -27,7 +27,8 @@ Do not probe the environment to decide — the arguments are the only signal.
   — focused on <thing>."
 - `/iris` with anything else → an answer, not a review. Reply in a few sentences, reading
   only what the answer needs. No phases, no verdict, no score. Defend a finding the way
-  you made it — with evidence — and concede it plainly when the reply refutes it.
+  you made it — with evidence — and concede it plainly when the reply refutes it. An
+  answer goes to `/tmp/review.md` like a review — the workflow posts whatever is there.
 
 **The PR thread is your memory.** Before phase 1, read the conversation with
 `gh pr view <N> --comments`. Your earlier reviews and the replies to them are input.

--- a/.github/workflows/iris-review.yml
+++ b/.github/workflows/iris-review.yml
@@ -150,10 +150,19 @@ jobs:
           model=$(jq -r 'first(.. | objects | select(has("model")) | .model) // empty' "$EXEC_FILE" || true)
           cost=$(jq -r 'first(.. | objects | select(has("total_cost_usd")) | .total_cost_usd) // empty' "$EXEC_FILE" || true)
           ms=$(jq -r 'first(.. | objects | select(has("duration_ms")) | .duration_ms) // empty' "$EXEC_FILE" || true)
+          tin=$(jq -r 'first(.. | objects | select(has("total_cost_usd"))) | .usage.input_tokens // empty' "$EXEC_FILE" || true)
+          tcache=$(jq -r 'first(.. | objects | select(has("total_cost_usd"))) | .usage
+            | (.cache_read_input_tokens // 0) + (.cache_creation_input_tokens // 0)
+            | if . > 0 then . else empty end' "$EXEC_FILE" || true)
+          tout=$(jq -r 'first(.. | objects | select(has("total_cost_usd"))) | .usage.output_tokens // empty' "$EXEC_FILE" || true)
+          tok() { if [ "$1" -ge 1000 ]; then echo "$(($1 / 1000))k"; else echo "$1"; fi; }
           footer="iris"
           [ -n "$model" ] && footer="$footer · $model"
           [ -n "$cost" ] && footer=$(printf '%s · $%.2f' "$footer" "$cost")
           [ -n "$ms" ] && footer="$footer · $((ms / 60000))m $((ms / 1000 % 60))s"
+          [ -n "$tin" ] && footer="$footer · $(tok "$tin") in"
+          [ -n "$tcache" ] && footer="$footer · $(tok "$tcache") cached"
+          [ -n "$tout" ] && footer="$footer · $(tok "$tout") out"
           # The reviewed commit anchors the next re-review's delta diff.
           sha=$(git rev-parse --short HEAD || true)
           [ -n "$sha" ] && footer="$footer · reviewed $sha"

--- a/.github/workflows/iris-review.yml
+++ b/.github/workflows/iris-review.yml
@@ -46,7 +46,10 @@ jobs:
           github.event_name == 'issue_comment' &&
           github.event.issue.pull_request != null &&
           github.event.issue.state == 'open' &&
-          contains(github.event.comment.body, '/iris') &&
+          (
+            github.event.comment.body == '/iris' ||
+            startsWith(github.event.comment.body, '/iris ')
+          ) &&
           (
             github.event.comment.author_association == 'OWNER' ||
             github.event.comment.author_association == 'MEMBER' ||

--- a/.github/workflows/iris-review.yml
+++ b/.github/workflows/iris-review.yml
@@ -46,7 +46,7 @@ jobs:
           github.event_name == 'issue_comment' &&
           github.event.issue.pull_request != null &&
           github.event.issue.state == 'open' &&
-          contains(github.event.comment.body, '/iris review') &&
+          contains(github.event.comment.body, '/iris') &&
           (
             github.event.comment.author_association == 'OWNER' ||
             github.event.comment.author_association == 'MEMBER' ||
@@ -151,6 +151,9 @@ jobs:
           [ -n "$model" ] && footer="$footer · $model"
           [ -n "$cost" ] && footer=$(printf '%s · $%.2f' "$footer" "$cost")
           [ -n "$ms" ] && footer="$footer · $((ms / 60000))m $((ms / 1000 % 60))s"
+          # The reviewed commit anchors the next re-review's delta diff.
+          sha=$(git rev-parse --short HEAD || true)
+          [ -n "$sha" ] && footer="$footer · reviewed $sha"
           printf '\n\n<sub>%s · [run](%s)</sub>\n' "$footer" "$RUN_URL" >> /tmp/review.md
           gh pr comment "$PR" -R "${{ github.repository }}" --body-file /tmp/review.md
 

--- a/docs/agents/iris-report.md
+++ b/docs/agents/iris-report.md
@@ -44,6 +44,10 @@ The reader must be able to stop after layer 1 and still know what is wrong.
   'smelly'"*. Say it is a feeling when it is.
 - No emoji, no filler. Zero issues → a one-line "Looks good" with what the change does.
   Never manufacture a concern.
+- **On re-review, account for the last review first.** One line per earlier finding:
+  resolved (name the commit), stands, or settled. Then the new findings, if any. A
+  settled finding is out of the score — "Settled: the SSL default, per @<author>" is the
+  whole entry, with no re-argument.
 
 Example:
 


### PR DESCRIPTION
Three changes, one idea: the PR thread is iris's memory.

- Iris reads the conversation before phase 1. A reply that settles a finding (accepted tradeoff, declared scope punt) stands — the next review lists it in one "Settled" line instead of re-arguing it. Earlier findings get a status: resolved, stands, or settled.
- The review footer now names the reviewed commit. A re-review diffs from there and skips code that did not move — the full cold pass only happens on the first review.
- The comment trigger matches `/iris`, not just `/iris review`. Anything after `/iris` that is not `review` gets a short answer, no phases, no verdict — a way to ask "why is this a concern?" without paying for a full pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)