### PR TITLE
fix(script query): report failures, and rerun when the inputs change

### DIFF
--- a/frontend/src2/charts/chart.ts
+++ b/frontend/src2/charts/chart.ts
@@ -454,9 +454,7 @@ function makeChart(name: string) {
 	function getDependentQueryColumns() {
 		return getDependentQueries().map((q) => {
 			const query = useQuery(q)
-			if (!query.result.executedSQL) {
-				query.execute()
-			}
+			query.ensureResult()
 			return {
 				group: query.doc.title,
 				items: query.result.columnOptions.map((c) => {

--- a/frontend/src2/charts/components/ChartQuerySelector.vue
+++ b/frontend/src2/charts/components/ChartQuerySelector.vue
@@ -15,10 +15,7 @@ wheneverChanges(
 	query,
 	() => {
 		if (query.value) {
-			const q = useQuery(query.value)
-			if (q && !q.result.executedSQL) {
-				q.execute()
-			}
+			useQuery(query.value)?.ensureResult()
 		}
 	},
 	{ immediate: true },

--- a/frontend/src2/charts/components/ChartRenderer.vue
+++ b/frontend/src2/charts/components/ChartRenderer.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { Button } from 'frappe-ui'
-import { Maximize, XIcon, RefreshCcw } from 'lucide-vue-next'
+import { Maximize, XIcon, RefreshCcw, TriangleAlert } from 'lucide-vue-next'
 import { computed, ref } from 'vue'
 import { titleCase } from '../../helpers'
 import { FIELDTYPES } from '../../helpers/constants.ts'
@@ -227,6 +227,12 @@ const showExpandedChartDialog = ref(false)
 						<RefreshCcw class="h-4 w-4 text-ink-gray-6" stroke-width="1.5" />
 					</template>
 				</Button>
+			</template>
+			<template v-else-if="chart.dataQuery.executionError">
+				<TriangleAlert class="h-5 w-5 text-ink-red-4" stroke-width="1.5" />
+				<p class="mt-1.5 px-4 text-center font-mono text-xs leading-5 text-ink-red-4">
+					{{ chart.dataQuery.executionError }}
+				</p>
 			</template>
 			<template v-else>
 				<ChartSectionEmptySvg></ChartSectionEmptySvg>

--- a/frontend/src2/charts/components/ChartRenderer.vue
+++ b/frontend/src2/charts/components/ChartRenderer.vue
@@ -202,7 +202,7 @@ const showExpandedChartDialog = ref(false)
 			:onClick="onChartElementClick"
 		/>
 		<NumberChart
-			v-else-if="!loading && chart_type == 'Number'"
+			v-else-if="!loading && chart_type == 'Number' && !chart.dataQuery.executionError"
 			:config="config as NumberChartConfig"
 			:result="result"
 			@drill-down="onNumberChartDrillDown"
@@ -230,7 +230,10 @@ const showExpandedChartDialog = ref(false)
 			</template>
 			<template v-else-if="chart.dataQuery.executionError">
 				<TriangleAlert class="h-5 w-5 text-ink-red-4" stroke-width="1.5" />
-				<p class="mt-1.5 px-4 text-center font-mono text-xs leading-5 text-ink-red-4">
+				<p
+					class="mt-1.5 line-clamp-3 px-4 text-center font-mono text-xs leading-5 text-ink-red-4"
+					:title="chart.dataQuery.executionError"
+				>
 					{{ chart.dataQuery.executionError }}
 				</p>
 			</template>

--- a/frontend/src2/query/components/NativeQueryEditor.vue
+++ b/frontend/src2/query/components/NativeQueryEditor.vue
@@ -17,7 +17,7 @@ import DataSourceSelector from './source_selector/DataSourceSelector.vue'
 
 const query = inject<Query>('query')!
 query.autoExecute = false
-query.execute()
+query.ensureResult()
 
 const operation = query.getSQLOperation()
 const data_source = ref(operation ? operation.data_source : '')

--- a/frontend/src2/query/components/QueryDataTable.vue
+++ b/frontend/src2/query/components/QueryDataTable.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { Button } from 'frappe-ui'
-import { Bell, Download } from 'lucide-vue-next'
+import { Bell, Download, TriangleAlert } from 'lucide-vue-next'
 import { computed, ref, watch } from 'vue'
 import DrillDown from '../../charts/components/DrillDown.vue'
 import DataTable from '../../components/DataTable.vue'
@@ -167,6 +167,15 @@ function onFilterChange(filters: Record<string, string>) {
 </script>
 
 <template>
+	<div
+		v-if="props.query.executionError"
+		class="flex flex-shrink-0 items-start gap-2 border-b bg-surface-gray-1 px-3 py-2"
+	>
+		<TriangleAlert class="mt-0.5 h-4 w-4 flex-shrink-0 text-ink-red-4" stroke-width="1.5" />
+		<div class="font-mono text-xs leading-5 text-ink-red-4">
+			{{ props.query.executionError }}
+		</div>
+	</div>
 	<DataTable
 		v-if="props.query.isloaded || props.query.islocal"
 		:loading="props.query.executing && !isFiltering"

--- a/frontend/src2/query/components/ScriptQueryEditor.vue
+++ b/frontend/src2/query/components/ScriptQueryEditor.vue
@@ -13,7 +13,7 @@ import QueryDataTable from './QueryDataTable.vue'
 
 const query = inject<Query>('query')!
 query.autoExecute = false
-query.execute()
+query.ensureResult()
 
 const operation = query.getCodeOperation()
 const code = ref(operation ? operation.code : '')

--- a/frontend/src2/query/components/ScriptQueryEditor.vue
+++ b/frontend/src2/query/components/ScriptQueryEditor.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { useTimeAgo } from '@vueuse/core'
-import { Braces, Bug, MoreHorizontal, Play } from 'lucide-vue-next'
+import { BookOpen, Braces, Bug, MoreHorizontal, Play } from 'lucide-vue-next'
 import { inject, ref } from 'vue'
 import Code from '../../components/Code.vue'
 import ContentEditable from '../../components/ContentEditable.vue'
@@ -19,7 +19,7 @@ const operation = query.getCodeOperation()
 const code = ref(operation ? operation.code : '')
 wheneverChanges(code, () => query.setCode({ code: code.value }), { debounce: 500 })
 
-const placeholder_script = `# Write your script here`
+const placeholder_script = `# assign rows to \`results\`, e.g. results = frappe.db.get_all("ToDo", fields=["name", "status"])`
 
 const showLogs = ref(false)
 const scriptLogs = ref<string[]>([])
@@ -122,6 +122,15 @@ function handleSaveVariables(variables: any[]) {
 							label: __('Logs'),
 							icon: Bug,
 							onClick: () => (showLogs = !showLogs),
+						},
+						{
+							label: __('Docs'),
+							icon: BookOpen,
+							onClick: () =>
+								window.open(
+									'https://docs.frappe.io/insights/querying/script-query-api',
+									'_blank',
+								),
 						},
 					]"
 				/>

--- a/frontend/src2/query/components/ScriptQueryEditor.vue
+++ b/frontend/src2/query/components/ScriptQueryEditor.vue
@@ -38,6 +38,12 @@ wheneverChanges(
 	},
 )
 
+const DOCS_URL = 'https://docs.frappe.io/insights/querying/script-query-api'
+
+function openDocs() {
+	window.open(DOCS_URL, '_blank', 'noopener')
+}
+
 const showVariablesDialog = ref(false)
 const localVariables = ref<any[]>([])
 
@@ -126,11 +132,7 @@ function handleSaveVariables(variables: any[]) {
 						{
 							label: __('Docs'),
 							icon: BookOpen,
-							onClick: () =>
-								window.open(
-									'https://docs.frappe.io/insights/querying/script-query-api',
-									'_blank',
-								),
+							onClick: openDocs,
 						},
 					]"
 				/>

--- a/frontend/src2/query/components/ScriptQueryEditor.vue
+++ b/frontend/src2/query/components/ScriptQueryEditor.vue
@@ -29,6 +29,15 @@ attachRealtimeListener('insights_script_log', (data: any) => {
 	}
 })
 
+// the error is written to the logs, so a failed run has to open the panel
+// holding it - otherwise the script author is told nothing at all
+wheneverChanges(
+	() => query.executionError,
+	(error) => {
+		if (error) showLogs.value = true
+	},
+)
+
 const showVariablesDialog = ref(false)
 const localVariables = ref<any[]>([])
 

--- a/frontend/src2/query/query.ts
+++ b/frontend/src2/query/query.ts
@@ -207,20 +207,20 @@ export function makeQuery(name: string) {
 		isServerBusy.value = false
 		executionError.value = ''
 
-		if (!query.doc.operations.length) {
-			result.value = { ...EMPTY_RESULT }
-			return
-		}
-
 		if (page_size) {
 			pageSize.value = page_size
 			currentPage.value = 1
 		}
 
-		// recorded before the request, not after it: the failure path mutates
-		// `result`, and a caller watching that would re-ask before a later write
-		// landed. These args have been asked for, whatever the run returns.
+		// recorded before the request, and above the empty-operations return,
+		// because both paths replace `result`. A caller watching it would
+		// otherwise re-ask before the write landed, or never see one at all.
 		lastExecutionArgs = currentExecutionArgs()
+
+		if (!query.doc.operations.length) {
+			result.value = { ...EMPTY_RESULT }
+			return
+		}
 
 		executing.value = true
 		const token = ++currentExecutionToken

--- a/frontend/src2/query/query.ts
+++ b/frontend/src2/query/query.ts
@@ -175,6 +175,30 @@ export function makeQuery(name: string) {
 	// set by whoever owns the layout, so a screenful of queries runs in a sensible
 	// order once they outnumber the free slots
 	const executionPriority = ref<number>()
+
+	function currentExecutionArgs() {
+		return {
+			operations: currentOperations.value,
+			adhoc_filters: adhocFilters.value,
+			page: currentPage.value,
+			page_size: pageSize.value,
+		}
+	}
+
+	// "make sure this query has a result" - for the reactive and mount-time
+	// callers that re-ask on every render. execute() is "run it now", so it
+	// must not be the one that answers them: a caller that reads the result and
+	// re-asks when it is empty would loop for as long as the run keeps failing.
+	async function ensureResult() {
+		if (!query.islocal) {
+			await waitUntil(() => query.isloaded)
+		}
+		if (lastExecutionArgs && isEqual(lastExecutionArgs, currentExecutionArgs())) {
+			return
+		}
+		return execute()
+	}
+
 	async function execute(force: boolean = false, page_size?: number) {
 		if (!query.islocal) {
 			await waitUntil(() => query.isloaded)
@@ -193,18 +217,10 @@ export function makeQuery(name: string) {
 			currentPage.value = 1
 		}
 
-		if (
-			!force &&
-			lastExecutionArgs &&
-			isEqual(lastExecutionArgs, {
-				operations: currentOperations.value,
-				adhoc_filters: adhocFilters.value,
-				page: currentPage.value,
-				page_size: pageSize.value,
-			})
-		) {
-			return Promise.resolve()
-		}
+		// recorded before the request, not after it: the failure path mutates
+		// `result`, and a caller watching that would re-ask before a later write
+		// landed. These args have been asked for, whatever the run returns.
+		lastExecutionArgs = currentExecutionArgs()
 
 		executing.value = true
 		const token = ++currentExecutionToken
@@ -250,15 +266,6 @@ export function makeQuery(name: string) {
 			})
 			result.value.timeTaken = response.time_taken
 			result.value.lastExecutedAt = new Date()
-
-			// only a run that produced a result may be memoised - memoising a
-			// failure turns the retry into a no-op that clears the error
-			lastExecutionArgs = {
-				operations: currentOperations.value,
-				adhoc_filters: adhocFilters.value,
-				page: currentPage.value,
-				page_size: pageSize.value,
-			}
 		})
 			.catch((err) => {
 				if (isStale()) return
@@ -1120,7 +1127,7 @@ export function makeQuery(name: string) {
 	}
 
 	const autoExecute = ref(false)
-	watchToggle(currentOperations, () => autoExecute.value && execute(), {
+	watchToggle(currentOperations, () => autoExecute.value && ensureResult(), {
 		immediate: true,
 		deep: true,
 		toggleCondition: () => autoExecute.value,
@@ -1171,6 +1178,7 @@ export function makeQuery(name: string) {
 		goToPage,
 
 		execute,
+		ensureResult,
 		fetchResultCount,
 		refreshStoredTables,
 		importingTables,

--- a/frontend/src2/query/query.ts
+++ b/frontend/src2/query/query.ts
@@ -6,6 +6,7 @@ import { computed, reactive, ref, toRefs, unref, watch } from 'vue'
 import {
 	copy,
 	copyToClipboard,
+	getErrorMessage,
 	getUniqueId,
 	safeJSONParse,
 	waitUntil,
@@ -155,6 +156,7 @@ export function makeQuery(name: string) {
 	})
 
 	const isServerBusy = ref(false)
+	const executionError = ref('')
 	const result = ref({ ...EMPTY_RESULT })
 	const executing = ref(false)
 	const downloading = ref(false)
@@ -179,6 +181,7 @@ export function makeQuery(name: string) {
 		}
 
 		isServerBusy.value = false
+		executionError.value = ''
 
 		if (!query.doc.operations.length) {
 			result.value = { ...EMPTY_RESULT }
@@ -251,6 +254,9 @@ export function makeQuery(name: string) {
 			.catch((err) => {
 				if (isStale()) return
 				isServerBusy.value = isServerBusyError(err)
+				// a failed run used to clear the table and say nothing, so the
+				// message has to survive the reset for the editor to show it
+				executionError.value = isServerBusy.value ? '' : getErrorMessage(err)
 				result.value = { ...EMPTY_RESULT }
 			})
 			.finally(() => {
@@ -1154,6 +1160,7 @@ export function makeQuery(name: string) {
 		executing,
 		fetchingCount,
 		isServerBusy,
+		executionError,
 		result,
 
 		currentPage,

--- a/frontend/src2/query/query.ts
+++ b/frontend/src2/query/query.ts
@@ -250,6 +250,15 @@ export function makeQuery(name: string) {
 			})
 			result.value.timeTaken = response.time_taken
 			result.value.lastExecutedAt = new Date()
+
+			// only a run that produced a result may be memoised - memoising a
+			// failure turns the retry into a no-op that clears the error
+			lastExecutionArgs = {
+				operations: currentOperations.value,
+				adhoc_filters: adhocFilters.value,
+				page: currentPage.value,
+				page_size: pageSize.value,
+			}
 		})
 			.catch((err) => {
 				if (isStale()) return
@@ -262,12 +271,6 @@ export function makeQuery(name: string) {
 			.finally(() => {
 				if (isStale()) return
 				executing.value = false
-				lastExecutionArgs = {
-					operations: currentOperations.value,
-					adhoc_filters: adhocFilters.value,
-					page: currentPage.value,
-					page_size: pageSize.value,
-				}
 			})
 	}
 

--- a/insights/insights/doctype/insights_data_source_v3/ibis_utils.py
+++ b/insights/insights/doctype/insights_data_source_v3/ibis_utils.py
@@ -1144,14 +1144,19 @@ class SafePandasDataFrame(pd.DataFrame):
 
 
 def publish_script_logs():
-    frappe.publish_realtime(
-        event="insights_script_log",
-        user=frappe.session.user,
-        message={
-            "user": frappe.session.user,
-            "logs": frappe.debug_log,
-        },
-    )
+    # this runs in a finally, so an unguarded raise here would replace the
+    # script's own exception - or its result - with a realtime transport error
+    try:
+        frappe.publish_realtime(
+            event="insights_script_log",
+            user=frappe.session.user,
+            message={
+                "user": frappe.session.user,
+                "logs": frappe.debug_log,
+            },
+        )
+    except Exception:
+        frappe.log_error("Failed to publish script query logs")
 
 
 def format_script_error(code: str) -> str:

--- a/insights/insights/doctype/insights_data_source_v3/ibis_utils.py
+++ b/insights/insights/doctype/insights_data_source_v3/ibis_utils.py
@@ -1,6 +1,8 @@
 import ast
 import re
+import sys
 import time
+import traceback
 from contextlib import contextmanager
 from datetime import date
 from functools import cached_property
@@ -12,7 +14,7 @@ import pandas as pd
 import sqlglot as sg
 import sqlparse
 from frappe.utils.data import flt
-from frappe.utils.safe_exec import safe_eval, safe_exec
+from frappe.utils.safe_exec import SERVER_SCRIPT_FILE_PREFIX, safe_eval, safe_exec
 from ibis import _
 from ibis.expr.datatypes import DataType
 from ibis.expr.operations.relations import DatabaseTable, Field
@@ -57,6 +59,7 @@ class IbisQueryBuilder:
         self.title = self.doc.title or self.doc.name
         self.active_operation_idx = active_operation_idx
         self.use_live_connection = bool(doc.use_live_connection)
+        self.force = False
         self.operations = doc.operations
         self.set_operations()
 
@@ -185,7 +188,7 @@ class IbisQueryBuilder:
         if table_args.type == "query":
             self.check_query_reference(table_args.query_name)
             q = frappe.get_doc("Insights Query v3", table_args.query_name)
-            _table = q.build(use_live_connection=self.use_live_connection)
+            _table = q.build(use_live_connection=self.use_live_connection, force=self.force)
 
         if _table is None:
             frappe.throw("Table or Query not found")
@@ -770,15 +773,15 @@ class IbisQueryBuilder:
         code = code_args.code
 
         adhoc_filters = frappe.as_json(getattr(frappe.local, "insights_adhoc_filters", {}))
-        digest = make_digest(code + adhoc_filters)
+        variables = resolve_variables(getattr(self.doc, "variables", None))
+        # a variable value changes the output as surely as the code does, so it
+        # belongs in the key that decides whether the script runs again
+        digest = make_digest(code, adhoc_filters, frappe.as_json(variables))
 
-        cached_results = get_cached_results(digest)
+        cached_results = None if self.force else get_cached_results(digest)
         if cached_results is not None:
             results = cached_results
         else:
-            variables = None
-            if hasattr(self.doc, "variables") and self.doc.variables:
-                variables = self.doc.variables
             results = get_code_results(code, variables=variables)
             cache_results(digest, results, cache_expiry=60 * 5)
 
@@ -1140,40 +1143,7 @@ class SafePandasDataFrame(pd.DataFrame):
         raise NotImplementedError("to_json is not supported in this context")
 
 
-def get_code_results(code: str, variables=None):
-    pandas = frappe._dict()
-    pandas.DataFrame = SafePandasDataFrame
-    pandas.read_csv = pd.read_csv
-    pandas.json_normalize = pd.json_normalize
-
-    results = []
-    frappe.local.debug_log = []
-
-    variable_context = {}
-    if variables:
-        from frappe.utils.password import get_decrypted_password
-
-        for var in variables:
-            if hasattr(var, "variable_name") and hasattr(var, "variable_value"):
-                variable_context[var.variable_name] = get_decrypted_password(
-                    var.doctype, var.name, "variable_value"
-                )
-            elif isinstance(var, dict):
-                variable_context[var.get("variable_name")] = var.get("variable_value")
-
-    _locals = {"results": results, **variable_context}
-    with ensure_rollback():
-        _, _locals = safe_exec(
-            code,
-            _globals={"pandas": pandas},
-            _locals=_locals,
-            restrict_commit_rollback=True,
-        )
-
-    results = _locals["results"]
-    if results is None or len(results) == 0:
-        results = [{"error": "No results"}]
-
+def publish_script_logs():
     frappe.publish_realtime(
         event="insights_script_log",
         user=frappe.session.user,
@@ -1183,18 +1153,99 @@ def get_code_results(code: str, variables=None):
         },
     )
 
-    if not isinstance(results, pd.DataFrame):
-        try:
-            if isinstance(results, list) and results and isinstance(results[0], list | tuple):
-                results = pd.DataFrame.from_records(results)
-            else:
-                results = pd.DataFrame(results)
-        except (ValueError, TypeError):
-            import json as _json
 
-            results = pd.DataFrame(_json.loads(frappe.as_json(results)))
+def format_script_error(code: str) -> str:
+    exc_type, exc_value, tb = sys.exc_info()
+    name = getattr(exc_type, "__name__", "Error")
+    message = f"{name}: {exc_value}"
 
-    return results
+    lineno = get_script_line_number(exc_value, tb)
+    if not lineno:
+        return message
+
+    lines = code.splitlines()
+    source = lines[lineno - 1].strip() if 0 < lineno <= len(lines) else ""
+    return f"Line {lineno}: {source}\n{message}" if source else f"Line {lineno}\n{message}"
+
+
+def get_script_line_number(exc_value, tb) -> int | None:
+    # RestrictedPython compiles the script under this filename, so its frames are
+    # the only ones with a line number that means anything to the author
+    for frame in traceback.extract_tb(tb):
+        if frame.filename.startswith(SERVER_SCRIPT_FILE_PREFIX):
+            return frame.lineno
+
+    # a syntax error never runs, so it has no frame of its own
+    if isinstance(exc_value, SyntaxError):
+        return exc_value.lineno
+
+    return None
+
+
+def resolve_variables(variables) -> dict:
+    if not variables:
+        return {}
+
+    from frappe.utils.password import get_decrypted_password
+
+    resolved = {}
+    for var in variables:
+        if isinstance(var, dict):
+            resolved[var.get("variable_name")] = var.get("variable_value")
+        else:
+            resolved[var.variable_name] = get_decrypted_password(var.doctype, var.name, "variable_value")
+    return resolved
+
+
+def get_code_results(code: str, variables: dict | None = None):
+    pandas = frappe._dict()
+    pandas.DataFrame = SafePandasDataFrame
+    pandas.read_csv = pd.read_csv
+    pandas.json_normalize = pd.json_normalize
+
+    results = []
+    frappe.local.debug_log = []
+
+    _locals = {"results": results, **(variables or {})}
+    start = time.monotonic()
+    try:
+        with ensure_rollback():
+            _, _locals = safe_exec(
+                code,
+                _globals={"pandas": pandas},
+                _locals=_locals,
+                restrict_commit_rollback=True,
+            )
+    except Exception:
+        # the panel is the only place the script author sees anything, so the
+        # error has to land there before it travels on as a request failure
+        frappe.log(format_script_error(code))
+        raise
+    else:
+        results = to_dataframe(_locals["results"])
+        frappe.log(f"{len(results)} rows in {flt(time.monotonic() - start, 3)}s")
+        return results
+    finally:
+        publish_script_logs()
+
+
+def to_dataframe(results) -> pd.DataFrame:
+    if isinstance(results, pd.DataFrame):
+        return results
+
+    if results is None or len(results) == 0:
+        # DuckDB cannot hold a table with no columns, so an empty run still needs
+        # one. A named column beats the fake row of errors this used to return.
+        return pd.DataFrame({"results": pd.Series([], dtype="string")})
+
+    try:
+        if isinstance(results, list) and isinstance(results[0], list | tuple):
+            return pd.DataFrame.from_records(results)
+        return pd.DataFrame(results)
+    except (ValueError, TypeError):
+        import json as _json
+
+        return pd.DataFrame(_json.loads(frappe.as_json(results)))
 
 
 @contextmanager

--- a/insights/insights/doctype/insights_query_v3/insights_query_v3.py
+++ b/insights/insights/doctype/insights_query_v3/insights_query_v3.py
@@ -159,11 +159,13 @@ class InsightsQueryv3(Document):
                 tables.append(ref)
         return tables
 
-    def build(self, active_operation_idx=None, use_live_connection=None):
+    def build(self, active_operation_idx=None, use_live_connection=None, force=False):
         builder = IbisQueryBuilder(self, active_operation_idx)
         builder.use_live_connection = (
             use_live_connection if use_live_connection is not None else self.use_live_connection
         )
+        # a script runs while the query is built, so only the builder can skip its cache
+        builder.force = force
         ibis_query = builder.build()
 
         if ibis_query is None:
@@ -181,7 +183,7 @@ class InsightsQueryv3(Document):
         page_size: int = 100,
     ):
         with set_adhoc_filters(adhoc_filters):
-            ibis_query = self.build(active_operation_idx)
+            ibis_query = self.build(active_operation_idx, force=force)
 
         results, time_taken = execute_ibis_query(
             ibis_query,

--- a/insights/tests/test_script_query_logs.py
+++ b/insights/tests/test_script_query_logs.py
@@ -1,0 +1,138 @@
+from unittest.mock import patch
+
+import frappe
+
+from insights.insights.doctype.insights_data_source_v3.ibis_utils import (
+    IbisQueryBuilder,
+    get_code_results,
+    resolve_variables,
+)
+from insights.tests.base import InsightsIntegrationTestCase
+
+
+class TestScriptQueryLogs(InsightsIntegrationTestCase):
+    def run_code(self, code):
+        published = []
+        with patch(
+            "frappe.publish_realtime",
+            side_effect=lambda **kwargs: published.append(kwargs),
+        ):
+            try:
+                results = get_code_results(code, variables={"token": "secret"})
+            except Exception as e:
+                return published, e
+            return published, results
+
+    def get_logs(self, published):
+        events = [p for p in published if p.get("event") == "insights_script_log"]
+        self.assertEqual(len(events), 1)
+        return events[0]["message"]["logs"]
+
+    def test_error_is_logged_with_line_number(self):
+        code = "\n".join(
+            [
+                "rows = [{'a': 1}]",
+                "results = rows[5]",
+            ]
+        )
+        published, error = self.run_code(code)
+
+        self.assertIsInstance(error, IndexError)
+        logs = self.get_logs(published)
+        self.assertIn("Line 2: results = rows[5]", logs[-1])
+        self.assertIn("IndexError", logs[-1])
+
+    def test_syntax_error_is_logged(self):
+        published, error = self.run_code("results = [")
+
+        self.assertIsInstance(error, SyntaxError)
+        logs = self.get_logs(published)
+        self.assertIn("SyntaxError", logs[-1])
+
+    def test_prints_before_the_error_survive(self):
+        code = "\n".join(
+            [
+                "print('step one')",
+                "raise ValueError('boom')",
+            ]
+        )
+        published, error = self.run_code(code)
+
+        self.assertIsInstance(error, ValueError)
+        logs = self.get_logs(published)
+        self.assertEqual(logs[0], "step one")
+        self.assertIn("ValueError: boom", logs[-1])
+
+    def test_logs_are_published_on_success(self):
+        code = "\n".join(
+            [
+                "print('done')",
+                "results = [{'a': 1}]",
+            ]
+        )
+        published, results = self.run_code(code)
+
+        self.assertEqual(len(results), 1)
+        logs = self.get_logs(published)
+        self.assertEqual(logs[0], "done")
+        self.assertRegex(logs[-1], r"^1 rows in [\d.]+s$")
+
+    def test_empty_results_give_an_empty_table(self):
+        published, results = self.run_code("results = []")
+
+        self.assertEqual(list(results.columns), ["results"])
+        self.assertEqual(len(results), 0)
+        self.assertRegex(self.get_logs(published)[-1], r"^0 rows in [\d.]+s$")
+
+    def test_variables_reach_the_script(self):
+        _published, results = self.run_code("results = [{'a': token}]")
+
+        self.assertEqual(results["a"].tolist(), ["secret"])
+
+    def test_resolve_variables_reads_plain_dicts(self):
+        variables = [{"variable_name": "token", "variable_value": "secret"}]
+        self.assertEqual(resolve_variables(variables), {"token": "secret"})
+        self.assertEqual(resolve_variables(None), {})
+
+
+class TestScriptQueryCache(InsightsIntegrationTestCase):
+    def build(self, code, variables=None, force=False):
+        doc = frappe._dict(
+            name="Script Query Cache Test",
+            title="Script Query Cache Test",
+            use_live_connection=0,
+            variables=variables,
+            operations=frappe.as_json([{"type": "code", "code": code}]),
+        )
+        builder = IbisQueryBuilder(doc)
+        builder.force = force
+        return builder.build()
+
+    def test_empty_results_build_a_queryable_table(self):
+        result = self.build("results = []").execute()
+
+        self.assertEqual(list(result.columns), ["results"])
+        self.assertEqual(len(result), 0)
+
+    def test_a_variable_change_reruns_the_script(self):
+        code = "results = [{'a': token}]"
+
+        first = self.build(code, variables=[{"variable_name": "token", "variable_value": "one"}])
+        self.assertEqual(first.execute()["a"].tolist(), ["one"])
+
+        second = self.build(code, variables=[{"variable_name": "token", "variable_value": "two"}])
+        self.assertEqual(second.execute()["a"].tolist(), ["two"])
+
+    def test_force_skips_the_code_cache(self):
+        code = "import_count = frappe.db.count('DocType')\nresults = [{'a': import_count}]"
+
+        with patch(
+            "insights.insights.doctype.insights_data_source_v3.ibis_utils.get_code_results",
+            wraps=get_code_results,
+        ) as spy:
+            self.build(code).execute()
+            self.build(code).execute()
+            self.assertEqual(spy.call_count, 1)
+
+            self.build(code, force=True).execute()
+            self.assertEqual(spy.call_count, 2)


### PR DESCRIPTION
A script query that raised published nothing to the Logs panel, so the error and every `print` before it were lost. The publish now runs in a `finally`, with the failing line logged ahead of it. The editor opens the panel on a failed run, and the data table shows the message — the execute path used to swallow the error and clear the table.

Force Run and a changed variable both left the five minute code cache in place, so the script did not run again. The builder carries `force`, and the cache key carries the variables.

An empty result was returned as one row of `{"error": "No results"}`, which reached the column pickers as a column named `error`. It is an empty table now, with the row count in the logs.

`execute()` served two callers: "run it now" from the Run button, and "make sure a result exists" from the reactive and mount-time callers. One memo could not satisfy both — memoising a failed run made Run a no-op that cleared the error, and not memoising it let a caller that re-asks whenever the result is empty re-send a failing query for as long as its screen stayed open. `ensureResult()` is the idempotent ask and holds the memo. `execute()` always runs, so `force` now means the server cache only.

A chart whose query failed showed "Pick a chart type". It shows the error, like the table already did.

The ⋯ menu links the [script query API docs](https://docs.frappe.io/insights/querying/script-query-api), and the editor placeholder shows the `results` contract.
