### PR TITLE
fix: mark an email alert as one, and check its recipients at save

### DIFF
--- a/insights/insights/doctype/insights_alert/insights_alert.json
+++ b/insights/insights/doctype/insights_alert/insights_alert.json
@@ -54,10 +54,11 @@
    "options": "Email\nTelegram\nWebhook"
   },
   {
+   "depends_on": "eval: doc.channel == \"Email\"",
    "fieldname": "recipients",
-  "mandatory_depends_on": "eval: doc.channel == \"Email\"",
    "fieldtype": "Small Text",
-   "label": "Recipients"
+   "label": "Recipients",
+   "mandatory_depends_on": "eval: doc.channel == \"Email\""
   },
   {
    "fieldname": "title",

--- a/insights/insights/doctype/insights_alert/insights_alert.json
+++ b/insights/insights/doctype/insights_alert/insights_alert.json
@@ -55,6 +55,7 @@
   },
   {
    "fieldname": "recipients",
+  "mandatory_depends_on": "eval: doc.channel == \"Email\"",
    "fieldtype": "Small Text",
    "label": "Recipients"
   },

--- a/insights/insights/doctype/insights_alert/insights_alert.py
+++ b/insights/insights/doctype/insights_alert/insights_alert.py
@@ -10,7 +10,7 @@ import telegram
 from croniter import croniter
 from frappe import _
 from frappe.model.document import Document
-from frappe.utils import validate_email_address
+from frappe.utils import escape_html, get_url, validate_email_address
 from frappe.utils.data import get_datetime, get_datetime_str, now_datetime
 
 from insights.http import post_to_public_url, validate_public_url
@@ -59,6 +59,9 @@ class InsightsAlert(Document):
 
         if self.query:
             self.has_query_permission()
+
+        if self.channel == "Email":
+            self.get_recipients()
 
         if self.channel == "Webhook":
             self.validate_webhook()
@@ -151,12 +154,17 @@ class InsightsAlert(Document):
             )
 
     def send_email_alert(self, message):
-        subject = f"Insights Alert: {self.title}"
-        recievers = self.get_recipients()
+        """Mail the alert, marked as one.
+
+        The body is written by whoever owns the alert and leaves on the site's
+        default outgoing account, so the mail names the alert that produced it
+        and answers to its author rather than to the site.
+        """
         frappe.sendmail(
-            recipients=recievers,
-            subject=subject,
+            recipients=self.get_recipients(),
+            subject=f"Insights Alert: {self.title}",
             message=message,
+            reply_to=self.owner,
             now=True,
         )
 
@@ -176,7 +184,15 @@ class InsightsAlert(Document):
 
         message_html = frappe.utils.md_to_html(message_md)
         return frappe.render_template(
-            "insights/templates/alert.html", context=frappe._dict(message=message_html)
+            "insights/templates/alert.html",
+            context=frappe._dict(
+                message=message_html,
+                # The template renders without autoescaping, and the title is
+                # written by whoever owns the alert.
+                alert=escape_html(self.title),
+                author=escape_html(self.owner),
+                site_url=get_url(allow_header_override=False),
+            ),
         )
 
     def get_message_context(self):
@@ -202,10 +218,20 @@ class InsightsAlert(Document):
         )
 
     def get_recipients(self):
-        recipients = self.recipients.split(",")
+        """The addresses this alert mails.
+
+        Read at save as well as at send. `send_alerts` turns a send-time error
+        into an Error Log entry and marks the alert as run, so an address
+        checked only at send fails where nobody is looking.
+        """
+        recipients = [address.strip() for address in (self.recipients or "").split(",") if address.strip()]
+        if not recipients:
+            frappe.throw(_("An email alert needs at least one recipient"))
+
         for recipient in recipients:
             if not validate_email_address(recipient):
-                frappe.throw(f"{recipient} is not a valid email address")
+                frappe.throw(_("{0} is not a valid email address").format(recipient))
+
         return recipients
 
     @property

--- a/insights/insights/doctype/insights_alert/insights_alert.py
+++ b/insights/insights/doctype/insights_alert/insights_alert.py
@@ -153,6 +153,17 @@ class InsightsAlert(Document):
                 _("Could not deliver the alert to {0} ({1})").format(self.webhook_url, type(e).__name__)
             )
 
+    def get_author_email(self):
+        """The address a reply reaches.
+
+        `owner` is a User name, which is an address for an account created from
+        an invite and the literal "Administrator" for the admin. `sendmail`
+        refuses a reply_to it cannot parse, so an author it cannot resolve
+        leaves the mail without one rather than unsent.
+        """
+        email = frappe.db.get_value("User", self.owner, "email")
+        return email if email and validate_email_address(email) else None
+
     def send_email_alert(self, message):
         """Mail the alert, marked as one.
 
@@ -164,7 +175,7 @@ class InsightsAlert(Document):
             recipients=self.get_recipients(),
             subject=f"Insights Alert: {self.title}",
             message=message,
-            reply_to=self.owner,
+            reply_to=self.get_author_email(),
             now=True,
         )
 
@@ -183,14 +194,14 @@ class InsightsAlert(Document):
             return message_md
 
         message_html = frappe.utils.md_to_html(message_md)
-        return frappe.render_template(
+        return frappe.render_template(  # nosemgrep - the template is a file in this app
             "insights/templates/alert.html",
             context=frappe._dict(
                 message=message_html,
-                # The template renders without autoescaping, and the title is
-                # written by whoever owns the alert.
+                # The template renders without autoescaping, so a value
+                # interpolated into it is escaped here.
                 alert=escape_html(self.title),
-                author=escape_html(self.owner),
+                author=escape_html(self.get_author_email() or self.owner),
                 site_url=get_url(allow_header_override=False),
             ),
         )

--- a/insights/insights/doctype/insights_alert/test_insights_alert.py
+++ b/insights/insights/doctype/insights_alert/test_insights_alert.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 import frappe
 import requests
 from frappe.tests import IntegrationTestCase
+from frappe.utils import validate_email_address
 
 from insights.http import OutboundRequestRefused
 from insights.insights.doctype.insights_alert.insights_alert import (
@@ -200,23 +201,22 @@ class TestEmailRecipients(InsightsIntegrationTestCase):
 
 
 class TestAlertMailIsAttributable(InsightsIntegrationTestCase):
-    """The body is written by the alert's owner and leaves on the site account.
+    """The mail carries the marks that say it is an Insights alert."""
 
-    Nothing bounds who an alert may reach, so the mail carries the marks that
-    say it is an Insights alert: it names the alert and the site that produced
-    it, and replies reach its author rather than the site's outgoing account.
-    """
+    AUTHOR = "alert_author@test.com"
 
     @classmethod
     def before_class(cls):
+        create_user(cls.AUTHOR, first_name="Alert", last_name="Author", roles="Insights User")
         cls.workbook = create_test_workbook("Administrator", title="Mail Workbook").name
         cls.query = create_test_query("Administrator", cls.workbook, title="Mail Query").name
 
     @classmethod
     def after_class(cls):
         frappe.delete_doc("Insights Workbook", cls.workbook, force=True)
+        delete_users(cls.AUTHOR)
 
-    def alert(self):
+    def alert(self, owner=None):
         doc = frappe.new_doc("Insights Alert")
         doc.title = "Overdue invoices"
         doc.channel = "Email"
@@ -228,21 +228,34 @@ class TestAlertMailIsAttributable(InsightsIntegrationTestCase):
         doc.recipients = "someone@external.example.org"
         with patch.object(InsightsAlert, "evaluate_condition", return_value=True):
             doc.insert()
+        if owner:
+            doc.db_set("owner", owner, update_modified=False)
+            doc.owner = owner
         self.addCleanup(frappe.delete_doc, "Insights Alert", doc.name, force=True)
         return doc
 
     def test_a_reply_reaches_the_author(self):
-        doc = self.alert()
+        doc = self.alert(owner=self.AUTHOR)
         with patch("frappe.sendmail") as sendmail:
             doc.send_email_alert("hello")
-        self.assertEqual(sendmail.call_args.kwargs["reply_to"], doc.owner)
+        self.assertEqual(sendmail.call_args.kwargs["reply_to"], self.AUTHOR)
+
+    def test_an_admin_owned_alert_replies_to_an_address(self):
+        """`owner` is a User name, and for the admin that name is
+        "Administrator". `sendmail` refuses a reply_to it cannot parse."""
+        doc = self.alert()
+        self.assertEqual(doc.owner, "Administrator")
+        with patch("frappe.sendmail") as sendmail:
+            doc.send_email_alert("hello")
+        reply_to = sendmail.call_args.kwargs["reply_to"]
+        self.assertTrue(validate_email_address(reply_to), f"{reply_to} is not an address")
 
     def test_the_body_names_the_alert_and_the_site(self):
-        doc = self.alert()
+        doc = self.alert(owner=self.AUTHOR)
         body = doc.evaluate_message({"rows": [], "count": 0, "datatable": ""})
         self.assertIn("Overdue invoices", body)
         self.assertIn(frappe.utils.get_url(allow_header_override=False), body)
-        self.assertIn(doc.owner, body)
+        self.assertIn(self.AUTHOR, body)
 
     def test_a_title_written_as_markup_stays_text_in_the_footer(self):
         doc = self.alert()

--- a/insights/insights/doctype/insights_alert/test_insights_alert.py
+++ b/insights/insights/doctype/insights_alert/test_insights_alert.py
@@ -14,7 +14,12 @@ from insights.insights.doctype.insights_alert.insights_alert import (
     send_alerts,
 )
 from insights.tests.base import InsightsIntegrationTestCase
-from insights.tests.factories import create_test_query, create_test_workbook
+from insights.tests.factories import (
+    create_test_query,
+    create_test_workbook,
+    create_user,
+    delete_users,
+)
 
 POST = "insights.insights.doctype.insights_alert.insights_alert.post_to_public_url"
 
@@ -141,3 +146,107 @@ class TestFailedAlertIsNotRetriedEveryTick(InsightsIntegrationTestCase):
             send_alerts()
 
         self.assertIsNotNone(frappe.db.get_value("Insights Alert", self.alert.name, "last_execution"))
+
+
+class TestEmailRecipients(InsightsIntegrationTestCase):
+    """A recipient list is read at save, and the mail it produces says who sent it."""
+
+    MEMBER = "alert_recipient@test.com"
+    OUTSIDER = "someone@external.example.org"
+
+    @classmethod
+    def before_class(cls):
+        create_user(cls.MEMBER, first_name="Alert", last_name="Recipient", roles="Insights User")
+        cls.workbook = create_test_workbook("Administrator", title="Alert Workbook").name
+        cls.query = create_test_query("Administrator", cls.workbook, title="Alert Query").name
+
+    @classmethod
+    def after_class(cls):
+        frappe.delete_doc("Insights Workbook", cls.workbook, force=True)
+        delete_users(cls.MEMBER)
+
+    def email_alert(self, recipients):
+        doc = frappe.new_doc("Insights Alert")
+        doc.title = "Overdue invoices"
+        doc.channel = "Email"
+        doc.query = self.query
+        doc.frequency = "Daily"
+        doc.custom_condition = 1
+        doc.condition = "q['status'] == 'Open'"
+        doc.message = "{{ rows }}"
+        doc.recipients = recipients
+        return doc
+
+    def test_an_address_outside_this_site_is_a_recipient(self):
+        """A report goes to a client or an accountant as often as to a colleague."""
+        self.assertEqual(self.email_alert(self.OUTSIDER).get_recipients(), [self.OUTSIDER])
+
+    def test_a_list_is_split_and_trimmed(self):
+        alert = self.email_alert(f" {self.MEMBER} , {self.OUTSIDER} ")
+        self.assertEqual(alert.get_recipients(), [self.MEMBER, self.OUTSIDER])
+
+    def test_an_empty_list_is_refused(self):
+        with self.assertRaises(frappe.ValidationError):
+            self.email_alert("  ,  ").get_recipients()
+
+    def test_saving_reads_the_list(self):
+        """`send_alerts` logs a send-time error and marks the alert as run, so a
+        list checked only at send fails where nobody is looking."""
+        with (
+            patch.object(InsightsAlert, "evaluate_condition", return_value=True),
+            self.assertRaisesRegex(frappe.ValidationError, "not a valid email address"),
+        ):
+            self.email_alert("not-an-address").insert()
+
+
+class TestAlertMailIsAttributable(InsightsIntegrationTestCase):
+    """The body is written by the alert's owner and leaves on the site account.
+
+    Nothing bounds who an alert may reach, so the mail carries the marks that
+    say it is an Insights alert: it names the alert and the site that produced
+    it, and replies reach its author rather than the site's outgoing account.
+    """
+
+    @classmethod
+    def before_class(cls):
+        cls.workbook = create_test_workbook("Administrator", title="Mail Workbook").name
+        cls.query = create_test_query("Administrator", cls.workbook, title="Mail Query").name
+
+    @classmethod
+    def after_class(cls):
+        frappe.delete_doc("Insights Workbook", cls.workbook, force=True)
+
+    def alert(self):
+        doc = frappe.new_doc("Insights Alert")
+        doc.title = "Overdue invoices"
+        doc.channel = "Email"
+        doc.query = self.query
+        doc.frequency = "Daily"
+        doc.custom_condition = 1
+        doc.condition = "q['status'] == 'Open'"
+        doc.message = "hello"
+        doc.recipients = "someone@external.example.org"
+        with patch.object(InsightsAlert, "evaluate_condition", return_value=True):
+            doc.insert()
+        self.addCleanup(frappe.delete_doc, "Insights Alert", doc.name, force=True)
+        return doc
+
+    def test_a_reply_reaches_the_author(self):
+        doc = self.alert()
+        with patch("frappe.sendmail") as sendmail:
+            doc.send_email_alert("hello")
+        self.assertEqual(sendmail.call_args.kwargs["reply_to"], doc.owner)
+
+    def test_the_body_names_the_alert_and_the_site(self):
+        doc = self.alert()
+        body = doc.evaluate_message({"rows": [], "count": 0, "datatable": ""})
+        self.assertIn("Overdue invoices", body)
+        self.assertIn(frappe.utils.get_url(allow_header_override=False), body)
+        self.assertIn(doc.owner, body)
+
+    def test_a_title_written_as_markup_stays_text_in_the_footer(self):
+        doc = self.alert()
+        doc.title = "<script>x</script>"
+        body = doc.evaluate_message({"rows": [], "count": 0, "datatable": ""})
+        self.assertNotIn("<script>x</script>", body)
+        self.assertIn("&lt;script&gt;", body)

--- a/insights/templates/alert.html
+++ b/insights/templates/alert.html
@@ -43,6 +43,19 @@
       position: relative;
       padding: 0.25rem 0rem;
     }
+    .alert-footer {
+      margin-top: 2rem;
+      padding-top: 0.75rem;
+      border-top: 1px solid #e2e2e2;
+      color: #7c7c7c;
+      font-size: 0.75rem;
+    }
   </style>
-  <div class="alert-container">{{ message }}</div>
+  <div class="alert-container">
+    {{ message }}
+    <div class="alert-footer">
+      Sent by the "{{ alert }}" alert on
+      <a href="{{ site_url }}">{{ site_url }}</a>, set up by {{ author }}.
+    </div>
+  </div>
 </div>


### PR DESCRIPTION
An alert's message embeds the rows its query returned, and the mail leaves on
the site's default outgoing account. The mail now names the alert that produced
it and the site it came from, and replies go to the alert's author rather than
to the site.

Recipients are read at save as well as at send. `send_alerts` turns a send-time
error into an Error Log entry and marks the alert as run, so an address checked
only at send fails where nobody is looking.

Bounding recipients to site accounts was tried and reversed. It broke alerts
that report to a client or an accountant, and the webhook channel on the same
doctype already posts the same rows to any public URL.

Split out of #1327.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
