### PR TITLE
fix: let the client reach get_site_info, and land an invitee in Insights

### DIFF
--- a/insights/api/__init__.py
+++ b/insights/api/__init__.py
@@ -27,11 +27,11 @@ def get_app_version():
     return frappe.get_attr("insights" + ".__version__")
 
 
-@frappe.whitelist(allow_guest=True, methods=["GET"])
+@frappe.whitelist(allow_guest=True)  # nosemgrep - the payload is the site's currency and
+# country, which a public dashboard already prints
 def get_site_info():
     """Settings of the site, not of whoever reads it. A guest opening a public
-    dashboard needs them to print an amount the way the workbook does, and they
-    say nothing a public dashboard does not already show."""
+    dashboard needs them to print an amount the way the workbook does."""
     return {
         "country": frappe.db.get_single_value("System Settings", "country"),
         **get_currency_info(),

--- a/insights/api/user.py
+++ b/insights/api/user.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2022, Frappe Technologies Pvt. Ltd. and contributors
 # For license information, please see license.txt
 
+from urllib.parse import quote
+
 import frappe
 from frappe.utils import split_emails, validate_email_address
 from frappe.utils.user import get_users_with_role
@@ -240,8 +242,9 @@ def accept_invitation(key: str):
 
     if not account_was_created:
         # the address already had an account. The invitation grants it access to
-        # Insights; signing in is for the account holder to do.
-        frappe.local.response["location"] = "/login"
+        # Insights; signing in is for the account holder to do. The login page
+        # carries them the rest of the way, so the link still ends in Insights.
+        frappe.local.response["location"] = f"/login?redirect-to={quote(get_app_url())}"
         return
 
     # a new account has no password yet, so the invitation link is how the

--- a/insights/insights/doctype/insights_user_invitation/test_insights_user_invitation.py
+++ b/insights/insights/doctype/insights_user_invitation/test_insights_user_invitation.py
@@ -8,11 +8,13 @@ only the account it just created.
 """
 
 from unittest.mock import patch
+from urllib.parse import quote
 
 import frappe
 from frappe.tests import IntegrationTestCase
 
 from insights.api.user import accept_invitation
+from insights.utils import get_app_url
 
 
 def make_invitation(email):
@@ -95,7 +97,8 @@ class TestInvitationDoesNotAuthenticate(IntegrationTestCase):
         response = self.redeem(invitation)
 
         self.assertEqual(self.logged_in_as, [])
-        self.assertEqual(response.location, "/login")
+        # the link still ends in Insights: the login page carries them there
+        self.assertEqual(response.location, f"/login?redirect-to={quote(get_app_url())}")
         # the invitation still did its job
         self.assertEqual(
             frappe.db.get_value("Insights User Invitation", invitation.name, "status"), "Accepted"

--- a/insights/tests/test_currency_info.py
+++ b/insights/tests/test_currency_info.py
@@ -64,3 +64,9 @@ class TestCurrencyInfo(InsightsIntegrationTestCase):
         currency, hidden = _defaults("USD")
         with as_user("Guest"), currency, hidden:
             self.assertEqual(get_site_info()["currency_symbol"], "$")
+
+    def test_the_client_can_reach_it_the_way_it_calls_it(self):
+        # frappe-ui's `call` posts. An endpoint declared GET-only answers it
+        # with a 403, and session.initialize() awaits this one - so restricting
+        # the method here blanks the app rather than hardening anything.
+        self.assertIn("POST", frappe.allowed_http_methods_for_whitelisted_func[get_site_info])


### PR DESCRIPTION
`get_site_info` is declared GET-only. frappe-ui's `call` posts, so frappe
answers 403. `session.initialize()` awaits that call and the router guard awaits
`initialize()`, so the rejection aborts every navigation — a blank app for a
member, and the 403 handler in `router.ts` bounces a guest off a public
dashboard to the login page. The endpoint reads and writes nothing, so the
method restriction had nothing to weigh against that.

Sending an invitee who already has an account to the login page rather than
signing them in is right: the invitation grants access, it does not prove who
holds the key. But `/login` carried no `redirect-to`, so they landed nowhere.
Most ERPNext invitees already have an account, so that is the common path.

Nothing tells them why they are on a login page. Frappe's login banners are
driven by `login.js` on form errors, so saying anything there needs a hook on
frappe first.