### PR TITLE
fix(iris): stop an unrelated comment from cancelling a review

### DIFF
--- a/.github/workflows/iris-review.yml
+++ b/.github/workflows/iris-review.yml
@@ -23,12 +23,6 @@ permissions:
   # For the reaction on the /iris review comment.
   issues: write
 
-concurrency:
-  # Split by trigger: every PR comment queues an `issue_comment` run, and it
-  # must not cancel a review already running for the PR itself.
-  group: iris-${{ github.event_name == 'pull_request' && 'auto' || 'manual' }}-${{ github.event.pull_request.number || github.event.issue.number || inputs.pr_number }}
-  cancel-in-progress: true
-
 jobs:
   review:
     # Kill switch: set repo variable IRIS_ENABLED=true to enable.
@@ -57,6 +51,12 @@ jobs:
           )
         )
       )
+    # On the job, not the workflow. Every comment on a PR starts a run, and a
+    # workflow-level group makes that run cancel a review in flight — even when
+    # its own job is skipped. A skipped job never enters a job-level group.
+    concurrency:
+      group: iris-${{ github.event_name == 'pull_request' && 'auto' || 'manual' }}-${{ github.event.pull_request.number || github.event.issue.number || inputs.pr_number }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:


### PR DESCRIPTION
A `/iris review` died whenever another bot commented on the same PR.

The concurrency group sat at workflow level, so **every** comment on the PR entered it — including comments iris ignores. Those runs skip their job, but they claim the group first, and `cancel-in-progress` then kills the review already running.

Evidence: review run [32937897311](https://github.com/frappe/insights/actions/runs/32937897311) was cancelled at 06:58:18. Run [32940501136](https://github.com/frappe/insights/actions/runs/32940501136), an `issue_comment` on the same PR that skipped, was created at 06:58:18.

The group moves to the job. A job skipped by `if` never enters it, so only real reviews contend. Two `/iris review` comments on one PR still collapse to the latest, which is the original intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)