### PR TITLE
fix: give the SQL column operation the same contract as develop

### DIFF
--- a/frontend/src2/query/helpers.ts
+++ b/frontend/src2/query/helpers.ts
@@ -353,9 +353,7 @@ export const query_operation_types = {
 			return `${op.new_name}`
 		},
 	},
-	// Not in `AddOperationPopover`, so nobody can author one: the migrator is the
-	// only writer. The label says so, because a raw SQL step is a thing to rewrite
-	// as a formula, not a thing to copy.
+	// No popover entry: the v2 migrator is the only writer.
 	sql_column: {
 		label: __('SQL column (from v2)'),
 		type: 'sql_column',

--- a/frontend/src2/types/query.types.ts
+++ b/frontend/src2/types/query.types.ts
@@ -137,8 +137,8 @@ export type Mutate = { type: 'mutate' } & MutateArgs
 export type SQLColumnArgs = {
 	new_name: string
 	data_type: ColumnDataType
-	fragment: string
-	data_source?: string
+	raw_sql: string
+	data_source: string
 }
 export type SQLColumn = { type: 'sql_column' } & SQLColumnArgs
 

--- a/insights/insights/doctype/insights_data_source_v3/ibis_utils.py
+++ b/insights/insights/doctype/insights_data_source_v3/ibis_utils.py
@@ -528,25 +528,36 @@ class IbisQueryBuilder:
         return self.query.mutate(**{new_name: new_column})
 
     def apply_sql_column(self, sql_column_args):
-        new_name = sql_column_args.new_name
-        fragment = sql_column_args.fragment
+        """Add one column from a raw SQL expression.
 
-        if not new_name or not fragment or not fragment.strip():
+        Written by the v2 migrator, for the constructs v2 expressed in SQL and v3
+        has no expression for. ibis has no scalar-level SQL escape - only
+        `Table.sql()` - so this is a relation-level operation and not a `mutate`.
+
+        `new_name` is not sanitized, unlike `apply_mutate` and `apply_rename`: a
+        migrated column keeps the name the v2 charts and filters already use.
+        """
+        new_name = sql_column_args.new_name
+        raw_sql = sql_column_args.raw_sql
+
+        if not new_name or not raw_sql or not raw_sql.strip():
             frappe.throw(
-                "A SQL column needs both a name and an expression",
-                title="Invalid SQL Column",
+                frappe._("A SQL column needs both a name and an expression"),
             )
 
-        source_dialect = None
-        if sql_column_args.data_source:
-            ds = frappe.get_doc("Insights Data Source v3", sql_column_args.data_source)
-            source_dialect = ds.get_sqlglot_dialect()
+        if not sql_column_args.data_source:
+            frappe.throw(
+                frappe._("A SQL column needs the data source its expression is written for"),
+            )
 
-        fragment = sqlparse.format(sql=fragment, strip_comments=True).strip()
-        self._validate_sql_column_fragment(fragment, source_dialect)
+        data_source = frappe.get_doc("Insights Data Source v3", sql_column_args.data_source)
+        source_dialect = data_source.get_sqlglot_dialect()
+
+        raw_sql = sqlparse.format(sql=raw_sql, strip_comments=True).strip()
 
         alias = sg.to_identifier(new_name, quoted=True).sql(dialect=source_dialect)
-        statement = f"SELECT *, {fragment} AS {alias} FROM {SQL_COLUMN_RELATION}"
+        statement = f"SELECT *, {raw_sql} AS {alias} FROM {SQL_COLUMN_RELATION}"
+        self._validate_sql_column_statement(statement, source_dialect)
 
         if not self.use_live_connection:
             statement = self._transpile_sql_to_duckdb(statement, source_dialect)
@@ -558,40 +569,30 @@ class IbisQueryBuilder:
         dtype = self.get_ibis_dtype(sql_column_args.data_type) if sql_column_args.data_type else None
         return query.cast({new_name: dtype}) if dtype else query
 
-    def _validate_sql_column_fragment(self, fragment: str, dialect: str | None) -> None:
-        """A fragment is one column expression. Anything that could open a statement is rejected."""
-        if ";" in fragment:
-            frappe.throw(
-                "A SQL column expression cannot contain multiple statements",
-                title="Invalid SQL Column",
-            )
+    def _validate_sql_column_statement(self, statement: str, dialect: str) -> None:
+        """Validate the assembled statement, not the expression alone.
 
-        if re.match(r"^(select|with|exec|execute)\b", fragment, flags=re.IGNORECASE):
-            frappe.throw(
-                "A SQL column expression cannot be a statement",
-                title="Invalid SQL Column",
-            )
-
+        An expression parsed on its own is read as the start of a statement, so
+        `replace(...)` reads as MySQL's REPLACE. In place, it is one projection.
+        """
         try:
-            parsed = sg.parse(fragment, dialect=dialect)
+            parsed = sg.parse(statement, dialect=dialect)
         except Exception as e:
             frappe.throw(
-                f"Failed to parse the SQL column expression: {e}",
-                title="Invalid SQL Column",
+                frappe._("Failed to parse the SQL column expression: {0}").format(e),
             )
 
-        if len(parsed) != 1 or parsed[0] is None:
+        if len(parsed) != 1 or not isinstance(parsed[0], sg.exp.Select):
             frappe.throw(
-                "A SQL column expression must be a single expression",
-                title="Invalid SQL Column",
+                frappe._("A SQL column expression must be a single expression"),
             )
 
-        expression = parsed[0]
-        is_statement = isinstance(expression, sg.exp.DDL | sg.exp.DML | sg.exp.Command)
-        if is_statement or expression.find(sg.exp.Select):
+        select = parsed[0]
+        tables = {table.name for table in select.find_all(sg.exp.Table)}
+        nested = len(list(select.find_all(sg.exp.Select))) > 1 or select.find(sg.exp.Subquery)
+        if nested or tables != {SQL_COLUMN_RELATION}:
             frappe.throw(
-                "A SQL column expression must be a single expression",
-                title="Invalid SQL Column",
+                frappe._("A SQL column expression cannot read another table"),
             )
 
     def apply_summary(self, summarize_args):

--- a/insights/migrator/v2_queries.py
+++ b/insights/migrator/v2_queries.py
@@ -907,14 +907,12 @@ class _Builder:
             column_name=label,
         )
 
-    def sql_column(self, name, fragment):
-        # `data_source` has to be set, or sqlglot parses v2's backtick
-        # identifiers with the default dialect and rejects them.
+    def sql_column(self, name, raw_sql):
         return {
             "type": "sql_column",
             "new_name": name,
             "data_type": "Auto",
-            "fragment": fragment,
+            "raw_sql": raw_sql,
             "data_source": self.data_source,
         }
 

--- a/insights/tests/test_sql_column.py
+++ b/insights/tests/test_sql_column.py
@@ -1,14 +1,15 @@
 import frappe
+import sqlglot as sg
 
 from insights.insights.doctype.insights_data_source_v3.ibis_utils import IbisQueryBuilder
 from insights.tests.base import InsightsIntegrationTestCase
 
 SOURCE_CODE = """
 results = [
-    {"idx": 1, "team": "alpha", "amount": 10, "note": None},
-    {"idx": 2, "team": "alpha", "amount": 20, "note": None},
-    {"idx": 3, "team": "beta", "amount": 30, "note": None},
-    {"idx": 4, "team": "beta", "amount": 40, "note": None},
+    {"idx": 1, "team": "alpha", "amount": 10, "note": "a;b"},
+    {"idx": 2, "team": "alpha", "amount": 20, "note": "a;b"},
+    {"idx": 3, "team": "beta", "amount": 30, "note": "a;b"},
+    {"idx": 4, "team": "beta", "amount": 40, "note": "a;b"},
 ]
 """
 
@@ -28,64 +29,69 @@ class TestSQLColumnOperation(InsightsIntegrationTestCase):
     def source_operations(self):
         return [{"type": "code", "code": SOURCE_CODE}]
 
+    def sql_column(self, new_name, raw_sql, **kwargs):
+        return {
+            "type": "sql_column",
+            "new_name": new_name,
+            "raw_sql": raw_sql,
+            "data_type": "Integer",
+            "data_source": "Site DB",
+            **kwargs,
+        }
+
+    def order_by(self, column_name):
+        return {
+            "type": "order_by",
+            "column": {"type": "column", "column_name": column_name},
+            "direction": "asc",
+        }
+
     def execute(self, operations):
         return self.build_query([*self.source_operations(), *operations]).execute()
 
-    def test_plain_fragment_adds_a_column(self):
+    def test_plain_expression_adds_a_column(self):
         result = self.execute(
             [
-                {
-                    "type": "sql_column",
-                    "new_name": "double_amount",
-                    "fragment": "amount * 2",
-                    "data_type": "Integer",
-                },
-                {
-                    "type": "order_by",
-                    "column": {"type": "column", "column_name": "idx"},
-                    "direction": "asc",
-                },
+                self.sql_column("double_amount", "amount * 2"),
+                self.order_by("idx"),
             ]
         )
 
         self.assertEqual(list(result["double_amount"]), [20, 40, 60, 80])
 
-    def test_fragment_name_may_contain_spaces(self):
-        result = self.execute(
-            [
-                {
-                    "type": "sql_column",
-                    "new_name": "Count of records ",
-                    "fragment": "amount + 1",
-                    "data_type": "Integer",
-                }
-            ]
-        )
+    def test_name_may_contain_spaces(self):
+        # unlike `mutate` and `rename`, the name is not sanitized: a migrated
+        # column keeps the name the v2 charts and filters already use
+        result = self.execute([self.sql_column("Count of records ", "amount + 1")])
 
         self.assertIn("Count of records ", result.columns)
 
-    def test_window_fragment(self):
+    def test_window_expression(self):
         result = self.execute(
             [
-                {
-                    "type": "sql_column",
-                    "new_name": "previous_amount",
-                    "fragment": "lag(amount, 1) over (partition by team order by idx)",
-                    "data_type": "Integer",
-                },
-                {
-                    "type": "order_by",
-                    "column": {"type": "column", "column_name": "idx"},
-                    "direction": "asc",
-                },
+                self.sql_column(
+                    "previous_amount",
+                    "lag(amount, 1) over (partition by team order by idx)",
+                ),
+                self.order_by("idx"),
             ]
         )
 
         self.assertEqual(list(result["previous_amount"].fillna(-1).astype(int)), [-1, 10, -1, 30])
 
-    def test_fragment_mid_pipeline_sees_derived_columns(self):
+    def test_a_semicolon_inside_a_string_is_allowed(self):
+        result = self.execute(
+            [
+                self.sql_column("clean_note", "replace(note, ';', ',')", data_type="String"),
+                self.order_by("idx"),
+            ]
+        )
+
+        self.assertEqual(list(result["clean_note"]), ["a,b"] * 4)
+
+    def test_expression_mid_pipeline_sees_derived_columns(self):
         # the case that needs `.alias()`: a filter and a mutate come first, and the
-        # fragment reads the mutated column
+        # expression reads the mutated column
         result = self.execute(
             [
                 {
@@ -100,31 +106,17 @@ class TestSQLColumnOperation(InsightsIntegrationTestCase):
                     "data_type": "Integer",
                     "expression": {"type": "expression", "expression": "amount * 3"},
                 },
-                {
-                    "type": "sql_column",
-                    "new_name": "tripled_plus_one",
-                    "fragment": "tripled + 1",
-                    "data_type": "Integer",
-                },
-                {
-                    "type": "order_by",
-                    "column": {"type": "column", "column_name": "idx"},
-                    "direction": "asc",
-                },
+                self.sql_column("tripled_plus_one", "tripled + 1"),
+                self.order_by("idx"),
             ]
         )
 
         self.assertEqual(list(result["tripled_plus_one"]), [61, 91, 121])
 
-    def test_aggregate_composes_after_a_fragment(self):
+    def test_aggregate_composes_after_a_sql_column(self):
         result = self.execute(
             [
-                {
-                    "type": "sql_column",
-                    "new_name": "double_amount",
-                    "fragment": "amount * 2",
-                    "data_type": "Integer",
-                },
+                self.sql_column("double_amount", "amount * 2"),
                 {
                     "type": "summarize",
                     "measures": [
@@ -142,37 +134,22 @@ class TestSQLColumnOperation(InsightsIntegrationTestCase):
                         }
                     ],
                 },
-                {
-                    "type": "order_by",
-                    "column": {"type": "column", "column_name": "team"},
-                    "direction": "asc",
-                },
+                self.order_by("team"),
             ]
         )
 
         self.assertEqual(dict(zip(result["team"], result["total"], strict=False)), {"alpha": 60, "beta": 140})
 
-    def test_fragment_is_transpiled_from_the_source_dialect(self):
+    def test_expression_is_transpiled_from_the_source_dialect(self):
         source = frappe.get_doc("Insights Data Source v3", "Site DB")
-        self.assertEqual(source.get_sqlglot_dialect(), "mysql")
+        dialect = source.get_sqlglot_dialect()
 
-        # `locate` is MySQL-only: the query runs on DuckDB, which knows `strpos`
-        result = self.execute(
-            [
-                {
-                    "type": "sql_column",
-                    "new_name": "a_at",
-                    "fragment": "locate('a', team)",
-                    "data_type": "Integer",
-                    "data_source": "Site DB",
-                },
-                {
-                    "type": "order_by",
-                    "column": {"type": "column", "column_name": "idx"},
-                    "direction": "asc",
-                },
-            ]
-        )
+        # every dialect spells this differently, and only the transpile makes the
+        # source's spelling run on DuckDB
+        position = sg.exp.StrPosition(this=sg.column("team"), substr=sg.exp.Literal.string("a"))
+        raw_sql = position.sql(dialect=dialect)
+
+        result = self.execute([self.sql_column("a_at", raw_sql), self.order_by("idx")])
 
         self.assertEqual(list(result["a_at"]), [1, 1, 4, 4])
 
@@ -185,29 +162,17 @@ class TestSQLColumnOperation(InsightsIntegrationTestCase):
             "(select max(amount) from _insights_sql_column)",
         ]
 
-        for fragment in cases:
-            with self.subTest(fragment=fragment):
+        for raw_sql in cases:
+            with self.subTest(raw_sql=raw_sql):
                 with self.assertRaises(frappe.ValidationError):
-                    self.execute(
-                        [
-                            {
-                                "type": "sql_column",
-                                "new_name": "smuggled",
-                                "fragment": fragment,
-                                "data_type": "Integer",
-                            }
-                        ]
-                    )
+                    self.execute([self.sql_column("smuggled", raw_sql)])
 
-    def test_an_unparsable_fragment_is_rejected(self):
+    def test_an_unparsable_expression_is_rejected(self):
         with self.assertRaises(frappe.ValidationError):
-            self.execute(
-                [
-                    {
-                        "type": "sql_column",
-                        "new_name": "broken",
-                        "fragment": "amount ) * 2",
-                        "data_type": "Integer",
-                    }
-                ]
-            )
+            self.execute([self.sql_column("broken", "amount ) * 2")])
+
+    def test_a_missing_data_source_is_rejected(self):
+        # without it the expression is parsed and transpiled in the wrong dialect,
+        # which silently changes what the column means
+        with self.assertRaises(frappe.ValidationError):
+            self.execute([self.sql_column("orphan", "amount * 2", data_source="")])


### PR DESCRIPTION
The iris review on #1355 renamed the `sql_column` field to `raw_sql` and made `data_source` required. That merged to `develop`. The migrator merged here, and it is the only writer — so this branch writes a field `develop` no longer reads. A site that migrates on a version-3 release and then upgrades loses every migrated column.

The `sql_column` code is byte-identical to `develop` now. The `perform_operation` refusal from the same review stays there: it only covers operations invented after the release carrying it, and an unknown operation throwing is a behaviour change this line should not take.