### PR TITLE
fix(tests): finish the sql_column rename to raw_sql

### DIFF
--- a/insights/insights/query_builders/sql_functions.py
+++ b/insights/insights/query_builders/sql_functions.py
@@ -1,6 +1,7 @@
 import datetime
 import operator
 from contextlib import suppress
+from typing import ClassVar
 
 import frappe
 from frappe.utils.data import (
@@ -54,7 +55,7 @@ class ColumnFormatter:
     def format(cls, format_options: dict, column_type: str, column: Column) -> Column:
         if format_options and format_options.date_format and column_type in DATE_TYPES:
             date_format = format_options.date_format
-            date_format = date_format if type(date_format) == str else date_format.get("value")
+            date_format = date_format if isinstance(date_format, str) else date_format.get("value")
             return cls.format_date(date_format, column)
         return column
 
@@ -413,13 +414,13 @@ def add_start_and_end_time(dates):
 
 
 class BinaryOperations:
-    ARITHMETIC_OPERATIONS = {
+    ARITHMETIC_OPERATIONS: ClassVar[dict] = {
         "+": operator.add,
         "-": operator.sub,
         "*": operator.mul,
         "/": operator.truediv,
     }
-    COMPARE_OPERATIONS = {
+    COMPARE_OPERATIONS: ClassVar[dict] = {
         "=": operator.eq,
         "!=": operator.ne,
         "<": operator.lt,
@@ -427,7 +428,7 @@ class BinaryOperations:
         "<=": operator.le,
         ">=": operator.ge,
     }
-    LOGICAL_OPERATIONS = {
+    LOGICAL_OPERATIONS: ClassVar[dict] = {
         "&&": lambda a, b: and_(a, b),
         "||": lambda a, b: or_(a, b),
     }

--- a/insights/tests/test_v2_migration_api.py
+++ b/insights/tests/test_v2_migration_api.py
@@ -421,7 +421,7 @@ class TestV2MigrationAPI(InsightsIntegrationTestCase):
         create_test_query(
             "Administrator",
             workbook.name,
-            operations=[{"type": "sql_column", "new_name": "x", "data_type": "Integer", "fragment": "1"}],
+            operations=[{"type": "sql_column", "new_name": "x", "data_type": "Integer", "raw_sql": "1"}],
         )
         self.addCleanup(frappe.delete_doc, DT.WORKBOOK, workbook.name, force=True)
 

--- a/insights/tests/test_v2_query_translation.py
+++ b/insights/tests/test_v2_query_translation.py
@@ -457,7 +457,7 @@ class TestExpressionColumns(UnitTestCase):
         result = translate(v2_query({"columns": [expression_column("Bumped", ast)]}))
         operation = find(result, "sql_column")
         self.assertEqual(operation["new_name"], "Bumped")
-        self.assertEqual(operation["fragment"], "`status` + 1")
+        self.assertEqual(operation["raw_sql"], "`status` + 1")
         # sqlglot rejects v2's backtick identifiers without the source dialect.
         self.assertEqual(operation["data_source"], "frappe.io")
 


### PR DESCRIPTION
#1358 renamed the `sql_column` field to `raw_sql` but left two tests on the old name. One of them fails.

The second commit clears the ruff errors in `sql_functions.py`. They are old, but the reformat in c76b01860 put the file into the linted set, so CI reports them now.