### PR TITLE
chore: sync translations with crowdin/github-action

### DIFF
--- a/.github/workflows/crowdin-actions-download-translations.yml
+++ b/.github/workflows/crowdin-actions-download-translations.yml
@@ -1,0 +1,46 @@
+name: Download translations from Crowdin
+
+on:
+  schedule:
+    - cron: "0 4 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  group: crowdin-download
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  download-translations:
+    name: Download translations into develop
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout develop
+        uses: actions/checkout@v6
+        with:
+          ref: develop
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Download translations and open PR
+        uses: crowdin/github-action@8f01d54f70f1713ee3f09d82c2bbb2daeac28689 # v2.17.1
+        with:
+          config: crowdin.yml
+          upload_sources: false
+          upload_translations: false
+          download_translations: true
+          crowdin_branch_name: "[frappe.insights] develop"
+          skip_ref_checkout: true
+          localization_branch_name: l10n_crowdin_develop
+          create_pull_request: true
+          pull_request_base_branch_name: develop
+          commit_message: "chore: sync translations from crowdin"
+          pull_request_title: "chore: sync translations from crowdin"
+          pull_request_labels: "translation"
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}

--- a/.github/workflows/crowdin-actions-update-main-pot.yml
+++ b/.github/workflows/crowdin-actions-update-main-pot.yml
@@ -1,0 +1,53 @@
+name: Upload main.pot to Crowdin
+
+on:
+  push:
+    branches:
+      - develop
+    paths:
+      - "insights/locale/main.pot"
+  workflow_dispatch:
+
+concurrency:
+  group: crowdin-upload-${{ github.ref_name }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  upload-sources:
+    name: Upload sources from ${{ github.ref_name }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout ${{ github.ref_name }}
+        uses: actions/checkout@v6
+
+      - name: Restore Crowdin cache
+        uses: actions/cache/restore@v6
+        with:
+          path: .crowdin
+          key: crowdin-${{ github.ref_name }}
+          restore-keys: crowdin-${{ github.ref_name }}-
+
+      - name: Upload main.pot to Crowdin
+        uses: crowdin/github-action@8f01d54f70f1713ee3f09d82c2bbb2daeac28689 # v2.17.1
+        with:
+          config: crowdin.yml
+          upload_sources: true
+          upload_translations: false
+          download_translations: false
+          create_pull_request: false
+          crowdin_branch_name: "[frappe.insights] ${{ github.ref_name }}"
+          upload_sources_args: "--cache"
+        env:
+          CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
+
+      - name: Save Crowdin cache
+        uses: actions/cache/save@v6
+        if: always()
+        with:
+          path: .crowdin
+          key: crowdin-${{ github.ref_name }}-${{ github.run_id }}

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,8 +1,5 @@
+preserve_hierarchy: true
+
 files:
   - source: /insights/locale/main.pot
     translation: /insights/locale/%two_letters_code%.po
-pull_request_title: 'chore: sync translations from crowdin'
-pull_request_labels:
-  - translation
-commit_message: 'chore: %language% translations'
-append_commit_message: 


### PR DESCRIPTION
Replaces the Crowdin GitHub integration, which fails at random and drops approved translations. Last sync landed 2026-07-10. Follows the guide from Diptanil's post.

- `crowdin-actions-update-main-pot.yml` — uploads `main.pot` when [generate-pot-file.yml](.github/workflows/generate-pot-file.yml) rewrites it
- `crowdin-actions-download-translations.yml` — opens a translation PR every Monday
- `crowdin.yml` — keeps the file mapping and gains `preserve_hierarchy: true`. The PR title, labels and commit message move into the workflow, where the action reads them

Single branch, no matrix: translations sync to `develop` only and reach `version-3-hotfix` by merge.

## Before merge

- Confirm `CROWDIN_PROJECT_ID` and `CROWDIN_PERSONAL_TOKEN` reach this repo from the org.
- Decide the Crowdin branch. The workflows target `[frappe.insights] develop`. Approved translations sit under the branch the old integration created, so that branch needs a rename, or we accept a fresh one.

## After merge

Delete the GitHub integration in the Crowdin portal, then run both workflows once by hand.