### PR TITLE
fix: let frappe check the argument types of every endpoint

### DIFF
--- a/insights/api/__init__.py
+++ b/insights/api/__init__.py
@@ -8,7 +8,7 @@ from frappe.handler import is_valid_http_method, is_whitelisted
 from frappe.monitor import add_data_to_monitor
 
 from insights.api.shared import is_public
-from insights.decorators import insights_whitelist, validate_type
+from insights.decorators import insights_whitelist
 from insights.insights.doctype.insights_data_source_v3.ibis_utils import (
     get_columns_from_schema,
 )
@@ -88,7 +88,6 @@ def create_uploads_if_not_exists():
 
 
 @insights_whitelist()
-@validate_type
 def get_file_data(filename: str):
     check_data_source_permission("uploads")
 
@@ -120,7 +119,6 @@ def get_file_data(filename: str):
 
 
 @insights_whitelist()
-@validate_type
 def import_csv_data(filename: str, tablename: str = ""):
     check_data_source_permission("uploads")
 
@@ -171,7 +169,6 @@ def _read_uploaded_table(db, file_path: str, ext: str):
 
 @frappe.whitelist(allow_guest=True)  # nosemgrep - falls back to is_public() only after the
 # framework has already refused the caller
-@validate_type
 def get_doc(doctype: str, name: str | int):
     try:
         from frappe.client import get as _get_doc

--- a/insights/api/alerts.py
+++ b/insights/api/alerts.py
@@ -1,10 +1,9 @@
 import frappe
 
-from insights.decorators import insights_whitelist, validate_type
+from insights.decorators import insights_whitelist
 
 
 @insights_whitelist()
-@validate_type
 def get_alerts(query: str):
     return frappe.get_list(
         "Insights Alert",

--- a/insights/api/dashboards.py
+++ b/insights/api/dashboards.py
@@ -1,7 +1,7 @@
 import frappe
 from frappe.query_builder.functions import Count, Max
 
-from insights.decorators import insights_whitelist, validate_type
+from insights.decorators import insights_whitelist
 
 
 @insights_whitelist()
@@ -148,7 +148,6 @@ def _dashboard_chart_counts(names: list[str]) -> dict[str, int]:
 
 
 @insights_whitelist()
-@validate_type
 def update_dashboard_preview(dashboard_name: str):
     frappe.has_permission("Insights Dashboard v3", ptype="read", doc=dashboard_name, throw=True)
     dashboard = frappe.get_doc("Insights Dashboard v3", dashboard_name)

--- a/insights/api/data_sources.py
+++ b/insights/api/data_sources.py
@@ -1,6 +1,6 @@
 import frappe
 
-from insights.decorators import insights_whitelist, validate_type
+from insights.decorators import insights_whitelist
 from insights.insights.doctype.insights_data_source_v3.ibis_utils import (
     execute_ibis_query,
     get_columns_from_schema,
@@ -35,7 +35,6 @@ def get_all_data_sources():
 
 
 @insights_whitelist()
-@validate_type
 def get_data_source_tables(data_source: str | None = None, search_term: str | None = None, limit: int = 100):
     tables = frappe.get_list(
         "Insights Table v3",
@@ -78,7 +77,6 @@ def get_permitted_ibis_table(data_source: str, table_name: str):
 
 
 @insights_whitelist()
-@validate_type
 def get_data_source_table(data_source: str, table_name: str):
     q = get_permitted_ibis_table(data_source, table_name).head(100)
     data, _ = execute_ibis_query(q, cache_expiry=24 * 60 * 60)
@@ -92,7 +90,6 @@ def get_data_source_table(data_source: str, table_name: str):
 
 
 @insights_whitelist()
-@validate_type
 def get_data_source_table_row_count(data_source: str, table_name: str):
     table = get_permitted_ibis_table(data_source, table_name)
     result = table.count().execute()
@@ -100,7 +97,6 @@ def get_data_source_table_row_count(data_source: str, table_name: str):
 
 
 @insights_whitelist()
-@validate_type
 def get_data_source_table_columns(data_source: str, table_name: str):
     table = get_permitted_ibis_table(data_source, table_name)
     return [
@@ -114,7 +110,6 @@ def get_data_source_table_columns(data_source: str, table_name: str):
 
 
 @insights_whitelist()
-@validate_type
 def update_data_source_tables(data_source: str):
     check_data_source_permission(data_source)
     ds = frappe.get_doc("Insights Data Source v3", data_source)
@@ -122,14 +117,12 @@ def update_data_source_tables(data_source: str):
 
 
 @insights_whitelist()
-@validate_type
 def get_table_links(data_source: str, left_table: str, right_table: str):
     check_table_permission(data_source, left_table)
     return InsightsTableLinkv3.get_links(data_source, left_table, right_table)
 
 
 @insights_whitelist()
-@validate_type
 def update_table_links(data_source: str):
     check_data_source_permission(data_source)
     ds = frappe.get_doc("Insights Data Source v3", data_source)
@@ -188,7 +181,6 @@ def get_data_sources_of_tables(table_names: list[str]):
 
 
 @insights_whitelist()
-@validate_type
 def get_schema(data_source: str):
     check_data_source_permission(data_source)
 

--- a/insights/api/data_store.py
+++ b/insights/api/data_store.py
@@ -1,11 +1,10 @@
 import frappe
 
-from insights.decorators import insights_whitelist, validate_type
+from insights.decorators import insights_whitelist
 from insights.insights.doctype.insights_table_v3.insights_table_v3 import get_table_name
 
 
 @insights_whitelist()
-@validate_type
 def get_data_store_tables(data_source: str | None = None, search_term: str | None = None, limit: int = 100):
     filters = {"stored": 1}
     if data_source:
@@ -50,7 +49,6 @@ def get_data_store_tables(data_source: str | None = None, search_term: str | Non
 
 
 @insights_whitelist(role="Insights Admin")
-@validate_type
 def import_table(data_source: str, table_name: str):
     name = get_table_name(data_source, table_name)
     table_doc = frappe.get_doc("Insights Table v3", name)

--- a/insights/api/shared.py
+++ b/insights/api/shared.py
@@ -1,8 +1,6 @@
 import frappe
 from frappe.query_builder import DocType
 
-from insights.decorators import validate_type
-
 public_doctypes = [
     "Insights Dashboard v3",
     "Insights Chart v3",
@@ -16,6 +14,11 @@ def check_public_access(doctype, name):
 
 
 def is_public(doctype: str, name: str):
+    # run_doc_method reads `name` out of a parsed JSON blob, which frappe checks
+    # only as a whole, so a dict can arrive here and reach frappe.db as a
+    # filter set. Nothing but a name names a public document.
+    if not isinstance(name, str):
+        return False
     if doctype not in public_doctypes:
         return False
     if has_valid_preview_key():
@@ -32,7 +35,6 @@ def is_public(doctype: str, name: str):
     return False
 
 
-@validate_type
 def is_public_workbook(name: str):
     public_dashboard_exists = frappe.db.exists(
         "Insights Dashboard v3",
@@ -60,7 +62,6 @@ def has_valid_preview_key():
     return preview_key and frappe.cache.get_value(f"insights_preview_key:{preview_key}")
 
 
-@validate_type
 def is_public_dashboard(name: str):
     return frappe.db.exists(
         "Insights Dashboard v3",
@@ -97,7 +98,6 @@ def get_public_charts():
     return list(set(charts))
 
 
-@validate_type
 def is_public_chart(name: str):
     is_public = frappe.db.exists(
         "Insights Chart v3",
@@ -112,7 +112,6 @@ def is_public_chart(name: str):
     return name in get_public_charts()
 
 
-@validate_type
 def is_public_query(name: str):
     # find a public chart that is linked with this query
     linked_charts = frappe.get_all(
@@ -131,7 +130,6 @@ def is_public_query(name: str):
 
 
 @frappe.whitelist(allow_guest=True)
-@validate_type
 def get_dashboard_name(dashboard_name: str):
     name = dashboard_name
     if not frappe.db.exists("Insights Dashboard v3", name):
@@ -142,7 +140,6 @@ def get_dashboard_name(dashboard_name: str):
 
 
 @frappe.whitelist(allow_guest=True)
-@validate_type
 def get_chart_name(chart_name: str):
     name = chart_name
     if not frappe.db.exists("Insights Chart v3", name):

--- a/insights/api/user.py
+++ b/insights/api/user.py
@@ -5,7 +5,7 @@ import frappe
 from frappe.utils import split_emails, validate_email_address
 from frappe.utils.user import get_users_with_role
 
-from insights.decorators import insights_whitelist, validate_type
+from insights.decorators import insights_whitelist
 from insights.insights.doctype.insights_team.insights_team import (
     get_teams as get_user_teams,
 )
@@ -163,7 +163,6 @@ def get_teams(search_term: str | None = None):
 
 
 @insights_whitelist(role="Insights Admin")
-@validate_type
 def create_team(team_name: str):
     team = frappe.new_doc("Insights Team")
     team.team_name = team_name
@@ -172,7 +171,6 @@ def create_team(team_name: str):
 
 
 @insights_whitelist(role="Insights Admin")
-@validate_type
 def update_team(team: dict):
     team = frappe._dict(team)
     doc = frappe.get_doc("Insights Team", team.name)
@@ -212,7 +210,6 @@ def update_team(team: dict):
 
 
 @insights_whitelist(role="Insights Admin")
-@validate_type
 def delete_team(team_name: str):
     frappe.delete_doc("Insights Team", team_name)
 
@@ -224,7 +221,6 @@ def add_insights_user(user: str):
 
 @frappe.whitelist(allow_guest=True)  # nosemgrep - an invitee follows this link before they have
 # an account, so it cannot require a session
-@validate_type
 def accept_invitation(key: str):
     if not key:
         frappe.throw("Invalid or expired key")
@@ -255,7 +251,6 @@ def accept_invitation(key: str):
 
 
 @insights_whitelist(role="Insights Admin")
-@validate_type
 def invite_users(emails: str):
     if not emails:
         return

--- a/insights/api/workbooks.py
+++ b/insights/api/workbooks.py
@@ -126,7 +126,7 @@ def _workbook_shares(names: list[str]) -> tuple[set, dict]:
 
 
 @insights_whitelist()
-def import_workbook(workbook: dict):
+def import_workbook(workbook: dict | str):
     from insights.insights.doctype.insights_workbook.insights_workbook import import_workbook
 
     return import_workbook(workbook)
@@ -191,7 +191,7 @@ def get_share_permissions(workbook_name: str):
 
 @insights_whitelist()
 def update_share_permissions(
-    workbook_name: str, user_permissions: dict, organization_access: str | None = None
+    workbook_name: str, user_permissions: list, organization_access: str | None = None
 ):
     if not frappe.has_permission("Insights Workbook", ptype="share", doc=workbook_name):
         frappe.throw(_("You do not have permission to share this workbook"), frappe.PermissionError)

--- a/insights/decorators.py
+++ b/insights/decorators.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2022, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
 
-import inspect
 import threading
 from functools import wraps
 
@@ -116,29 +115,6 @@ def debounce(wait):
     return decorator
 
 
-def validate_type(func):
-    @wraps(func)
-    def wrapper(*args, **kwargs):
-        sig = inspect.signature(func)
-        annotated_types = {
-            k: v.annotation for k, v in sig.parameters.items() if v.annotation != inspect._empty
-        }
-        bound_args = sig.bind(*args, **kwargs)
-        bound_args.apply_defaults()
-        for arg_name, arg_value in bound_args.arguments.items():
-            if (
-                arg_name in annotated_types
-                and arg_value is not None
-                and not isinstance(arg_value, annotated_types[arg_name])
-            ):
-                raise TypeError(
-                    f"{func.__name__}: Argument {arg_name} must be of type {annotated_types[arg_name]}"
-                )
-        return func(*args, **kwargs)
-
-    return wrapper
-
-
 def insights_whitelist(*args, role="Insights User", **kwargs):
     # usage:
     # @insights_whitelist()
@@ -156,12 +132,13 @@ def insights_whitelist(*args, role="Insights User", **kwargs):
     #     pass
 
     def decorator(function):
-        @wraps(function)
-        @frappe.whitelist(*args, **kwargs)
-        @check_role(role)
-        def wrapper(*args, **kwargs):
-            return function(*args, **kwargs)
-
-        return wrapper
+        # frappe.whitelist checks the argument types of the function it decorates:
+        # it reads the annotations off that function, and names its positional
+        # arguments through its __code__. A `*args` wrapper carries neither, so
+        # frappe must decorate `function` itself for the checks to run at all.
+        validated = frappe.whitelist(*args, **kwargs)(function)
+        # the second call whitelists the role check, which is what the module
+        # exports and what the request dispatcher looks up.
+        return frappe.whitelist(*args, **kwargs)(check_role(role)(validated))
 
     return decorator

--- a/insights/tests/test_endpoint_arg_types.py
+++ b/insights/tests/test_endpoint_arg_types.py
@@ -1,0 +1,110 @@
+"""The endpoints check the types their signatures already declare.
+
+`insights_whitelist` used to wrap the endpoint in a `*args, **kwargs` function
+and hand that to `frappe.whitelist`. Frappe reads the annotations off the
+function it decorates, so it read an empty `__annotations__` and checked
+nothing. It now decorates the endpoint itself.
+"""
+
+import frappe
+
+from insights.api.shared import is_public
+from insights.api.workbooks import (
+    create_folder,
+    delete_folder,
+    import_workbook,
+    move_item_to_folder,
+    rename_folder,
+    toggle_folder_expanded,
+)
+from insights.decorators import insights_whitelist
+from insights.tests.base import InsightsIntegrationTestCase
+from insights.tests.factories import (
+    DT,
+    USER_1,
+    as_user,
+    create_test_user,
+    create_test_workbook,
+    delete_users,
+)
+
+OWNER = USER_1
+
+
+class EndpointsCheckArgumentTypes(InsightsIntegrationTestCase):
+    @classmethod
+    def before_class(cls):
+        create_test_user(OWNER)
+        cls.workbook = create_test_workbook(OWNER).name
+        with as_user(OWNER):
+            cls.folder = create_folder(cls.workbook, "Arg Types Folder", "query")
+
+    @classmethod
+    def after_class(cls):
+        frappe.delete_doc(DT.WORKBOOK, cls.workbook, force=True, delete_permanently=True)
+        delete_users(OWNER)
+
+    def test_frappe_checks_an_insights_whitelisted_signature(self):
+        @insights_whitelist()
+        def takes_a_name(name: str):
+            return name
+
+        with as_user(OWNER):
+            self.assertEqual(takes_a_name(name="a name"), "a name")
+            with self.assertRaises(TypeError):
+                takes_a_name(name={"title": "not a name"})
+
+    def test_a_positional_argument_is_checked_too(self):
+        """Frappe names positional arguments through `__code__`, which a `*args`
+        wrapper does not carry. Passing one hides the check if it ever returns."""
+
+        @insights_whitelist()
+        def takes_a_name(name: str):
+            return name
+
+        with as_user(OWNER), self.assertRaises(TypeError):
+            takes_a_name({"title": "not a name"})
+
+    def test_an_unannotated_endpoint_is_refused(self):
+        """`require_type_annotated_api_methods` is on, so frappe refuses one."""
+
+        @insights_whitelist()
+        def takes_anything(name):
+            return name
+
+        with as_user(OWNER), self.assertRaises(TypeError):
+            takes_anything(name="a name")
+
+    def test_a_filter_set_is_not_a_folder_name(self):
+        """A dict reaches `frappe.get_doc` as a filter set, so it is not a name."""
+        with as_user(OWNER), self.assertRaises(TypeError):
+            move_item_to_folder("query", {"title": "Arg Types Folder"})
+
+        with as_user(OWNER), self.assertRaises(TypeError):
+            rename_folder({"title": "Arg Types Folder"}, "renamed")
+
+    def test_a_workbook_file_arrives_as_json_text_or_as_a_dict(self):
+        """`import_workbook` starts with `frappe.parse_json`, so both are names
+        for the same file. The annotation used to admit only a dict."""
+        with as_user(OWNER), self.assertRaises(KeyError):
+            import_workbook("{}")
+
+    def test_a_flag_arrives_as_true_or_as_1(self):
+        """JSON carries a flag either way, and `isinstance(1, bool)` is False."""
+        with as_user(OWNER):
+            toggle_folder_expanded(self.folder, 1)
+            self.assertEqual(frappe.db.get_value("Insights Folder", self.folder, "is_expanded"), 1)
+            toggle_folder_expanded(self.folder, False)
+            self.assertEqual(frappe.db.get_value("Insights Folder", self.folder, "is_expanded"), 0)
+
+    def test_a_delete_flag_arrives_as_1(self):
+        with as_user(OWNER):
+            folder = create_folder(self.workbook, "Arg Types Doomed Folder", "query")
+            delete_folder(folder, 1)
+            self.assertFalse(frappe.db.exists("Insights Folder", folder))
+
+    def test_a_name_from_a_json_blob_is_still_a_name(self):
+        """`run_doc_method` reads `name` out of a payload frappe checks only as
+        a whole, so a dict can reach `frappe.db.exists` as a filter set."""
+        with as_user(OWNER):
+            self.assertFalse(is_public("Insights Chart v3", {"is_public": 1}))


### PR DESCRIPTION
Split out of https://github.com/frappe/insights/pull/1326.

`insights_whitelist` handed a `*args, **kwargs` wrapper to `frappe.whitelist`.
Frappe reads annotations off the function it decorates, so it read an empty
`__annotations__` and checked nothing. Every annotation on every endpoint was
decoration, and a dict reached `frappe.db` as a filter set.

Frappe now decorates the endpoint itself. `@wraps` alone would not do: frappe
names positional arguments through `__code__`, which `wraps` does not copy, so
positional calls would still pass unchecked. A test pins that.

`validate_type` covered the gap by hand and is deleted. `is_public` keeps one
`isinstance`, because `run_doc_method` reads `name` out of a JSON blob that
frappe checks only as a whole.

I checked all 86 annotations against their callers. Two were wrong and had
never fired: `update_share_permissions` reads a list, and `import_workbook`
also takes a JSON string.