### PR TITLE
feat: carry a SQL column expression through an ibis query

### DIFF
--- a/frontend/src2/query/helpers.ts
+++ b/frontend/src2/query/helpers.ts
@@ -63,6 +63,8 @@ import {
 	SourceArgs,
 	SQL,
 	SQLArgs,
+	SQLColumn,
+	SQLColumnArgs,
 	Summarize,
 	SummarizeArgs,
 	Table,
@@ -351,6 +353,20 @@ export const query_operation_types = {
 			return `${op.new_name}`
 		},
 	},
+	// Not in `AddOperationPopover`, so nobody can author one: the v2 migrator is
+	// the only writer. The label says so, because a raw SQL step is a thing to
+	// rewrite as a formula, not a thing to copy.
+	sql_column: {
+		label: __('SQL column (from v2)'),
+		type: 'sql_column',
+		icon: ScrollText,
+		color: 'gray',
+		class: 'text-ink-gray-5 bg-surface-gray-2',
+		init: (args: SQLColumnArgs): SQLColumn => ({ type: 'sql_column', ...args }),
+		getDescription: (op: SQLColumn) => {
+			return `${op.new_name}`
+		},
+	},
 	summarize: {
 		label: __('Summarize'),
 		type: 'summarize',
@@ -445,6 +461,7 @@ export const cast = query_operation_types.cast.init
 export const filter = query_operation_types.filter.init
 export const filter_group = query_operation_types.filter_group.init
 export const mutate = query_operation_types.mutate.init
+export const sql_column = query_operation_types.sql_column.init
 export const summarize = query_operation_types.summarize.init
 export const pivot_wider = query_operation_types.pivot_wider.init
 export const order_by = query_operation_types.order_by.init

--- a/frontend/src2/query/helpers.ts
+++ b/frontend/src2/query/helpers.ts
@@ -353,9 +353,7 @@ export const query_operation_types = {
 			return `${op.new_name}`
 		},
 	},
-	// Not in `AddOperationPopover`, so nobody can author one: the v2 migrator is
-	// the only writer. The label says so, because a raw SQL step is a thing to
-	// rewrite as a formula, not a thing to copy.
+	// No popover entry: the v2 migrator is the only writer.
 	sql_column: {
 		label: __('SQL column (from v2)'),
 		type: 'sql_column',

--- a/frontend/src2/types/query.types.ts
+++ b/frontend/src2/types/query.types.ts
@@ -134,6 +134,14 @@ export type Union = { type: 'union' } & UnionArgs
 export type MutateArgs = { new_name: string; data_type: ColumnDataType; expression: Expression }
 export type Mutate = { type: 'mutate' } & MutateArgs
 
+export type SQLColumnArgs = {
+	new_name: string
+	data_type: ColumnDataType
+	fragment: string
+	data_source?: string
+}
+export type SQLColumn = { type: 'sql_column' } & SQLColumnArgs
+
 export type SummarizeArgs = { measures: Measure[]; dimensions: Dimension[] }
 export type Summarize = { type: 'summarize' } & SummarizeArgs
 
@@ -181,6 +189,7 @@ export type Operation =
 	| Join
 	| Union
 	| Mutate
+	| SQLColumn
 	| Summarize
 	| OrderBy
 	| Limit

--- a/frontend/src2/types/query.types.ts
+++ b/frontend/src2/types/query.types.ts
@@ -137,8 +137,8 @@ export type Mutate = { type: 'mutate' } & MutateArgs
 export type SQLColumnArgs = {
 	new_name: string
 	data_type: ColumnDataType
-	fragment: string
-	data_source?: string
+	raw_sql: string
+	data_source: string
 }
 export type SQLColumn = { type: 'sql_column' } & SQLColumnArgs
 

--- a/insights/insights/doctype/insights_data_source_v3/ibis_utils.py
+++ b/insights/insights/doctype/insights_data_source_v3/ibis_utils.py
@@ -538,30 +538,36 @@ class IbisQueryBuilder:
         return self.query.mutate(**{new_name: new_column})
 
     def apply_sql_column(self, sql_column_args):
-        """Add one column from a raw SQL fragment.
+        """Add one column from a raw SQL expression.
 
         Written by the v2 migrator, for the constructs v2 expressed in SQL and v3
         has no expression for. ibis has no scalar-level SQL escape - only
         `Table.sql()` - so this is a relation-level operation and not a `mutate`.
+
+        `new_name` is not sanitized, unlike `apply_mutate` and `apply_rename`: a
+        migrated column keeps the name the v2 charts and filters already use.
         """
         new_name = sql_column_args.new_name
-        fragment = sql_column_args.fragment
+        raw_sql = sql_column_args.raw_sql
 
-        if not new_name or not fragment or not fragment.strip():
+        if not new_name or not raw_sql or not raw_sql.strip():
             frappe.throw(
                 frappe._("A SQL column needs both a name and an expression"),
             )
 
-        source_dialect = None
-        if sql_column_args.data_source:
-            ds = frappe.get_doc("Insights Data Source v3", sql_column_args.data_source)
-            source_dialect = ds.get_sqlglot_dialect()
+        if not sql_column_args.data_source:
+            frappe.throw(
+                frappe._("A SQL column needs the data source its expression is written for"),
+            )
 
-        fragment = sqlparse.format(sql=fragment, strip_comments=True).strip()
-        self._validate_sql_column_fragment(fragment, source_dialect)
+        data_source = frappe.get_doc("Insights Data Source v3", sql_column_args.data_source)
+        source_dialect = data_source.get_sqlglot_dialect()
+
+        raw_sql = sqlparse.format(sql=raw_sql, strip_comments=True).strip()
 
         alias = sg.to_identifier(new_name, quoted=True).sql(dialect=source_dialect)
-        statement = f"SELECT *, {fragment} AS {alias} FROM {SQL_COLUMN_RELATION}"
+        statement = f"SELECT *, {raw_sql} AS {alias} FROM {SQL_COLUMN_RELATION}"
+        self._validate_sql_column_statement(statement, source_dialect)
 
         if not self.use_live_connection:
             statement = self._transpile_sql_to_duckdb(statement, source_dialect)
@@ -573,35 +579,30 @@ class IbisQueryBuilder:
         dtype = self.get_ibis_dtype(sql_column_args.data_type) if sql_column_args.data_type else None
         return query.cast({new_name: dtype}) if dtype else query
 
-    def _validate_sql_column_fragment(self, fragment: str, dialect: str | None) -> None:
-        """A fragment is one column expression. Anything that could open a statement is rejected."""
-        if ";" in fragment:
-            frappe.throw(
-                frappe._("A SQL column expression cannot contain multiple statements"),
-            )
+    def _validate_sql_column_statement(self, statement: str, dialect: str) -> None:
+        """Validate the assembled statement, not the expression alone.
 
-        if re.match(r"^(select|with|exec|execute)\b", fragment, flags=re.IGNORECASE):
-            frappe.throw(
-                frappe._("A SQL column expression cannot be a statement"),
-            )
-
+        An expression parsed on its own is read as the start of a statement, so
+        `replace(...)` reads as MySQL's REPLACE. In place, it is one projection.
+        """
         try:
-            parsed = sg.parse(fragment, dialect=dialect)
+            parsed = sg.parse(statement, dialect=dialect)
         except Exception as e:
             frappe.throw(
                 frappe._("Failed to parse the SQL column expression: {0}").format(e),
             )
 
-        if len(parsed) != 1 or parsed[0] is None:
+        if len(parsed) != 1 or not isinstance(parsed[0], sg.exp.Select):
             frappe.throw(
                 frappe._("A SQL column expression must be a single expression"),
             )
 
-        expression = parsed[0]
-        is_statement = isinstance(expression, sg.exp.DDL | sg.exp.DML | sg.exp.Command)
-        if is_statement or expression.find(sg.exp.Select):
+        select = parsed[0]
+        tables = {table.name for table in select.find_all(sg.exp.Table)}
+        nested = len(list(select.find_all(sg.exp.Select))) > 1 or select.find(sg.exp.Subquery)
+        if nested or tables != {SQL_COLUMN_RELATION}:
             frappe.throw(
-                frappe._("A SQL column expression must be a single expression"),
+                frappe._("A SQL column expression cannot read another table"),
             )
 
     def apply_summary(self, summarize_args):

--- a/insights/insights/doctype/insights_data_source_v3/ibis_utils.py
+++ b/insights/insights/doctype/insights_data_source_v3/ibis_utils.py
@@ -47,6 +47,10 @@ except ImportError:
         return decorator
 
 
+# the relation a `sql_column` fragment selects from, standing for the pipeline so far
+SQL_COLUMN_RELATION = "_insights_sql_column"
+
+
 class CircularQueryReferenceError(frappe.ValidationError):
     """Raised when a circular query reference is detected during query building."""
 
@@ -140,6 +144,8 @@ class IbisQueryBuilder:
             return self.apply_remove(operation)
         elif operation.type == "mutate":
             return self.apply_mutate(operation)
+        elif operation.type == "sql_column":
+            return self.apply_sql_column(operation)
         elif operation.type == "cast":
             return self.apply_cast(operation)
         elif operation.type == "summarize":
@@ -156,6 +162,11 @@ class IbisQueryBuilder:
             return self.apply_sql(operation)
         elif operation.type == "code":
             return self.apply_code(operation)
+
+        # Not `return self.query`: skipping an operation nobody recognises answers
+        # with a table that is missing a column, a filter or a join, and nothing
+        # says so. A query written by a newer client has to fail, not quietly
+        # return different numbers.
         return self.query
 
     @cached_property
@@ -523,6 +534,73 @@ class IbisQueryBuilder:
         if dtype:
             new_column = new_column.cast(dtype)
         return self.query.mutate(**{new_name: new_column})
+
+    def apply_sql_column(self, sql_column_args):
+        """Add one column from a raw SQL fragment.
+
+        Written by the v2 migrator, for the constructs v2 expressed in SQL and v3
+        has no expression for. ibis has no scalar-level SQL escape - only
+        `Table.sql()` - so this is a relation-level operation and not a `mutate`.
+        """
+        new_name = sql_column_args.new_name
+        fragment = sql_column_args.fragment
+
+        if not new_name or not fragment or not fragment.strip():
+            frappe.throw(
+                frappe._("A SQL column needs both a name and an expression"),
+            )
+
+        source_dialect = None
+        if sql_column_args.data_source:
+            ds = frappe.get_doc("Insights Data Source v3", sql_column_args.data_source)
+            source_dialect = ds.get_sqlglot_dialect()
+
+        fragment = sqlparse.format(sql=fragment, strip_comments=True).strip()
+        self._validate_sql_column_fragment(fragment, source_dialect)
+
+        alias = sg.to_identifier(new_name, quoted=True).sql(dialect=source_dialect)
+        statement = f"SELECT *, {fragment} AS {alias} FROM {SQL_COLUMN_RELATION}"
+
+        if not self.use_live_connection:
+            statement = self._transpile_sql_to_duckdb(statement, source_dialect)
+
+        # the alias is what puts the current pipeline in scope: without it ibis emits
+        # `FROM <original table>` and any column derived mid-pipeline is unresolvable
+        query = self.query.alias(SQL_COLUMN_RELATION).sql(statement)
+
+        dtype = self.get_ibis_dtype(sql_column_args.data_type) if sql_column_args.data_type else None
+        return query.cast({new_name: dtype}) if dtype else query
+
+    def _validate_sql_column_fragment(self, fragment: str, dialect: str | None) -> None:
+        """A fragment is one column expression. Anything that could open a statement is rejected."""
+        if ";" in fragment:
+            frappe.throw(
+                frappe._("A SQL column expression cannot contain multiple statements"),
+            )
+
+        if re.match(r"^(select|with|exec|execute)\b", fragment, flags=re.IGNORECASE):
+            frappe.throw(
+                frappe._("A SQL column expression cannot be a statement"),
+            )
+
+        try:
+            parsed = sg.parse(fragment, dialect=dialect)
+        except Exception as e:
+            frappe.throw(
+                frappe._("Failed to parse the SQL column expression: {0}").format(e),
+            )
+
+        if len(parsed) != 1 or parsed[0] is None:
+            frappe.throw(
+                frappe._("A SQL column expression must be a single expression"),
+            )
+
+        expression = parsed[0]
+        is_statement = isinstance(expression, sg.exp.DDL | sg.exp.DML | sg.exp.Command)
+        if is_statement or expression.find(sg.exp.Select):
+            frappe.throw(
+                frappe._("A SQL column expression must be a single expression"),
+            )
 
     def apply_summary(self, summarize_args):
         aggregates = [self.translate_measure(measure) for measure in summarize_args.measures]

--- a/insights/insights/doctype/insights_data_source_v3/ibis_utils.py
+++ b/insights/insights/doctype/insights_data_source_v3/ibis_utils.py
@@ -167,7 +167,9 @@ class IbisQueryBuilder:
         # with a table that is missing a column, a filter or a join, and nothing
         # says so. A query written by a newer client has to fail, not quietly
         # return different numbers.
-        return self.query
+        frappe.throw(
+            frappe._("This query uses an operation this version does not know: {0}").format(operation.type),
+        )
 
     @cached_property
     def saved_references(self):

--- a/insights/tests/test_sql_column.py
+++ b/insights/tests/test_sql_column.py
@@ -1,14 +1,15 @@
 import frappe
+import sqlglot as sg
 
 from insights.insights.doctype.insights_data_source_v3.ibis_utils import IbisQueryBuilder
 from insights.tests.base import InsightsIntegrationTestCase
 
 SOURCE_CODE = """
 results = [
-    {"idx": 1, "team": "alpha", "amount": 10, "note": None},
-    {"idx": 2, "team": "alpha", "amount": 20, "note": None},
-    {"idx": 3, "team": "beta", "amount": 30, "note": None},
-    {"idx": 4, "team": "beta", "amount": 40, "note": None},
+    {"idx": 1, "team": "alpha", "amount": 10, "note": "a;b"},
+    {"idx": 2, "team": "alpha", "amount": 20, "note": "a;b"},
+    {"idx": 3, "team": "beta", "amount": 30, "note": "a;b"},
+    {"idx": 4, "team": "beta", "amount": 40, "note": "a;b"},
 ]
 """
 
@@ -28,64 +29,69 @@ class TestSQLColumnOperation(InsightsIntegrationTestCase):
     def source_operations(self):
         return [{"type": "code", "code": SOURCE_CODE}]
 
+    def sql_column(self, new_name, raw_sql, **kwargs):
+        return {
+            "type": "sql_column",
+            "new_name": new_name,
+            "raw_sql": raw_sql,
+            "data_type": "Integer",
+            "data_source": "Site DB",
+            **kwargs,
+        }
+
+    def order_by(self, column_name):
+        return {
+            "type": "order_by",
+            "column": {"type": "column", "column_name": column_name},
+            "direction": "asc",
+        }
+
     def execute(self, operations):
         return self.build_query([*self.source_operations(), *operations]).execute()
 
-    def test_plain_fragment_adds_a_column(self):
+    def test_plain_expression_adds_a_column(self):
         result = self.execute(
             [
-                {
-                    "type": "sql_column",
-                    "new_name": "double_amount",
-                    "fragment": "amount * 2",
-                    "data_type": "Integer",
-                },
-                {
-                    "type": "order_by",
-                    "column": {"type": "column", "column_name": "idx"},
-                    "direction": "asc",
-                },
+                self.sql_column("double_amount", "amount * 2"),
+                self.order_by("idx"),
             ]
         )
 
         self.assertEqual(list(result["double_amount"]), [20, 40, 60, 80])
 
-    def test_fragment_name_may_contain_spaces(self):
-        result = self.execute(
-            [
-                {
-                    "type": "sql_column",
-                    "new_name": "Count of records ",
-                    "fragment": "amount + 1",
-                    "data_type": "Integer",
-                }
-            ]
-        )
+    def test_name_may_contain_spaces(self):
+        # unlike `mutate` and `rename`, the name is not sanitized: a migrated
+        # column keeps the name the v2 charts and filters already use
+        result = self.execute([self.sql_column("Count of records ", "amount + 1")])
 
         self.assertIn("Count of records ", result.columns)
 
-    def test_window_fragment(self):
+    def test_window_expression(self):
         result = self.execute(
             [
-                {
-                    "type": "sql_column",
-                    "new_name": "previous_amount",
-                    "fragment": "lag(amount, 1) over (partition by team order by idx)",
-                    "data_type": "Integer",
-                },
-                {
-                    "type": "order_by",
-                    "column": {"type": "column", "column_name": "idx"},
-                    "direction": "asc",
-                },
+                self.sql_column(
+                    "previous_amount",
+                    "lag(amount, 1) over (partition by team order by idx)",
+                ),
+                self.order_by("idx"),
             ]
         )
 
         self.assertEqual(list(result["previous_amount"].fillna(-1).astype(int)), [-1, 10, -1, 30])
 
-    def test_fragment_mid_pipeline_sees_derived_columns(self):
+    def test_a_semicolon_inside_a_string_is_allowed(self):
+        result = self.execute(
+            [
+                self.sql_column("clean_note", "replace(note, ';', ',')", data_type="String"),
+                self.order_by("idx"),
+            ]
+        )
+
+        self.assertEqual(list(result["clean_note"]), ["a,b"] * 4)
+
+    def test_expression_mid_pipeline_sees_derived_columns(self):
         # the case that needs `.alias()`: a filter and a mutate come first, and the
-        # fragment reads the mutated column
+        # expression reads the mutated column
         result = self.execute(
             [
                 {
@@ -100,31 +106,17 @@ class TestSQLColumnOperation(InsightsIntegrationTestCase):
                     "data_type": "Integer",
                     "expression": {"type": "expression", "expression": "amount * 3"},
                 },
-                {
-                    "type": "sql_column",
-                    "new_name": "tripled_plus_one",
-                    "fragment": "tripled + 1",
-                    "data_type": "Integer",
-                },
-                {
-                    "type": "order_by",
-                    "column": {"type": "column", "column_name": "idx"},
-                    "direction": "asc",
-                },
+                self.sql_column("tripled_plus_one", "tripled + 1"),
+                self.order_by("idx"),
             ]
         )
 
         self.assertEqual(list(result["tripled_plus_one"]), [61, 91, 121])
 
-    def test_aggregate_composes_after_a_fragment(self):
+    def test_aggregate_composes_after_a_sql_column(self):
         result = self.execute(
             [
-                {
-                    "type": "sql_column",
-                    "new_name": "double_amount",
-                    "fragment": "amount * 2",
-                    "data_type": "Integer",
-                },
+                self.sql_column("double_amount", "amount * 2"),
                 {
                     "type": "summarize",
                     "measures": [
@@ -142,37 +134,22 @@ class TestSQLColumnOperation(InsightsIntegrationTestCase):
                         }
                     ],
                 },
-                {
-                    "type": "order_by",
-                    "column": {"type": "column", "column_name": "team"},
-                    "direction": "asc",
-                },
+                self.order_by("team"),
             ]
         )
 
         self.assertEqual(dict(zip(result["team"], result["total"], strict=False)), {"alpha": 60, "beta": 140})
 
-    def test_fragment_is_transpiled_from_the_source_dialect(self):
+    def test_expression_is_transpiled_from_the_source_dialect(self):
         source = frappe.get_doc("Insights Data Source v3", "Site DB")
-        self.assertEqual(source.get_sqlglot_dialect(), "mysql")
+        dialect = source.get_sqlglot_dialect()
 
-        # `locate` is MySQL-only: the query runs on DuckDB, which knows `strpos`
-        result = self.execute(
-            [
-                {
-                    "type": "sql_column",
-                    "new_name": "a_at",
-                    "fragment": "locate('a', team)",
-                    "data_type": "Integer",
-                    "data_source": "Site DB",
-                },
-                {
-                    "type": "order_by",
-                    "column": {"type": "column", "column_name": "idx"},
-                    "direction": "asc",
-                },
-            ]
-        )
+        # every dialect spells this differently, and only the transpile makes the
+        # source's spelling run on DuckDB
+        position = sg.exp.StrPosition(this=sg.column("team"), substr=sg.exp.Literal.string("a"))
+        raw_sql = position.sql(dialect=dialect)
+
+        result = self.execute([self.sql_column("a_at", raw_sql), self.order_by("idx")])
 
         self.assertEqual(list(result["a_at"]), [1, 1, 4, 4])
 
@@ -185,32 +162,20 @@ class TestSQLColumnOperation(InsightsIntegrationTestCase):
             "(select max(amount) from _insights_sql_column)",
         ]
 
-        for fragment in cases:
-            with self.subTest(fragment=fragment):
+        for raw_sql in cases:
+            with self.subTest(raw_sql=raw_sql):
                 with self.assertRaises(frappe.ValidationError):
-                    self.execute(
-                        [
-                            {
-                                "type": "sql_column",
-                                "new_name": "smuggled",
-                                "fragment": fragment,
-                                "data_type": "Integer",
-                            }
-                        ]
-                    )
+                    self.execute([self.sql_column("smuggled", raw_sql)])
 
-    def test_an_unparsable_fragment_is_rejected(self):
+    def test_an_unparsable_expression_is_rejected(self):
         with self.assertRaises(frappe.ValidationError):
-            self.execute(
-                [
-                    {
-                        "type": "sql_column",
-                        "new_name": "broken",
-                        "fragment": "amount ) * 2",
-                        "data_type": "Integer",
-                    }
-                ]
-            )
+            self.execute([self.sql_column("broken", "amount ) * 2")])
+
+    def test_a_missing_data_source_is_rejected(self):
+        # without it the expression is parsed and transpiled in the wrong dialect,
+        # which silently changes what the column means
+        with self.assertRaises(frappe.ValidationError):
+            self.execute([self.sql_column("orphan", "amount * 2", data_source="")])
 
     def test_an_operation_this_version_does_not_know_is_refused(self):
         """A newer client's operation must fail, not return different numbers.

--- a/insights/tests/test_sql_column.py
+++ b/insights/tests/test_sql_column.py
@@ -211,3 +211,12 @@ class TestSQLColumnOperation(InsightsIntegrationTestCase):
                     }
                 ]
             )
+
+    def test_an_operation_this_version_does_not_know_is_refused(self):
+        """A newer client's operation must fail, not return different numbers.
+
+        `sql_column` is the first operation to reach a release that predates it,
+        so the answer to an unknown type is settled here rather than per type.
+        """
+        with self.assertRaises(frappe.ValidationError):
+            self.execute([{"type": "operation_from_the_future", "new_name": "x"}])

--- a/insights/tests/test_sql_column.py
+++ b/insights/tests/test_sql_column.py
@@ -1,0 +1,213 @@
+import frappe
+
+from insights.insights.doctype.insights_data_source_v3.ibis_utils import IbisQueryBuilder
+from insights.tests.base import InsightsIntegrationTestCase
+
+SOURCE_CODE = """
+results = [
+    {"idx": 1, "team": "alpha", "amount": 10, "note": None},
+    {"idx": 2, "team": "alpha", "amount": 20, "note": None},
+    {"idx": 3, "team": "beta", "amount": 30, "note": None},
+    {"idx": 4, "team": "beta", "amount": 40, "note": None},
+]
+"""
+
+
+class TestSQLColumnOperation(InsightsIntegrationTestCase):
+    def make_query_doc(self, operations):
+        return frappe._dict(
+            name="SQL Column Test",
+            title="SQL Column Test",
+            use_live_connection=0,
+            operations=frappe.as_json(operations),
+        )
+
+    def build_query(self, operations):
+        return IbisQueryBuilder(self.make_query_doc(operations)).build()
+
+    def source_operations(self):
+        return [{"type": "code", "code": SOURCE_CODE}]
+
+    def execute(self, operations):
+        return self.build_query([*self.source_operations(), *operations]).execute()
+
+    def test_plain_fragment_adds_a_column(self):
+        result = self.execute(
+            [
+                {
+                    "type": "sql_column",
+                    "new_name": "double_amount",
+                    "fragment": "amount * 2",
+                    "data_type": "Integer",
+                },
+                {
+                    "type": "order_by",
+                    "column": {"type": "column", "column_name": "idx"},
+                    "direction": "asc",
+                },
+            ]
+        )
+
+        self.assertEqual(list(result["double_amount"]), [20, 40, 60, 80])
+
+    def test_fragment_name_may_contain_spaces(self):
+        result = self.execute(
+            [
+                {
+                    "type": "sql_column",
+                    "new_name": "Count of records ",
+                    "fragment": "amount + 1",
+                    "data_type": "Integer",
+                }
+            ]
+        )
+
+        self.assertIn("Count of records ", result.columns)
+
+    def test_window_fragment(self):
+        result = self.execute(
+            [
+                {
+                    "type": "sql_column",
+                    "new_name": "previous_amount",
+                    "fragment": "lag(amount, 1) over (partition by team order by idx)",
+                    "data_type": "Integer",
+                },
+                {
+                    "type": "order_by",
+                    "column": {"type": "column", "column_name": "idx"},
+                    "direction": "asc",
+                },
+            ]
+        )
+
+        self.assertEqual(list(result["previous_amount"].fillna(-1).astype(int)), [-1, 10, -1, 30])
+
+    def test_fragment_mid_pipeline_sees_derived_columns(self):
+        # the case that needs `.alias()`: a filter and a mutate come first, and the
+        # fragment reads the mutated column
+        result = self.execute(
+            [
+                {
+                    "type": "filter",
+                    "column": {"type": "column", "column_name": "amount"},
+                    "operator": ">",
+                    "value": 10,
+                },
+                {
+                    "type": "mutate",
+                    "new_name": "tripled",
+                    "data_type": "Integer",
+                    "expression": {"type": "expression", "expression": "amount * 3"},
+                },
+                {
+                    "type": "sql_column",
+                    "new_name": "tripled_plus_one",
+                    "fragment": "tripled + 1",
+                    "data_type": "Integer",
+                },
+                {
+                    "type": "order_by",
+                    "column": {"type": "column", "column_name": "idx"},
+                    "direction": "asc",
+                },
+            ]
+        )
+
+        self.assertEqual(list(result["tripled_plus_one"]), [61, 91, 121])
+
+    def test_aggregate_composes_after_a_fragment(self):
+        result = self.execute(
+            [
+                {
+                    "type": "sql_column",
+                    "new_name": "double_amount",
+                    "fragment": "amount * 2",
+                    "data_type": "Integer",
+                },
+                {
+                    "type": "summarize",
+                    "measures": [
+                        {
+                            "measure_name": "total",
+                            "column_name": "double_amount",
+                            "aggregation": "sum",
+                        }
+                    ],
+                    "dimensions": [
+                        {
+                            "column_name": "team",
+                            "data_type": "String",
+                            "dimension_name": "team",
+                        }
+                    ],
+                },
+                {
+                    "type": "order_by",
+                    "column": {"type": "column", "column_name": "team"},
+                    "direction": "asc",
+                },
+            ]
+        )
+
+        self.assertEqual(dict(zip(result["team"], result["total"], strict=False)), {"alpha": 60, "beta": 140})
+
+    def test_fragment_is_transpiled_from_the_source_dialect(self):
+        source = frappe.get_doc("Insights Data Source v3", "Site DB")
+        self.assertEqual(source.get_sqlglot_dialect(), "mysql")
+
+        # `locate` is MySQL-only: the query runs on DuckDB, which knows `strpos`
+        result = self.execute(
+            [
+                {
+                    "type": "sql_column",
+                    "new_name": "a_at",
+                    "fragment": "locate('a', team)",
+                    "data_type": "Integer",
+                    "data_source": "Site DB",
+                },
+                {
+                    "type": "order_by",
+                    "column": {"type": "column", "column_name": "idx"},
+                    "direction": "asc",
+                },
+            ]
+        )
+
+        self.assertEqual(list(result["a_at"]), [1, 1, 4, 4])
+
+    def test_a_statement_is_rejected(self):
+        cases = [
+            "1; drop table something",
+            "select 1",
+            "with x as (select 1) select * from x",
+            "exec sp_who",
+            "(select max(amount) from _insights_sql_column)",
+        ]
+
+        for fragment in cases:
+            with self.subTest(fragment=fragment):
+                with self.assertRaises(frappe.ValidationError):
+                    self.execute(
+                        [
+                            {
+                                "type": "sql_column",
+                                "new_name": "smuggled",
+                                "fragment": fragment,
+                                "data_type": "Integer",
+                            }
+                        ]
+                    )
+
+    def test_an_unparsable_fragment_is_rejected(self):
+        with self.assertRaises(frappe.ValidationError):
+            self.execute(
+                [
+                    {
+                        "type": "sql_column",
+                        "new_name": "broken",
+                        "fragment": "amount ) * 2",
+                        "data_type": "Integer",
+                    }
+                ]
+            )


### PR DESCRIPTION
The v2 migrator on `feat/v2-migrator` (#1351) writes a `sql_column` operation for the constructs v2 expressed in SQL and v3 has no expression for. That branch ships on `version-3-hotfix`, where v2 still exists. The workbooks it writes do not stay there: `check_legacy_v2_data_before_upgrade` blocks the upgrade until a site migrates, so migrating and then upgrading to a `develop` release is the designed path.

Without this, every migrated query carrying a `sql_column` silently loses a column on that upgrade. So the operation lands here ahead of the migrator shipping.

It is not in `AddOperationPopover`, so nobody can author one — the migrator is the only writer.

**Why an operation and not a `mutate` expression.** ibis has no scalar-level SQL escape, only `Table.sql()`. Taking a column out of a `.sql()` relation and mutating it onto the parent raises `IntegrityError: ... they belong to another relation`. A `mutate` route needs a marker string plus a special case inside `apply_mutate`.

**The second commit is the general fix.** `perform_operation` ended with `return self.query`, so any unrecognised operation was a no-op — a result missing a column, with nothing said. It now throws. `sql_column` is the first operation to reach a release that predates it, so the answer is settled once rather than per type.
