### PR TITLE
fix: rendered output, exported files and database connections

### DIFF
--- a/frontend/src2/components/Form.vue
+++ b/frontend/src2/components/Form.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, watch } from 'vue'
 
 const props = defineProps<{
 	fields: {
@@ -11,6 +11,7 @@ const props = defineProps<{
 		required?: boolean
 		defaultValue?: any
 		description?: string
+		dependsOn?: string
 	}[]
 	actions?: {
 		label: string
@@ -20,6 +21,7 @@ const props = defineProps<{
 	}[]
 }>()
 
+type Field = (typeof props.fields)[number]
 type Form = Record<string, any>
 const form = defineModel<Form>({
 	required: true,
@@ -31,9 +33,27 @@ props.fields.forEach((field) => {
 	}
 })
 
+function isVisible(field: Field) {
+	return !field.dependsOn || Boolean(form.value[field.dependsOn])
+}
+
+// A hidden field is not part of the form. Vue keeps whatever its input last
+// held, so without this it would still submit after its dependency turns off.
+watch(
+	() => props.fields.map(isVisible),
+	(visible) => {
+		props.fields.forEach((field, index) => {
+			if (!visible[index]) delete form.value[field.name]
+		})
+	},
+	{ immediate: true },
+)
+
 defineExpose({
 	hasRequiredFields: computed(() => {
-		return props.fields.every((field) => !field.required || form.value[field.name])
+		return props.fields.every(
+			(field) => !field.required || !isVisible(field) || form.value[field.name],
+		)
 	}),
 })
 </script>
@@ -41,23 +61,25 @@ defineExpose({
 <template>
 	<div class="flex w-full flex-col gap-2">
 		<div class="flex flex-col gap-4">
-			<div class="relative" v-for="field in fields" :key="field.name">
-				<FormControl
-					autocomplete="off"
-					:type="field.type"
-					:label="field.label"
-					:options="field.options"
-					:placeholder="field.placeholder"
-					:description="field.description"
-					v-model="form[field.name]"
-				/>
-				<span
-					v-if="field.required && !form[field.name]"
-					class="absolute right-0 top-0 text-xs text-ink-red-5"
-				>
-					* required
-				</span>
-			</div>
+			<template v-for="field in fields" :key="field.name">
+				<div class="relative" v-if="isVisible(field)">
+					<FormControl
+						autocomplete="off"
+						:type="field.type"
+						:label="field.label"
+						:options="field.options"
+						:placeholder="field.placeholder"
+						:description="field.description"
+						v-model="form[field.name]"
+					/>
+					<span
+						v-if="field.required && !form[field.name]"
+						class="absolute right-0 top-0 text-xs text-ink-red-5"
+					>
+						* required
+					</span>
+				</div>
+			</template>
 		</div>
 		<div class="flex w-full justify-end gap-2 pt-2">
 			<Button v-for="action in actions" :key="action.label" v-bind="action" />

--- a/frontend/src2/components/Toast.vue
+++ b/frontend/src2/components/Toast.vue
@@ -14,8 +14,7 @@
 							{{ title }}
 						</p>
 						<p v-if="message" class="text-p-sm text-ink-gray-5">
-							<span v-if="containsHTML" v-html="message"></span>
-							<span v-else>{{ message }}</span>
+							{{ message }}
 						</p>
 					</slot>
 				</div>
@@ -39,8 +38,6 @@ const props = defineProps<{
 	icon?: Component
 	iconClasses?: string
 }>()
-
-const containsHTML = computed(() => props.message?.includes('<'))
 
 const variantClasses = computed(() => {
 	if (props.variant === 'success') {

--- a/frontend/src2/data_source/ConnectClickhouseDialog.vue
+++ b/frontend/src2/data_source/ConnectClickhouseDialog.vue
@@ -66,7 +66,7 @@ const fields = [
 		placeholder: '**********',
 		required: true,
 	},
-	{ label: __('Use secure connection (SSL)?'), name: 'use_ssl', type: 'checkbox' },
+	{ label: __('Encrypt connection (SSL)'), name: 'use_ssl', type: 'checkbox' },
 ]
 
 const sources = useDataSourceStore()

--- a/frontend/src2/data_source/ConnectMariaDBDialog.vue
+++ b/frontend/src2/data_source/ConnectMariaDBDialog.vue
@@ -18,6 +18,7 @@ const database = ref<MariaDBDataSource>({
 	username: '',
 	password: '',
 	use_ssl: false,
+	ssl_ca: '',
 })
 
 const form = ref()
@@ -66,7 +67,17 @@ const fields = [
 		placeholder: '**********',
 		required: true,
 	},
-	{ label: __('Use secure connection (SSL)?'), name: 'use_ssl', type: 'checkbox' },
+	{ label: __('Encrypt connection (SSL)'), name: 'use_ssl', type: 'checkbox' },
+	{
+		label: __('CA Certificate'),
+		name: 'ssl_ca',
+		type: 'textarea',
+		placeholder: '-----BEGIN CERTIFICATE-----',
+		description: __(
+			"Optional. Certificate of the authority that signed the database server's certificate. Add one to verify the server, not just encrypt the connection.",
+		),
+		dependsOn: 'use_ssl',
+	},
 ]
 
 const sources = useDataSourceStore()

--- a/frontend/src2/data_source/ConnectPostgreSQLDialog.vue
+++ b/frontend/src2/data_source/ConnectPostgreSQLDialog.vue
@@ -19,6 +19,7 @@ const database = ref<PostgreSQLDataSource>({
 	username: '',
 	password: '',
 	use_ssl: false,
+	ssl_ca: '',
 })
 
 const form = ref()
@@ -74,7 +75,17 @@ const fields = [
 		placeholder: '**********',
 		required: true,
 	},
-	{ label: __('Use secure connection (SSL)?'), name: 'use_ssl', type: 'checkbox' },
+	{ label: __('Encrypt connection (SSL)'), name: 'use_ssl', type: 'checkbox' },
+	{
+		label: __('CA Certificate'),
+		name: 'ssl_ca',
+		type: 'textarea',
+		placeholder: '-----BEGIN CERTIFICATE-----',
+		description: __(
+			"Optional. Certificate of the authority that signed the database server's certificate. Add one to verify the server, not just encrypt the connection.",
+		),
+		dependsOn: 'use_ssl',
+	},
 ]
 
 const sources = useDataSourceStore()

--- a/frontend/src2/data_source/data_source.types.ts
+++ b/frontend/src2/data_source/data_source.types.ts
@@ -28,6 +28,7 @@ export type MariaDBDataSource = BaseDataSource & {
 	username: string
 	password: string
 	use_ssl: boolean
+	ssl_ca?: string
 }
 
 export type PostgreSQLDataSource = BaseDataSource & {
@@ -39,6 +40,7 @@ export type PostgreSQLDataSource = BaseDataSource & {
 	username: string
 	password: string
 	use_ssl: boolean
+	ssl_ca?: string
 }
 
 export type ClickHouseDataSource = BaseDataSource & {

--- a/insights/api/data_sources.py
+++ b/insights/api/data_sources.py
@@ -148,6 +148,7 @@ def make_data_source(data_source):
     ds.database_name = data_source.database_name
     ds.schema = data_source.schema
     ds.use_ssl = data_source.use_ssl
+    ds.ssl_ca = data_source.ssl_ca
     ds.connection_string = data_source.connection_string
     return ds
 

--- a/insights/api/shared.py
+++ b/insights/api/shared.py
@@ -18,7 +18,7 @@ def check_public_access(doctype, name):
 def is_public(doctype: str, name: str):
     if doctype not in public_doctypes:
         return False
-    if has_valid_preview_key():
+    if is_being_previewed(doctype, name):
         return True
     if doctype == "Insights Workbook":
         return is_public_workbook(name)
@@ -54,10 +54,40 @@ def is_public_workbook(name: str):
     )
 
 
-def has_valid_preview_key():
+def is_being_previewed(doctype: str, name: str):
+    """Whether this document is part of the dashboard a preview key was cut for.
+
+    The preview browser reads a dashboard, the charts on it and the queries
+    behind those charts — the documents the image it produces already shows.
+    The key opens those and stops there.
+    """
+    dashboard = get_previewed_dashboard()
+    if not dashboard:
+        return False
+    if doctype == "Insights Dashboard v3":
+        return name == dashboard
+    charts = frappe.get_all(
+        "Insights Dashboard Chart v3",
+        filters={"parent": dashboard, "parenttype": "Insights Dashboard v3"},
+        pluck="chart",
+    )
+    if doctype == "Insights Chart v3":
+        return name in charts
+
+    linked = frappe.get_all(
+        "Insights Chart v3",
+        filters={"name": ["in", charts]},
+        fields=["query", "data_query"],
+    )
+    return any(name in (chart.query, chart.data_query) for chart in linked)
+
+
+def get_previewed_dashboard():
     # used to generate preview images of a dashboard
-    preview_key = frappe.request.headers.get("X-Insights-Preview-Key")
-    return preview_key and frappe.cache.get_value(f"insights_preview_key:{preview_key}")
+    preview_key = frappe.request and frappe.request.headers.get("X-Insights-Preview-Key")
+    if not preview_key:
+        return None
+    return frappe.cache.get_value(f"insights_preview_key:{preview_key}")
 
 
 @validate_type

--- a/insights/insights/doctype/insights_dashboard_v3/insights_dashboard_v3.py
+++ b/insights/insights/doctype/insights_dashboard_v3/insights_dashboard_v3.py
@@ -9,6 +9,7 @@ import requests
 from frappe.model.document import Document
 from frappe.query_builder import Interval
 from frappe.query_builder.functions import Now
+from frappe.utils.html_utils import sanitize_html
 from frappe.utils.telemetry import capture
 
 from insights.utils import DocShare, File, get_app_url
@@ -39,9 +40,30 @@ class InsightsDashboardv3(Document):
     # end: auto-generated types
 
     def before_validate(self):
+        self.sanitize_text_items()
         # linked_charts is derived from items, so build it before anything
         # validates it - validate() runs before before_save()
         self.set_linked_charts()
+
+    def sanitize_text_items(self):
+        """A text item is authored as rich text and rendered as HTML.
+
+        The framework sanitizes the fields it knows carry markup, and `items`
+        is a JSON field, so nothing reaches inside it. Sanitizing on the way in
+        makes the stored text safe for every reader of the dashboard, including
+        the Guest who follows a public link.
+        """
+        items = frappe.parse_json(self.items) or []
+        sanitized = False
+        for item in items:
+            if item.get("type") != "text" or not item.get("text"):
+                continue
+            clean = sanitize_html(item["text"], always_sanitize=True)
+            sanitized = sanitized or clean != item["text"]
+            item["text"] = clean
+
+        if sanitized:
+            self.items = items
 
     def validate(self):
         from insights.permissions import check_dashboard_chart_access

--- a/insights/insights/doctype/insights_dashboard_v3/insights_dashboard_v3.py
+++ b/insights/insights/doctype/insights_dashboard_v3/insights_dashboard_v3.py
@@ -158,9 +158,15 @@ class InsightsDashboardv3(Document):
         self.generate_dashboard_preview()
 
     def generate_dashboard_preview(self):
-        with generate_preview_key() as key:
+        with generate_preview_key(self.name) as key:
             preview = get_page_preview(
-                frappe.utils.get_url(get_app_url(f"/shared/dashboard/{self.name}")),
+                # The browser runs on the server and carries a preview key, so
+                # the page it opens is the site's own, not one a request header
+                # named.
+                frappe.utils.get_url(
+                    get_app_url(f"/shared/dashboard/{self.name}"),
+                    allow_header_override=False,
+                ),
                 headers={
                     "X-Insights-Preview-Key": key,
                 },
@@ -336,10 +342,16 @@ def create_preview_file(content: bytes, dashboard_name: str):
 
 
 @contextmanager
-def generate_preview_key():
+def generate_preview_key(dashboard: str):
+    """A key that stands in for the viewer of one dashboard, for one render.
+
+    The key names its dashboard, so a leaked key reads that dashboard and the
+    charts and queries on it — the same documents the preview image itself
+    shows — and nothing else.
+    """
     try:
         key = frappe.generate_hash()
-        frappe.cache.set_value(f"insights_preview_key:{key}", True)
+        frappe.cache.set_value(f"insights_preview_key:{key}", dashboard)
         yield key
     finally:
         frappe.cache.delete_value(f"insights_preview_key:{key}")

--- a/insights/insights/doctype/insights_data_source_v3/connectors/mariadb.py
+++ b/insights/insights/doctype/insights_data_source_v3/connectors/mariadb.py
@@ -6,6 +6,8 @@ from functools import wraps
 
 import ibis
 
+from .ssl import ca_certificate_file
+
 
 def suppress_ibis_utc_warning(func):
     @wraps(func)
@@ -21,14 +23,29 @@ def suppress_ibis_utc_warning(func):
 def get_mariadb_connection(data_source):
     password = data_source.get_password(raise_exception=False)
     data_source.port = int(data_source.port or 3306)
-    return ibis.mysql.connect(
-        host=data_source.host,
-        port=data_source.port,
-        user=data_source.username,
-        password=password,
-        database=data_source.database_name,
-        charset="utf8mb4",
-        use_unicode=True,
-        ssl_mode="VERIFY_CA" if data_source.use_ssl else "DISABLED",
-        connect_timeout=5,
-    )
+
+    with ca_certificate_file(data_source) as ca_certificate:
+        if not data_source.use_ssl:
+            ssl_options = {"ssl_mode": "DISABLED"}
+        elif ca_certificate:
+            # Measured against MariaDB Connector/C, which is what mysqlclient
+            # links in an ordinary Frappe install: `ssl_mode` on its own
+            # accepts a self-signed certificate, and a CA on its own is not
+            # checked. Together they refuse one, so both are sent.
+            ssl_options = {"ssl_mode": "VERIFY_IDENTITY", "ssl": {"ca": ca_certificate}}
+        else:
+            # It read VERIFY_CA before, which this driver cannot honour with no
+            # CA to check against. Same connection, under a name that says so.
+            ssl_options = {"ssl_mode": "REQUIRED"}
+
+        return ibis.mysql.connect(
+            host=data_source.host,
+            port=data_source.port,
+            user=data_source.username,
+            password=password,
+            database=data_source.database_name,
+            charset="utf8mb4",
+            use_unicode=True,
+            connect_timeout=5,
+            **ssl_options,
+        )

--- a/insights/insights/doctype/insights_data_source_v3/connectors/postgresql.py
+++ b/insights/insights/doctype/insights_data_source_v3/connectors/postgresql.py
@@ -5,14 +5,29 @@ from urllib.parse import quote_plus
 
 import ibis
 
+from .ssl import ca_certificate_file
+
 
 def get_postgres_connection(data_source):
     if data_source.connection_string:
         conn_string = quote_plus(data_source.connection_string)
         return ibis.connect(conn_string)
-    else:
-        password = data_source.get_password(raise_exception=False)
-        data_source.port = int(data_source.port or 5432)
+
+    password = data_source.get_password(raise_exception=False)
+    data_source.port = int(data_source.port or 5432)
+
+    with ca_certificate_file(data_source) as ca_certificate:
+        ssl_options = {}
+        if data_source.use_ssl:
+            # "require" encrypts and accepts any certificate, so any host that
+            # can answer for this one passes. A CA on the data source is how an
+            # admin asks for more than that.
+            ssl_options = (
+                {"sslmode": "verify-full", "sslrootcert": ca_certificate}
+                if ca_certificate
+                else {"sslmode": "require"}
+            )
+
         return ibis.postgres.connect(
             host=data_source.host,
             port=data_source.port,
@@ -20,6 +35,6 @@ def get_postgres_connection(data_source):
             password=password,
             database=data_source.database_name,
             schema=data_source.schema,
-            sslmode="require" if data_source.use_ssl else None,
             connect_timeout=5,
+            **ssl_options,
         )

--- a/insights/insights/doctype/insights_data_source_v3/connectors/ssl.py
+++ b/insights/insights/doctype/insights_data_source_v3/connectors/ssl.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+import tempfile
+from contextlib import contextmanager
+
+
+@contextmanager
+def ca_certificate_file(data_source):
+    """Yield the path of the source's CA certificate, or None when it has none.
+
+    A CA is what turns an encrypted connection into a verified one, so
+    supplying one is how a data source asks to be verified. The drivers read a
+    path, not a string, and they read it while connecting — writing the file
+    for the length of the connect keeps it off disk the rest of the time.
+    """
+    certificate = (data_source.get("ssl_ca") or "").strip()
+    if not certificate:
+        yield None
+        return
+
+    with tempfile.NamedTemporaryFile("w", suffix=".pem") as file:
+        file.write(certificate + "\n")
+        file.flush()
+        yield file.name

--- a/insights/insights/doctype/insights_data_source_v3/data_warehouse.py
+++ b/insights/insights/doctype/insights_data_source_v3/data_warehouse.py
@@ -402,7 +402,7 @@ class WarehouseTableImporter:
 
         if is_job_enqueued(job_id) or self.import_in_progress():
             insights.create_toast(
-                f"Import for {frappe.bold(self.table.table_name)} is in progress."
+                f"Import for {self.table.table_name} is in progress."
                 "You may not see the results till the import is completed.",
                 title="Import In Progress",
                 type="info",
@@ -435,7 +435,7 @@ class WarehouseTableImporter:
                 self.update_log()
 
         insights.create_toast(
-            f"Imported {frappe.bold(self.table.table_name)} to the data store. "
+            f"Imported {self.table.table_name} to the data store. "
             "Please refresh the query to see the updated data.",
             title="Import Completed",
             type="success",
@@ -456,7 +456,7 @@ class WarehouseTableImporter:
         )
 
         insights.create_toast(
-            f"Importing {frappe.bold(self.table.table_name)} to the data store. "
+            f"Importing {self.table.table_name} to the data store. "
             "You may not see the results till the import is completed.",
             title="Import Started",
             duration=7,

--- a/insights/insights/doctype/insights_data_source_v3/ibis_utils.py
+++ b/insights/insights/doctype/insights_data_source_v3/ibis_utils.py
@@ -106,7 +106,7 @@ class IbisQueryBuilder:
                 except CircularQueryReferenceError:
                     raise
                 except BaseException as e:
-                    operation_type_title = frappe.bold(operation.type.title())
+                    operation_type_title = operation.type.title()
                     create_toast(
                         title=f"Failed to Build {self.title} Query",
                         message=f"Please check the {operation_type_title} operation at position {idx + 1}",

--- a/insights/insights/doctype/insights_data_source_v3/insights_data_source_v3.json
+++ b/insights/insights/doctype/insights_data_source_v3/insights_data_source_v3.json
@@ -120,7 +120,8 @@
    "depends_on": "eval:doc.database_type == 'PostgreSQL'",
    "fieldname": "connection_string",
    "fieldtype": "Text",
-   "label": "Connection String"
+   "label": "Connection String",
+   "permlevel": 1
   },
   {
    "depends_on": "eval:doc.database_type == 'BigQuery'",
@@ -138,7 +139,8 @@
    "depends_on": "eval:doc.database_type == 'BigQuery'",
    "fieldname": "bigquery_service_account_key",
    "fieldtype": "JSON",
-   "label": "BigQuery Service Account Key (JSON)"
+   "label": "BigQuery Service Account Key (JSON)",
+   "permlevel": 1
   },
   {
    "default": "0",
@@ -157,7 +159,8 @@
    "depends_on": "eval:doc.database_type == 'DuckDB' && doc.database_name?.includes(\"http\")",
    "fieldname": "http_headers",
    "fieldtype": "JSON",
-   "label": "HTTP Headers"
+   "label": "HTTP Headers",
+   "permlevel": 1
   },
   {
    "default": "0",
@@ -238,10 +241,11 @@
   },
   {
    "depends_on": "eval:doc.type=='REST API'",
-   "description": "Custom headers for API requests (non-sensitive data only)",
+   "description": "Custom headers for API requests. Sent with every request, so a key belongs here rather than in the URL.",
    "fieldname": "api_custom_headers",
    "fieldtype": "JSON",
-   "label": "Custom Headers"
+   "label": "Custom Headers",
+   "permlevel": 1
   }
  ],
  "index_web_pages_for_search": 1,
@@ -277,6 +281,12 @@
    "report": 1,
    "role": "Insights User",
    "share": 1
+  },
+  {
+   "permlevel": 1,
+   "read": 1,
+   "role": "Insights Admin",
+   "write": 1
   }
  ],
  "row_format": "Dynamic",

--- a/insights/insights/doctype/insights_data_source_v3/insights_data_source_v3.json
+++ b/insights/insights/doctype/insights_data_source_v3/insights_data_source_v3.json
@@ -24,6 +24,7 @@
   "host",
   "port",
   "use_ssl",
+  "ssl_ca",
   "is_ducklake",
   "is_site_db",
   "is_frappe_db",
@@ -73,9 +74,10 @@
   },
   {
    "default": "0",
+   "description": "Encrypts the connection. Add a CA certificate below to also verify the server.",
    "fieldname": "use_ssl",
    "fieldtype": "Check",
-   "label": "Use SSL"
+   "label": "Encrypt Connection (SSL)"
   },
   {
    "default": "0",
@@ -246,6 +248,13 @@
    "fieldtype": "JSON",
    "label": "Custom Headers",
    "permlevel": 1
+  },
+  {
+   "depends_on": "eval:doc.use_ssl \u0026\u0026 ['MariaDB', 'PostgreSQL'].includes(doc.database_type)",
+   "description": "Optional. PEM certificate of the authority that signed the database server's certificate. With one, Insights checks that the server is who it says it is. Without one, the connection is encrypted but the server is not checked.",
+   "fieldname": "ssl_ca",
+   "fieldtype": "Small Text",
+   "label": "CA Certificate"
   }
  ],
  "index_web_pages_for_search": 1,

--- a/insights/insights/doctype/insights_data_source_v3/insights_data_source_v3.py
+++ b/insights/insights/doctype/insights_data_source_v3/insights_data_source_v3.py
@@ -139,6 +139,7 @@ class InsightsDataSourceDocument:
                 or self.host != doc_before.host
                 or self.port != doc_before.port
                 or self.use_ssl != doc_before.use_ssl
+                or self.ssl_ca != doc_before.ssl_ca
             )
 
     def on_trash(self):
@@ -234,6 +235,7 @@ class InsightsDataSourcev3(InsightsDataSourceDocument, Document):
         password: DF.Password | None
         port: DF.Int
         schema: DF.Data | None
+        ssl_ca: DF.SmallText | None
         status: DF.Literal["Inactive", "Active"]
         title: DF.Data
         type: DF.Literal["Database", "REST API"]

--- a/insights/insights/doctype/insights_data_source_v3/insights_data_source_v3.py
+++ b/insights/insights/doctype/insights_data_source_v3/insights_data_source_v3.py
@@ -241,6 +241,28 @@ class InsightsDataSourcev3(InsightsDataSourceDocument, Document):
         username: DF.Data | None
     # end: auto-generated types
 
+    def throw_connection_error(self, error: Exception):
+        """Report a failed connection without repeating what the driver said.
+
+        A driver names the host it could not reach, the account it was refused
+        as, and — when the source is configured by connection string — the
+        password inside it. Anyone who may edit the data source has already
+        seen all three, so they read the driver's own words. Everyone else,
+        including a Guest running a published query, gets the fact and nothing
+        else. The detail stays in the Error Log either way.
+        """
+        frappe.log_error(title=f"Failed to connect to '{self.title}'")
+        may_configure = frappe.has_permission(self.doctype, "write", self)
+        frappe.throw(
+            title="Connection Error",
+            msg=(
+                f"There was an error connecting to '{self.title}' data source: {error!s}"
+                if may_configure
+                else f"Could not connect to the '{self.title}' data source."
+            ),
+            exc=DataSourceConnectionError,
+        )
+
     def _get_ibis_backend(self) -> BaseBackend:
         if self.name in insights.db_connections:
             return insights.db_connections[self.name]
@@ -248,11 +270,7 @@ class InsightsDataSourcev3(InsightsDataSourceDocument, Document):
         try:
             db: BaseBackend = self._get_db_connection()
         except Exception as e:
-            frappe.throw(
-                title="Connection Error",
-                msg=f"There was an error connecting to '{self.title}' data source: {e!s}",
-                exc=DataSourceConnectionError,
-            )
+            self.throw_connection_error(e)
 
         if self.database_type == "MariaDB":
             db.raw_sql("SET SESSION time_zone='+00:00'")

--- a/insights/insights/doctype/insights_query_v3/insights_query_v3.py
+++ b/insights/insights/doctype/insights_query_v3/insights_query_v3.py
@@ -27,7 +27,7 @@ from insights.insights.query_utils import (
     sync_query_references,
     transitive_closure,
 )
-from insights.utils import deep_convert_dict_to_dict
+from insights.utils import as_text, deep_convert_dict_to_dict
 
 
 class InsightsQueryv3(Document):
@@ -261,6 +261,7 @@ class InsightsQueryv3(Document):
             reference_name=self.name,
         )
 
+        results = as_text(results)
         if format == "excel":
             output = BytesIO()
             results.to_excel(output, index=False, engine="openpyxl")

--- a/insights/insights/doctype/insights_table_v3/insights_table_v3.js
+++ b/insights/insights/doctype/insights_table_v3/insights_table_v3.js
@@ -3,6 +3,12 @@
 
 frappe.ui.form.on("Insights Table v3", {
 	refresh: function (frm) {
+		// __() substitutes {0} into a string that frappe.confirm and the dialog
+		// title both append as HTML, so the label is escaped, not interpolated.
+		const table_label = frappe.utils.escape_html(
+			frm.doc.label || frm.doc.table,
+		);
+
 		frm.add_custom_button(__("Import to Warehouse"), function () {
 			frm.call("import_to_warehouse").then(() => {
 				frappe.msgprint(__("Import job has been queued"));
@@ -14,7 +20,7 @@ frappe.ui.form.on("Insights Table v3", {
 				frappe.confirm(
 					__(
 						"This will delete all warehouse data for <b>{0}</b> and reset the sync bookmark. Are you sure?",
-						[frm.doc.label || frm.doc.table],
+						[table_label],
 					),
 					() => {
 						frm.call("clear_warehouse_data").then(() => {
@@ -88,9 +94,7 @@ frappe.ui.form.on("Insights Table v3", {
 </div>`;
 
 				new frappe.ui.Dialog({
-					title: __("Statistics — {0}", [
-						frm.doc.label || frm.doc.table,
-					]),
+					title: __("Statistics — {0}", [table_label]),
 					fields: [{ fieldtype: "HTML", options: html }],
 					primary_action_label: __("Close"),
 					primary_action(values) {

--- a/insights/tests/test_client_escaping.py
+++ b/insights/tests/test_client_escaping.py
@@ -7,6 +7,7 @@ The app has no JavaScript test runner. A source check is a poorer test than a
 rendered one, and it is what keeps the rule from being undone by a later edit.
 """
 
+import re
 from pathlib import Path
 
 from frappe.tests import UnitTestCase
@@ -22,3 +23,20 @@ class TestErrorToastRendersText(UnitTestCase):
     def test_the_toast_renders_no_html(self):
         toast = (APP / "frontend/src2/components/Toast.vue").read_text()
         self.assertNotIn("v-html", toast)
+
+
+class TestDeskFormEscapesTheTableLabel(UnitTestCase):
+    """The table label is a value, so the desk form escapes it before it renders.
+
+    `__()` substitution is plain `{0}` replacement with no escaping, and both
+    `frappe.confirm` and a dialog title append what it produces as HTML.
+    """
+
+    def test_every_read_of_the_label_is_escaped(self):
+        form = (APP / "insights/insights/doctype/insights_table_v3/insights_table_v3.js").read_text()
+        # Collapsed, so a reformat that rewraps the call cannot fail the rule.
+        form = re.sub(r"\s+", " ", form)
+        reads = re.findall(r"(\S{0,14} )?frm\.doc\.label", form)
+        self.assertTrue(reads, "the form no longer reads the label")
+        for read in reads:
+            self.assertIn("escape_html(", read)

--- a/insights/tests/test_client_escaping.py
+++ b/insights/tests/test_client_escaping.py
@@ -1,0 +1,24 @@
+"""The client renders what the server sent, and it renders it as text.
+
+A toast message is a server error line, and a server error repeats input the
+caller never chose — a column name, a table name, a title somebody else wrote.
+
+The app has no JavaScript test runner. A source check is a poorer test than a
+rendered one, and it is what keeps the rule from being undone by a later edit.
+"""
+
+from pathlib import Path
+
+from frappe.tests import UnitTestCase
+
+import insights
+
+APP = Path(insights.__file__).parent.parent
+
+
+class TestErrorToastRendersText(UnitTestCase):
+    """The toast renders what the server sent, so it renders it as text."""
+
+    def test_the_toast_renders_no_html(self):
+        toast = (APP / "frontend/src2/components/Toast.vue").read_text()
+        self.assertNotIn("v-html", toast)

--- a/insights/tests/test_dashboard_preview.py
+++ b/insights/tests/test_dashboard_preview.py
@@ -1,0 +1,122 @@
+"""What the preview browser opens, and what its key opens in return.
+
+Generating a preview image starts a browser on the server and hands it a key,
+because the dashboard it renders is not public. Two things follow. The page it
+opens must be this site's, not one a request header named. And the key must open
+the documents that image already shows, not every document a public link could.
+"""
+
+from unittest.mock import patch
+
+import frappe
+from werkzeug.test import EnvironBuilder
+
+from insights.api.shared import is_public
+from insights.tests.base import InsightsIntegrationTestCase
+from insights.tests.factories import (
+    DT,
+    create_test_chart,
+    create_test_dashboard,
+    create_test_query,
+    create_test_workbook,
+    delete_users,
+)
+from insights.tests.permissions_utils import USER_1, create_test_users
+
+OWNER = USER_1
+ATTACKER_HOST = "attacker.example"
+
+
+class TestDashboardPreview(InsightsIntegrationTestCase):
+    @classmethod
+    def before_class(cls):
+        create_test_users()
+        cls.workbook = create_test_workbook(OWNER, title="Preview Workbook").name
+        cls.query = create_test_query(OWNER, cls.workbook, title="Preview Query").name
+        cls.chart = create_test_chart(OWNER, cls.workbook, query=cls.query, title="Preview Chart").name
+        cls.dashboard = create_test_dashboard(
+            OWNER, cls.workbook, chart=cls.chart, title="Preview Dashboard"
+        ).name
+
+        cls.other_workbook = create_test_workbook(OWNER, title="Unpreviewed Workbook").name
+        cls.other_query = create_test_query(OWNER, cls.other_workbook, title="Unpreviewed Query").name
+        cls.other_chart = create_test_chart(
+            OWNER, cls.other_workbook, query=cls.other_query, title="Unpreviewed Chart"
+        ).name
+        cls.other_dashboard = create_test_dashboard(
+            OWNER, cls.other_workbook, chart=cls.other_chart, title="Unpreviewed Dashboard"
+        ).name
+
+    @classmethod
+    def after_class(cls):
+        for workbook in (cls.workbook, cls.other_workbook):
+            frappe.delete_doc(DT.WORKBOOK, workbook, force=True, ignore_permissions=True)
+        delete_users(OWNER)
+
+    def before_test(self):
+        self.request_was = getattr(frappe.local, "request", None)
+        self.addCleanup(setattr, frappe.local, "request", self.request_was)
+        frappe.local.request = EnvironBuilder(headers={"Host": ATTACKER_HOST}).get_request()
+
+    def reads_with_key(self, key, doctype, name):
+        request_was = frappe.local.request
+        frappe.local.request = EnvironBuilder(headers={"X-Insights-Preview-Key": key}).get_request()
+        try:
+            return bool(is_public(doctype, name))
+        finally:
+            frappe.local.request = request_was
+
+    def render(self, dashboard):
+        """Run a preview and return the URL opened and the key it carried."""
+        opened = {}
+
+        def record(url, headers=None):
+            opened["url"] = url
+            opened["key"] = (headers or {})["X-Insights-Preview-Key"]
+            # what the browser sees when it comes back with the key
+            opened["public"] = {
+                (doctype, name): self.reads_with_key(opened["key"], doctype, name)
+                for doctype, name in (
+                    (DT.DASHBOARD, self.dashboard),
+                    (DT.CHART, self.chart),
+                    (DT.QUERY, self.query),
+                    (DT.DASHBOARD, self.other_dashboard),
+                    (DT.CHART, self.other_chart),
+                    (DT.QUERY, self.other_query),
+                )
+            }
+            return b"preview"
+
+        doc = frappe.get_doc(DT.DASHBOARD, dashboard)
+        with (
+            patch(
+                "insights.insights.doctype.insights_dashboard_v3.insights_dashboard_v3.get_page_preview",
+                side_effect=record,
+            ),
+            patch(
+                "insights.insights.doctype.insights_dashboard_v3.insights_dashboard_v3.create_preview_file",
+                return_value="/files/preview.jpeg",
+            ),
+        ):
+            doc.generate_dashboard_preview()
+        return opened
+
+    def test_the_browser_opens_this_site(self):
+        self.assertNotIn(ATTACKER_HOST, self.render(self.dashboard)["url"])
+
+    def test_the_key_opens_the_dashboard_being_previewed(self):
+        public = self.render(self.dashboard)["public"]
+        self.assertTrue(public[(DT.DASHBOARD, self.dashboard)])
+        self.assertTrue(public[(DT.CHART, self.chart)])
+        self.assertTrue(public[(DT.QUERY, self.query)])
+
+    def test_the_key_opens_nothing_else(self):
+        public = self.render(self.dashboard)["public"]
+        self.assertFalse(public[(DT.DASHBOARD, self.other_dashboard)])
+        self.assertFalse(public[(DT.CHART, self.other_chart)])
+        self.assertFalse(public[(DT.QUERY, self.other_query)])
+
+    def test_a_spent_key_opens_nothing(self):
+        opened = self.render(self.dashboard)
+        frappe.local.request = EnvironBuilder(headers={"X-Insights-Preview-Key": opened["key"]}).get_request()
+        self.assertFalse(is_public(DT.DASHBOARD, self.dashboard))

--- a/insights/tests/test_dashboard_text.py
+++ b/insights/tests/test_dashboard_text.py
@@ -1,0 +1,80 @@
+"""Dashboard text is rich text, so it is stored as HTML that is safe to render.
+
+A dashboard reaches readers the author never chose — anyone the workbook is
+shared with, and every Guest who follows a public link. `items` is a JSON field,
+which the framework's own sanitizer does not look inside, so the doctype does it.
+
+Text stored before this rule is left alone. Rewriting it in place would delete
+any `<iframe>` the editor put there, and there is no way back from that.
+"""
+
+import frappe
+
+from insights.tests.base import InsightsIntegrationTestCase
+from insights.tests.factories import DT, create_test_workbook, delete_users
+from insights.tests.permissions_utils import USER_1, create_test_users
+
+OWNER = USER_1
+PAYLOAD = "<img src=x onerror=alert(document.domain)>"
+# a bare double-quoted string is valid JSON, which older sanitizers passed through
+JSON_WRAPPED_PAYLOAD = f'"{PAYLOAD}"'
+
+
+class TestDashboardText(InsightsIntegrationTestCase):
+    @classmethod
+    def before_class(cls):
+        create_test_users()
+        cls.workbook = create_test_workbook(OWNER, title="Text Workbook").name
+
+    @classmethod
+    def after_class(cls):
+        frappe.delete_doc(DT.WORKBOOK, cls.workbook, force=True, ignore_permissions=True)
+        delete_users(OWNER)
+
+    def stored_text(self, text):
+        with self.as_user(OWNER):
+            dashboard = frappe.get_doc(
+                {
+                    "doctype": DT.DASHBOARD,
+                    "title": "Text Dashboard",
+                    "workbook": self.workbook,
+                    "items": [{"id": "text-1", "type": "text", "text": text}],
+                }
+            ).insert()
+        self.addCleanup(frappe.delete_doc, DT.DASHBOARD, dashboard.name, force=True)
+        return frappe.parse_json(frappe.db.get_value(DT.DASHBOARD, dashboard.name, "items"))[0]["text"]
+
+    def test_an_event_handler_does_not_survive_a_save(self):
+        self.assertNotIn("onerror", self.stored_text(PAYLOAD))
+
+    def test_wrapping_the_payload_in_quotes_does_not_smuggle_it_through(self):
+        self.assertNotIn("onerror", self.stored_text(JSON_WRAPPED_PAYLOAD))
+
+    def test_what_the_editor_writes_survives(self):
+        """Measured against the marks `RichTextKit` emits, not a guess at them."""
+        cases = {
+            "marks": ("<b>up</b>", "<b>up</b>"),
+            "link": ('<a href="/app">Details</a>', 'href="/app"'),
+            "align": ('<p style="text-align:center">c</p>', "text-align:center"),
+            "highlight": ('<mark data-color="yellow">n</mark>', '<mark data-color="yellow">'),
+            "colour": ('<span style="color:rgb(255, 0, 0)">r</span>', "color:rgb(255, 0, 0)"),
+            "table": ("<table><tbody><tr><td><p>c</p></td></tr></tbody></table>", "<td><p>c</p></td>"),
+            "task": (
+                '<ul data-type="taskList"><li data-checked="true" data-type="taskItem">'
+                "<div><p>d</p></div></li></ul>",
+                'data-type="taskItem"',
+            ),
+            "image": ('<img src="/files/a.png" alt="a">', 'src="/files/a.png"'),
+            "mention": ('<span class="mention" data-id="a@b.com">@Ada</span>', 'data-id="a@b.com"'),
+            "heading": ("<h2>Title</h2>", "<h2>Title</h2>"),
+            "code": ('<pre><code class="language-sql">select 1</code></pre>', 'class="language-sql"'),
+        }
+        stored = self.stored_text("".join(markup for markup, _ in cases.values()))
+        for name, (_, expected) in cases.items():
+            with self.subTest(name):
+                self.assertIn(expected, stored)
+
+    def test_an_embed_does_not_survive(self):
+        """The one thing the sanitizer removes outright. Pinned so it is a known
+        cost of the rule and not a surprise."""
+        self.assertNotIn("<iframe", self.stored_text('<iframe src="https://example.com"></iframe>'))

--- a/insights/tests/test_data_source_connection_errors.py
+++ b/insights/tests/test_data_source_connection_errors.py
@@ -1,0 +1,72 @@
+"""A failed connection reports the fact to everyone and the reason to few.
+
+A published query runs against a data source the caller cannot read, so the
+driver's exception travels back to whoever asked — including a Guest. That
+exception names the host, the account, and for a source configured by
+connection string the password with it.
+"""
+
+from unittest.mock import patch
+
+import frappe
+
+import insights
+from insights.insights.doctype.insights_data_source_v3.insights_data_source_v3 import (
+    DataSourceConnectionError,
+)
+from insights.tests.base import InsightsIntegrationTestCase
+from insights.tests.factories import DT, create_user, delete_users
+
+ADMIN = "connection_errors_admin@test.com"
+USER = "connection_errors_user@test.com"
+
+SECRET = "hunter2"
+DRIVER_ERROR = OSError(f'connection to "postgresql://svc:{SECRET}@warehouse.internal" failed')
+
+
+class TestConnectionErrorReporting(InsightsIntegrationTestCase):
+    @classmethod
+    def before_class(cls):
+        create_user(ADMIN, first_name="Connection", last_name="Admin", roles="Insights Admin")
+        create_user(USER, first_name="Connection", last_name="User", roles="Insights User")
+        cls.data_source = (
+            frappe.get_doc(
+                {
+                    "doctype": DT.DATA_SOURCE,
+                    "title": "Unreachable Source",
+                    "database_type": "DuckDB",
+                    "database_name": "unreachable",
+                }
+            )
+            .insert()
+            .name
+        )
+
+    @classmethod
+    def after_class(cls):
+        frappe.delete_doc(DT.DATA_SOURCE, cls.data_source, force=True, ignore_permissions=True)
+        delete_users(ADMIN, USER)
+
+    def connect_as(self, user):
+        """Return the message raised when the driver refuses the connection."""
+        # the source connected once on insert, and a live backend short-circuits
+        insights.db_connections.pop(self.data_source, None)
+        doc = frappe.get_doc(DT.DATA_SOURCE, self.data_source)
+        with self.as_user(user), patch.object(doc, "_get_db_connection", side_effect=DRIVER_ERROR):
+            with self.assertRaises(DataSourceConnectionError):
+                doc._get_ibis_backend()
+        return frappe.message_log[-1].get("message")
+
+    def test_an_insights_user_reads_no_driver_detail(self):
+        message = self.connect_as(USER)
+        self.assertNotIn(SECRET, message)
+        self.assertNotIn("warehouse.internal", message)
+        self.assertIn("Unreachable Source", message)
+
+    def test_a_guest_reads_no_driver_detail(self):
+        message = self.connect_as("Guest")
+        self.assertNotIn(SECRET, message)
+        self.assertNotIn("warehouse.internal", message)
+
+    def test_whoever_may_edit_the_source_reads_the_driver_detail(self):
+        self.assertIn(SECRET, self.connect_as(ADMIN))

--- a/insights/tests/test_data_source_credentials.py
+++ b/insights/tests/test_data_source_credentials.py
@@ -1,0 +1,96 @@
+"""A data source's credentials are readable only by the roles that configure it.
+
+Reading a data source and reading how it connects are two different grants. The
+generic document routes — `/api/resource`, `frappe.client.get`, `get_list` with a
+field list — return whatever the doctype exposes, so the boundary has to live on
+the fields themselves rather than on the endpoints that read them.
+
+`Password` fields already mask themselves. These four do not, so they carry a
+permlevel instead.
+"""
+
+import frappe
+
+from insights.tests.base import InsightsIntegrationTestCase
+from insights.tests.factories import DT, create_user, delete_users
+
+ADMIN = "credentials_admin@test.com"
+USER = "credentials_user@test.com"
+
+CREDENTIAL_FIELDS = (
+    "connection_string",
+    "bigquery_service_account_key",
+    "http_headers",
+    "api_custom_headers",
+)
+
+CONNECTION_STRING = "postgresql://svc:hunter2@warehouse.internal:5432/analytics"
+SERVICE_ACCOUNT_KEY = '{"type": "service_account", "private_key": "-----BEGIN PRIVATE KEY-----"}'
+
+
+class TestDataSourceCredentials(InsightsIntegrationTestCase):
+    @classmethod
+    def before_class(cls):
+        create_user(ADMIN, first_name="Credentials", last_name="Admin", roles="Insights Admin")
+        create_user(USER, first_name="Credentials", last_name="User", roles="Insights User")
+        cls.data_source = (
+            frappe.get_doc(
+                {
+                    "doctype": DT.DATA_SOURCE,
+                    "title": "Credentials Test Source",
+                    "database_type": "PostgreSQL",
+                    "database_name": "analytics",
+                    "connection_string": CONNECTION_STRING,
+                    "bigquery_service_account_key": SERVICE_ACCOUNT_KEY,
+                }
+            )
+            .insert()
+            .name
+        )
+
+    @classmethod
+    def after_class(cls):
+        frappe.delete_doc(DT.DATA_SOURCE, cls.data_source, force=True, ignore_permissions=True)
+        delete_users(ADMIN, USER)
+
+    def read_as(self, user):
+        with self.as_user(user):
+            doc = frappe.get_doc(DT.DATA_SOURCE, self.data_source)
+            doc.apply_fieldlevel_read_permissions()
+            return doc
+
+    def test_an_insights_user_reads_no_credential_field(self):
+        doc = self.read_as(USER)
+        for fieldname in CREDENTIAL_FIELDS:
+            self.assertIsNone(doc.get(fieldname), f"{fieldname} reached an Insights User")
+
+    def test_an_insights_admin_still_reads_the_credentials(self):
+        doc = self.read_as(ADMIN)
+        self.assertEqual(doc.connection_string, CONNECTION_STRING)
+        self.assertEqual(doc.bigquery_service_account_key, SERVICE_ACCOUNT_KEY)
+
+    def test_a_credential_field_is_dropped_from_a_list_field_list(self):
+        with self.as_user(USER):
+            rows = frappe.get_list(
+                DT.DATA_SOURCE,
+                filters={"name": self.data_source},
+                fields=["name", "connection_string"],
+            )
+        self.assertEqual(rows, [{"name": self.data_source}])
+
+    def test_the_generic_document_route_returns_no_credentials(self):
+        """`frappe.client.get` is what `/api/resource/<doctype>/<name>` calls."""
+        import frappe.client
+
+        with self.as_user(USER):
+            doc = frappe.client.get(DT.DATA_SOURCE, self.data_source)
+        for fieldname in CREDENTIAL_FIELDS:
+            self.assertIsNone(doc.get(fieldname), f"{fieldname} reached an Insights User")
+
+    def test_the_title_stays_readable(self):
+        """The permlevel bounds the credentials, not the document."""
+        with self.as_user(USER):
+            self.assertEqual(
+                frappe.get_list(DT.DATA_SOURCE, filters={"name": self.data_source}, pluck="title"),
+                ["Credentials Test Source"],
+            )

--- a/insights/tests/test_data_source_ssl.py
+++ b/insights/tests/test_data_source_ssl.py
@@ -1,0 +1,120 @@
+"""A data source can be verified, and says so by naming an authority.
+
+Encryption on its own stops a listener and lets through anyone who can answer
+for the database host. The CA certificate on the source decides which one a
+connection gets: with a CA the driver checks the server, without one it only
+encrypts. No existing source loses verification, because none had it.
+
+Measured against MariaDB Connector/C, which mysqlclient links and ibis uses, on
+a server holding a self-signed certificate:
+
+    ssl_mode="VERIFY_IDENTITY" alone   connects — no anchor, nothing to check
+    ssl={"ca": <bundle>} alone         connects — the CA is not consulted
+    both together                      refused: self-signed certificate
+
+So `VERIFY_CA` with no CA file was a label, not a check, and the driver does not
+fall back to the system trust store. The test pins both keywords together.
+"""
+
+from typing import ClassVar
+from unittest.mock import patch
+
+from frappe.tests import UnitTestCase
+
+from insights.insights.doctype.insights_data_source_v3.connectors.mariadb import (
+    get_mariadb_connection,
+)
+from insights.insights.doctype.insights_data_source_v3.connectors.postgresql import (
+    get_postgres_connection,
+)
+
+CA_CERTIFICATE = "-----BEGIN CERTIFICATE-----\nQ09SUE9SQVRFIENB\n-----END CERTIFICATE-----"
+
+
+class FakeDataSource(dict):
+    """Enough of a data source for a connector to read."""
+
+    DEFAULTS: ClassVar[dict] = {
+        "host": "db.internal",
+        "port": 5432,
+        "username": "svc",
+        "database_name": "analytics",
+        "schema": "",
+        "connection_string": None,
+        "use_ssl": 1,
+        "ssl_ca": None,
+    }
+
+    def __init__(self, **fields):
+        super().__init__(self.DEFAULTS | fields)
+
+    def __getattr__(self, name):
+        return self.get(name)
+
+    def __setattr__(self, name, value):
+        self[name] = value
+
+    def get_password(self, raise_exception=False):
+        return "secret"
+
+
+def connect_kwargs(connector, backend, **fields):
+    """The arguments the connector hands its driver.
+
+    An authority is written out only for the length of the connect, so its
+    contents are read while the driver would be reading them, under `anchor`.
+    """
+    captured = {}
+
+    def record(**kwargs):
+        captured.update(kwargs)
+        anchor = kwargs.get("sslrootcert") or (kwargs.get("ssl") or {}).get("ca")
+        if anchor:
+            with open(anchor) as certificate:
+                captured["anchor"] = certificate.read()
+
+    with patch(backend, side_effect=record):
+        connector(FakeDataSource(**fields))
+    return captured
+
+
+def postgres_kwargs(**fields):
+    return connect_kwargs(get_postgres_connection, "ibis.postgres.connect", **fields)
+
+
+def mariadb_kwargs(**fields):
+    return connect_kwargs(get_mariadb_connection, "ibis.mysql.connect", **fields)
+
+
+class TestPostgresSSL(UnitTestCase):
+    def test_ssl_without_an_authority_only_encrypts(self):
+        kwargs = postgres_kwargs()
+        self.assertEqual(kwargs["sslmode"], "require")
+        self.assertNotIn("sslrootcert", kwargs)
+
+    def test_an_authority_turns_the_same_flag_into_verification(self):
+        kwargs = postgres_kwargs(ssl_ca=CA_CERTIFICATE)
+        self.assertEqual(kwargs["sslmode"], "verify-full")
+        self.assertIn(CA_CERTIFICATE, kwargs["anchor"])
+
+    def test_no_ssl_sends_no_ssl_options(self):
+        kwargs = postgres_kwargs(use_ssl=0)
+        self.assertNotIn("sslmode", kwargs)
+        self.assertNotIn("sslrootcert", kwargs)
+
+
+class TestMariaDBSSL(UnitTestCase):
+    def test_ssl_without_an_authority_only_encrypts(self):
+        kwargs = mariadb_kwargs()
+        self.assertEqual(kwargs["ssl_mode"], "REQUIRED")
+        self.assertNotIn("ssl", kwargs)
+
+    def test_an_authority_sends_both_the_mode_and_the_certificate(self):
+        kwargs = mariadb_kwargs(ssl_ca=CA_CERTIFICATE)
+        self.assertEqual(kwargs["ssl_mode"], "VERIFY_IDENTITY")
+        self.assertIn(CA_CERTIFICATE, kwargs["anchor"])
+
+    def test_no_ssl_disables_it(self):
+        kwargs = mariadb_kwargs(use_ssl=0)
+        self.assertEqual(kwargs["ssl_mode"], "DISABLED")
+        self.assertNotIn("ssl", kwargs)

--- a/insights/tests/test_export_formulas.py
+++ b/insights/tests/test_export_formulas.py
@@ -1,0 +1,146 @@
+"""An exported cell is data, not a program.
+
+A query reads columns other people write, and a value beginning with `=` is a
+live formula once a spreadsheet opens the file. The export is the last place
+that can say the value is text.
+
+The rule costs a stray apostrophe, so it is kept narrow. `@`, `+` and `-` also
+start handles, phone numbers and text-column negatives, and a CSV is read by
+scripts as often as by people.
+"""
+
+import base64
+from io import BytesIO
+from unittest.mock import MagicMock, patch
+from zipfile import ZipFile
+
+import frappe
+import pandas as pd
+from frappe.tests import UnitTestCase
+
+from insights.tests.base import InsightsIntegrationTestCase
+from insights.tests.factories import DT, create_test_query, create_test_workbook, delete_users
+from insights.tests.permissions_utils import ADMIN, create_test_users
+from insights.utils import as_text
+
+PAYLOAD = "=cmd|'/c calc'!A1"
+
+
+def exported(**columns):
+    return as_text(pd.DataFrame(columns))
+
+
+def sheet_xml(df):
+    output = BytesIO()
+    df.to_excel(output, index=False, engine="openpyxl")
+    with ZipFile(BytesIO(output.getvalue())) as workbook:
+        return workbook.read("xl/worksheets/sheet1.xml").decode()
+
+
+class TestFormulasAreNeutralised(UnitTestCase):
+    def frame(self):
+        return pd.DataFrame({"name": [PAYLOAD, "Ada Lovelace"], "amount": [1, 2]})
+
+    def test_a_formula_is_quoted_in_csv(self):
+        self.assertIn(f"'{PAYLOAD}", as_text(self.frame()).to_csv(index=False))
+
+    def test_a_formula_does_not_become_a_formula_cell_in_excel(self):
+        self.assertNotIn("<f>", sheet_xml(as_text(self.frame())))
+
+    def test_the_triggers_that_always_open_a_formula(self):
+        triggers = ("=SUM(A1)", "\tone", "\rone", "\none")
+        self.assertEqual(
+            list(exported(value=list(triggers))["value"]),
+            [f"'{value}" for value in triggers],
+        )
+
+    def test_an_ambiguous_start_that_can_call_something_is_quoted(self):
+        payloads = (
+            "@SUM(A1)",
+            "@cmd|'/c calc'!A1",
+            "+cmd|'/c calc'!A1",
+            "-2+3+cmd|'/c calc'!A0",
+            "-SUM(A1:A2)",
+        )
+        self.assertEqual(
+            list(exported(value=list(payloads))["value"]),
+            [f"'{value}" for value in payloads],
+        )
+
+
+class TestOrdinaryDataSurvives(UnitTestCase):
+    """The cost of the rule, pinned so it cannot grow."""
+
+    def test_a_handle_keeps_its_at_sign(self):
+        self.assertEqual(exported(handle=["@acmecorp"])["handle"][0], "@acmecorp")
+
+    def test_an_email_address_is_untouched(self):
+        self.assertEqual(exported(cc=["@ada@example.com"])["cc"][0], "@ada@example.com")
+
+    def test_a_phone_number_keeps_its_plus(self):
+        self.assertEqual(exported(phone=["+91 9876543210"])["phone"][0], "+91 9876543210")
+
+    def test_a_negative_held_as_text_is_untouched(self):
+        values = ["-5", "-1234.50", "-0.5"]
+        self.assertEqual(list(exported(value=values)["value"]), values)
+
+    def test_numbers_are_untouched(self):
+        self.assertEqual(exported(amount=[-5, 12])["amount"][0], -5)
+
+    def test_headers_are_not_rewritten(self):
+        """They name the columns of whatever reads the file next."""
+        self.assertEqual(list(exported(**{PAYLOAD: ["value"]}).columns), [PAYLOAD])
+
+    def test_ordinary_text_is_untouched(self):
+        self.assertEqual(exported(name=["Ada Lovelace"])["name"][0], "Ada Lovelace")
+
+    def test_column_types_survive(self):
+        """A number written as text would import as text."""
+        frame = pd.DataFrame({"n": [1], "f": [1.5], "d": pd.to_datetime(["2024-01-01"])})
+        self.assertEqual(list(as_text(frame).dtypes), list(frame.dtypes))
+
+
+class TestEveryStringColumnReadsTheRule(UnitTestCase):
+    """ibis hands back arrow-backed strings, which are not `object` dtype."""
+
+    def test_an_arrow_backed_column_is_quoted(self):
+        frame = pd.DataFrame({"value": pd.array([PAYLOAD, "Ada"], dtype="string[pyarrow]")})
+        self.assertEqual(as_text(frame)["value"][0], f"'{PAYLOAD}")
+
+
+class TestQueryExportAppliesTheRule(InsightsIntegrationTestCase):
+    """The rule is worth nothing if the download path skips it."""
+
+    @classmethod
+    def before_class(cls):
+        create_test_users()
+        cls.workbook = create_test_workbook(ADMIN, title="Export Workbook").name
+        cls.query = create_test_query(ADMIN, cls.workbook, title="Export Query").name
+
+    @classmethod
+    def after_class(cls):
+        frappe.delete_doc(DT.WORKBOOK, cls.workbook, force=True, ignore_permissions=True)
+        delete_users(ADMIN)
+
+    def download(self, format):
+        doc = frappe.get_doc(DT.QUERY, self.query)
+        rows = pd.DataFrame({"name": [PAYLOAD]})
+        built = MagicMock()
+        built.columns = []
+        built.limit.return_value = built
+        with (
+            patch.object(type(doc), "build", return_value=built),
+            patch(
+                "insights.insights.doctype.insights_query_v3.insights_query_v3.execute_ibis_query",
+                return_value=(rows, 0),
+            ),
+        ):
+            return doc.download_results(format=format)
+
+    def test_the_csv_download_quotes_a_formula(self):
+        self.assertIn(f"'{PAYLOAD}", self.download("csv"))
+
+    def test_the_excel_download_writes_no_formula_cell(self):
+        workbook = base64.b64decode(self.download("excel"))
+        with ZipFile(BytesIO(workbook)) as sheet:
+            self.assertNotIn("<f>", sheet.read("xl/worksheets/sheet1.xml").decode())

--- a/insights/utils.py
+++ b/insights/utils.py
@@ -150,6 +150,35 @@ def anonymize_data(df, columns_to_anonymize, prefix_by_column=None):
     return df
 
 
+# A leading control character can carry a formula past an importer that trims
+# before it parses, so it counts as a trigger. `@`, `+` and `-` also start
+# ordinary data — a handle, a phone number, a text-column negative — so they are
+# quoted only when the value carries the characters a formula needs to call.
+FORMULA_TRIGGERS = ("=", "\t", "\r", "\n")
+AMBIGUOUS_STARTS = ("@", "+", "-")
+CALL_CHARACTERS = frozenset("|!()")
+
+
+def quote_formula(value):
+    """Prefix a value a spreadsheet would evaluate, so it reads as text."""
+    if not isinstance(value, str) or not value:
+        return value
+    if value.startswith(FORMULA_TRIGGERS) or (
+        value.startswith(AMBIGUOUS_STARTS) and CALL_CHARACTERS.intersection(value)
+    ):
+        return "'" + value
+    return value
+
+
+def as_text(df: pd.DataFrame) -> pd.DataFrame:
+    """Return the frame with every cell safe to write to a sheet.
+
+    Values only. A header is the alias the query's author chose, and rewriting
+    it would rename the columns of every export something downstream parses.
+    """
+    return df.map(quote_formula)
+
+
 def xls_to_df(file_path: str) -> list[pd.DataFrame]:
     file_extension = file_path.split(".")[-1].lower()
     if file_extension != "xlsx" or file_extension != "xls":


### PR DESCRIPTION
Eight independent fixes to what leaves the app — rendered output, exported files
and database transport. Each has a test that fails without it.

Reviewer notes, for what the diff does not say:

- **Credentials move behind a permlevel.** A site with Custom DocPerm rows on
  `Insights Data Source v3` will not pick the new level up from migrate.
- **"Use SSL" is relabelled, and a CA certificate is new and optional.** With a
  CA the driver verifies the server. Without one it encrypts and does not.
  Nothing loses verification, because nothing had it — the old code sent
  `VERIFY_CA` with no CA to check against. The measurement behind that is in the
  module docstring of `insights/tests/test_data_source_ssl.py`.
- **Dashboard text is sanitized on save, and existing rows are left alone.** The
  sanitizer removes an `<iframe>` outright, so rewriting stored rows in place
  had no way back. Text stored before this stays until someone edits it. The
  test pins which of the editor's own marks survive.
- **The toast renders `{{ message }}`.** Four publishers wrapped a table name in
  `frappe.bold` and now drop it, because the client would show the tags.

Needs `bench migrate` — a new field and a permission level.

Two fixes from the same pass are split out, because each changes behaviour on
existing sites: the email alert marking is #1333, and the native SQL parser swap
is still on a branch.

Replaces #1327.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
