### PR TITLE
fix: drop the add_roles patch, which cannot run

### DIFF
--- a/insights/patches.txt
+++ b/insights/patches.txt
@@ -4,7 +4,6 @@ insights.patches.convert_duration_to_float
 execute:frappe.delete_doc('DocType', 'Query Filter', ignore_missing=True)
 execute:frappe.delete_doc('DocType', 'Query Field', ignore_missing=True)
 execute:frappe.delete_doc('DocType', 'Query Chart', ignore_missing=True)
-insights.patches.add_roles
 insights.insights.doctype.insights_query.patches.make_query_variable_value_password_field
 insights.patches.name_workbooks_as_strings
 insights.patches.normalize_workbook #6

--- a/insights/patches/add_roles.py
+++ b/insights/patches/add_roles.py
@@ -1,8 +1,0 @@
-# Copyright (c) 2022, Frappe Technologies Pvt. Ltd. and contributors
-# For license information, please see license.txt
-
-from insights.setup import create_roles
-
-
-def execute():
-    create_roles()


### PR DESCRIPTION
`insights/patches/add_roles.py` imports `create_roles` from `insights.setup`. That function was removed in 2c1c68d1a (Jan 2023), when role creation moved to `insights/fixtures/role.json`. The patch has been unrunnable ever since.

It only shows up on a site whose patch log does not already contain it — an existing site skips it and never notices. Such a site fails `bench migrate` with:

```
ImportError: cannot import name 'create_roles' from 'insights.setup'
```

Nothing replaces it: `sync_fixtures` creates both roles on install and on every migrate. Verified on a site where the patch was skipped — `Insights Admin` and `Insights User` are both present.

`develop` no longer carries the patch; it was removed incidentally with the v2 code.