### PR TITLE
fix: native SQL queries with a CTE fail with "Duplicate query name"

### DIFF
--- a/insights/insights/doctype/insights_data_source_v3/ibis_utils.py
+++ b/insights/insights/doctype/insights_data_source_v3/ibis_utils.py
@@ -791,7 +791,7 @@ class IbisQueryBuilder:
             if table_ref.db or table_ref.catalog:
                 frappe.throw(
                     frappe._("Schema-qualified table names are not supported for native queries yet"),
-                    title="Unsupported SQL Query",
+                    title=frappe._("Unsupported SQL Query"),
                 )
 
             tables.add(table_ref.name)

--- a/insights/insights/doctype/insights_data_source_v3/ibis_utils.py
+++ b/insights/insights/doctype/insights_data_source_v3/ibis_utils.py
@@ -1,5 +1,4 @@
 import ast
-import re
 import sys
 import time
 import traceback
@@ -708,10 +707,14 @@ class IbisQueryBuilder:
                 check_permissions=check_permissions,
             )
 
+            # after the transpile the SQL is DuckDB's, so the rewrite below reads
+            # and writes that dialect instead of the source's
+            target_dialect = source_dialect
             if not self.use_live_connection:
                 raw_sql = self._transpile_sql_to_duckdb(raw_sql, source_dialect)
+                target_dialect = "duckdb"
 
-            raw_sql = self._prepend_sql_with_clauses(raw_sql, replace_map)
+            raw_sql = self._replace_sql_tables(raw_sql, replace_map, dialect=target_dialect)
 
         supports_stored_procedure = ds.database_type in ["PostgreSQL", "MSSQL", "MariaDB"]
         if (
@@ -828,27 +831,47 @@ class IbisQueryBuilder:
 
         return replace_map
 
-    def _prepend_sql_with_clauses(self, raw_sql: str, replace_map: dict[str, str]) -> str:
+    def _replace_sql_tables(
+        self,
+        raw_sql: str,
+        replace_map: dict[str, str],
+        dialect: sg.Dialect | None,
+    ) -> str:
+        """Swap every reference to a bound table for its permission-filtered select.
+
+        Prepending one CTE per table is shorter, but then the CTE name is the
+        collision surface. MariaDB matches CTE names case-insensitively, so a query
+        that reads `tabTask` in one place and `tabtask` in another asks for two CTEs
+        that MariaDB reads as one, and it refuses the pair. Replacing the reference
+        itself needs no name, so no spelling can collide.
+        """
         if not replace_map:
             return raw_sql
 
-        with_clauses = []
-        for table_name, table_sql in replace_map.items():
-            quoted_table_name = sg.to_identifier(table_name)
-            with_clauses.append(f"{quoted_table_name} AS ({table_sql})")
-
-        with_clause_sql = ", ".join(with_clauses)
-        raw_sql_stripped = raw_sql.strip()
-        if raw_sql_stripped.lower().startswith("with"):
-            return re.sub(
-                r"(\bwith\b)",
-                f"WITH {with_clause_sql},",
-                raw_sql_stripped,
-                count=1,
-                flags=re.IGNORECASE,
+        try:
+            statements = sg.parse(raw_sql, dialect=dialect)
+        except Exception as e:
+            frappe.throw(
+                f"Failed to apply permissions to the SQL query: {e}",
+                title="Unsupported SQL Query",
             )
 
-        return f"WITH {with_clause_sql} {raw_sql_stripped}"
+        for statement in statements:
+            # collect first: the replacements carry their own table references,
+            # and re-reading them would replace a table inside its own binding
+            for table_exp in list(statement.find_all(sg.exp.Table)):
+                table_sql = replace_map.get(table_exp.name)
+                if table_sql is None:
+                    continue
+
+                # an unaliased reference keeps the table name as its alias, so a
+                # qualified column such as `tabTask`.name still resolves
+                alias = table_exp.args.get("alias") or sg.exp.TableAlias(this=table_exp.this.copy())
+                subquery = sg.parse_one(table_sql, dialect=dialect).subquery()
+                subquery.set("alias", alias)
+                table_exp.replace(subquery)
+
+        return ";\n".join(statement.sql(dialect=dialect) for statement in statements if statement)
 
     def apply_code(self, code_args):
         code = code_args.code

--- a/insights/insights/doctype/insights_data_source_v3/ibis_utils.py
+++ b/insights/insights/doctype/insights_data_source_v3/ibis_utils.py
@@ -49,6 +49,9 @@ except ImportError:
 # the relation a `sql_column` fragment selects from, standing for the pipeline so far
 SQL_COLUMN_RELATION = "_insights_sql_column"
 
+# the alias a native SQL query is nested under before ibis sees it
+NATIVE_SQL_RELATION = "_insights_native_sql"
+
 
 class CircularQueryReferenceError(frappe.ValidationError):
     """Raised when a circular query reference is detected during query building."""
@@ -693,6 +696,10 @@ class IbisQueryBuilder:
             "Insights Settings", "enable_permissions"
         ) or frappe.db.get_single_value("Insights Settings", "apply_user_permissions")
 
+        # the data store reads DuckDB, so from the transpile on, that is the dialect
+        # this query is written in
+        target_dialect = source_dialect if self.use_live_connection else "duckdb"
+
         if check_permissions or not self.use_live_connection:
             tables = self._get_sql_table_names(raw_sql, dialect=source_dialect)
             replace_map = self._get_sql_table_bindings(
@@ -703,12 +710,8 @@ class IbisQueryBuilder:
                 check_permissions=check_permissions,
             )
 
-            # after the transpile the SQL is DuckDB's, so the rewrite below reads
-            # and writes that dialect instead of the source's
-            target_dialect = source_dialect
             if not self.use_live_connection:
                 raw_sql = self._transpile_sql_to_duckdb(raw_sql, source_dialect)
-                target_dialect = "duckdb"
 
             raw_sql = self._replace_sql_tables(raw_sql, replace_map, dialect=target_dialect)
 
@@ -731,7 +734,7 @@ class IbisQueryBuilder:
             results = ibis.memtable(df)
 
         elif raw_sql.strip().lower().startswith(("select", "with")):
-            results = db.sql(raw_sql)
+            results = db.sql(self._hide_ctes_from_ibis(raw_sql, dialect=target_dialect))
 
         else:
             frappe.throw(
@@ -841,27 +844,46 @@ class IbisQueryBuilder:
         if not replace_map:
             return raw_sql
 
-        # `sg.parse` over `sg.parse_one`: only `parse` reports every statement on
-        # every sqlglot version, and a statement dropped here is a statement that
-        # never runs. An empty one — a stray `;` — parses to None.
-        statements = [statement for statement in sg.parse(raw_sql, dialect=dialect) if statement]
+        parsed = sg.parse_one(raw_sql, dialect=dialect)
 
-        for statement in statements:
-            # collect first: the replacements carry their own table references,
-            # and re-reading them would replace a table inside its own binding
-            for table_exp in list(statement.find_all(sg.exp.Table)):
-                table_sql = replace_map.get(table_exp.name)
-                if table_sql is None:
-                    continue
+        # collect first: the replacements carry their own table references, and
+        # re-reading them would replace a table inside its own binding
+        for table_exp in list(parsed.find_all(sg.exp.Table)):
+            table_sql = replace_map.get(table_exp.name)
+            if table_sql is None:
+                continue
 
-                # an unaliased reference keeps the table name as its alias, so a
-                # qualified column such as `tabTask`.name still resolves
-                alias = table_exp.args.get("alias") or sg.exp.TableAlias(this=table_exp.this.copy())
-                subquery = sg.parse_one(table_sql, dialect=dialect).subquery()
-                subquery.set("alias", alias)
-                table_exp.replace(subquery)
+            # an unaliased reference keeps the table name as its alias, so a
+            # qualified column such as `tabTask`.name still resolves
+            alias = table_exp.args.get("alias") or sg.exp.TableAlias(this=table_exp.this.copy())
+            subquery = sg.parse_one(table_sql, dialect=dialect).subquery()
+            subquery.set("alias", alias)
+            table_exp.replace(subquery)
 
-        return ";\n".join(statement.sql(dialect=dialect) for statement in statements)
+        return parsed.sql(dialect=dialect)
+
+    def _hide_ctes_from_ibis(self, raw_sql: str, dialect: sg.Dialect | None) -> str:
+        """Nest a query that opens with `WITH`, so ibis is handed no top-level CTE.
+
+        ibis 11 clears a parsed statement's `WITH` clause with `args.pop("with")`
+        before re-attaching it. sqlglot 28 renamed that key to `with_`, so the clear
+        became a no-op and every CTE is written twice. MariaDB rejects the pair:
+        `(4004, 'Duplicate query name ... in WITH clause')`.
+
+        Dropping back below sqlglot 28 is not open to us — frappe needs 30. Nesting
+        the statement leaves the outer query with no CTE, so ibis re-attaches
+        nothing. Remove this once ibis pops the right key.
+        """
+        try:
+            parsed = sg.parse_one(raw_sql, dialect=dialect)
+        except Exception:
+            # not ours to reject: let ibis fail on it the way it always has
+            return raw_sql
+
+        if not parsed.ctes:
+            return raw_sql
+
+        return f"SELECT * FROM ({raw_sql}) AS {NATIVE_SQL_RELATION}"
 
     def apply_code(self, code_args):
         code = code_args.code

--- a/insights/insights/doctype/insights_data_source_v3/ibis_utils.py
+++ b/insights/insights/doctype/insights_data_source_v3/ibis_utils.py
@@ -694,11 +694,7 @@ class IbisQueryBuilder:
         ) or frappe.db.get_single_value("Insights Settings", "apply_user_permissions")
 
         if check_permissions or not self.use_live_connection:
-            tables = self._get_sql_table_names(
-                raw_sql,
-                dialect=source_dialect,
-                use_live_connection=self.use_live_connection,
-            )
+            tables = self._get_sql_table_names(raw_sql, dialect=source_dialect)
             replace_map = self._get_sql_table_bindings(
                 data_source,
                 tables,
@@ -784,17 +780,14 @@ class IbisQueryBuilder:
 
         return transpiled_sql[0]
 
-    def _get_sql_table_names(
-        self,
-        raw_sql: str,
-        dialect: sg.Dialect | None,
-        use_live_connection: bool,
-    ) -> set[str]:
+    def _get_sql_table_names(self, raw_sql: str, dialect: sg.Dialect | None) -> set[str]:
         tables = set()
         for table_ref in extract_sql_table_refs(raw_sql, dialect=dialect):
-            if not use_live_connection and (table_ref.db or table_ref.catalog):
+            # a binding is looked up by the bare name, so a qualified reference would
+            # bind the same-named table in the default schema — a different table
+            if table_ref.db or table_ref.catalog:
                 frappe.throw(
-                    "Schema-qualified table names are not supported with Data Store for native queries yet",
+                    "Schema-qualified table names are not supported for native queries yet",
                     title="Unsupported SQL Query",
                 )
 
@@ -848,13 +841,10 @@ class IbisQueryBuilder:
         if not replace_map:
             return raw_sql
 
-        try:
-            statements = sg.parse(raw_sql, dialect=dialect)
-        except Exception as e:
-            frappe.throw(
-                f"Failed to apply permissions to the SQL query: {e}",
-                title="Unsupported SQL Query",
-            )
+        # `sg.parse` over `sg.parse_one`: only `parse` reports every statement on
+        # every sqlglot version, and a statement dropped here is a statement that
+        # never runs. An empty one — a stray `;` — parses to None.
+        statements = [statement for statement in sg.parse(raw_sql, dialect=dialect) if statement]
 
         for statement in statements:
             # collect first: the replacements carry their own table references,
@@ -871,7 +861,7 @@ class IbisQueryBuilder:
                 subquery.set("alias", alias)
                 table_exp.replace(subquery)
 
-        return ";\n".join(statement.sql(dialect=dialect) for statement in statements if statement)
+        return ";\n".join(statement.sql(dialect=dialect) for statement in statements)
 
     def apply_code(self, code_args):
         code = code_args.code

--- a/insights/insights/doctype/insights_data_source_v3/ibis_utils.py
+++ b/insights/insights/doctype/insights_data_source_v3/ibis_utils.py
@@ -747,14 +747,17 @@ class IbisQueryBuilder:
     def _validate_native_sql(self, raw_sql: str, use_live_connection: bool) -> str:
         raw_sql = raw_sql.strip()
 
-        if not use_live_connection:
-            statements = [stmt for stmt in sqlparse.parse(raw_sql) if stmt.tokens and stmt.value.strip()]
-            if len(statements) > 1:
-                frappe.throw(
-                    "Multiple SQL statements are not supported with Data Store for native queries",
-                    title="Unsupported SQL Query",
-                )
+        # one statement, on every path: ibis cannot run two — `db.sql` on a pair
+        # fails while it reads the schema — and both rewrites below read the first
+        # statement only, so a second one would be dropped rather than refused
+        statements = [stmt for stmt in sqlparse.parse(raw_sql) if stmt.tokens and stmt.value.strip()]
+        if len(statements) > 1:
+            frappe.throw(
+                frappe._("Multiple SQL statements are not supported for native queries"),
+                title=frappe._("Unsupported SQL Query"),
+            )
 
+        if not use_live_connection:
             if raw_sql.lower().startswith("exec"):
                 frappe.throw(
                     "Stored procedures are not supported with Data Store for native queries",
@@ -872,7 +875,8 @@ class IbisQueryBuilder:
 
         Dropping back below sqlglot 28 is not open to us — frappe needs 30. Nesting
         the statement leaves the outer query with no CTE, so ibis re-attaches
-        nothing. Remove this once ibis pops the right key.
+        nothing. ibis 12 no longer pops that key at all, so drop this when the
+        `ibis-framework` pin moves off 11.
         """
         try:
             parsed = sg.parse_one(raw_sql, dialect=dialect)
@@ -883,7 +887,9 @@ class IbisQueryBuilder:
         if not parsed.ctes:
             return raw_sql
 
-        return f"SELECT * FROM ({raw_sql}) AS {NATIVE_SQL_RELATION}"
+        # nest what was parsed, not the text it came from: the text can carry a
+        # trailing semicolon, and that would land inside the brackets
+        return f"SELECT * FROM ({parsed.sql(dialect=dialect)}) AS {NATIVE_SQL_RELATION}"
 
     def apply_code(self, code_args):
         code = code_args.code

--- a/insights/insights/doctype/insights_data_source_v3/ibis_utils.py
+++ b/insights/insights/doctype/insights_data_source_v3/ibis_utils.py
@@ -790,7 +790,7 @@ class IbisQueryBuilder:
             # bind the same-named table in the default schema — a different table
             if table_ref.db or table_ref.catalog:
                 frappe.throw(
-                    "Schema-qualified table names are not supported for native queries yet",
+                    frappe._("Schema-qualified table names are not supported for native queries yet"),
                     title="Unsupported SQL Query",
                 )
 

--- a/insights/insights/query_utils.py
+++ b/insights/insights/query_utils.py
@@ -13,11 +13,7 @@ def extract_sql_table_refs(raw_sql: str, dialect: sg.Dialect | None = None) -> l
         # In the future, we may want to log these exceptions to help improve our SQL parsing capabilities.
         return []
 
-    cte_aliases = {
-        str(alias)
-        for cte_exp in parsed.find_all(sg.exp.CTE)
-        if (alias := getattr(cte_exp, "alias_or_name", None) or cte_exp.alias)
-    }
+    cte_aliases = {cte_exp.alias_or_name for cte_exp in parsed.find_all(sg.exp.CTE) if cte_exp.alias_or_name}
 
     table_refs = []
     seen_refs = set()

--- a/insights/insights/query_utils.py
+++ b/insights/insights/query_utils.py
@@ -7,10 +7,7 @@ import sqlglot as sg
 
 def extract_sql_table_refs(raw_sql: str, dialect: sg.Dialect | None = None) -> list[frappe._dict]:
     try:
-        # `sg.parse` over `sg.parse_one`: only `parse` reports every statement on
-        # every sqlglot version, and a statement missed here is a table nobody
-        # checks. An empty statement — a stray `;` — parses to None.
-        statements = [statement for statement in sg.parse(raw_sql, dialect=dialect) if statement]
+        parsed = sg.parse_one(raw_sql, dialect=dialect)
     except Exception:
         # If parsing fails, we return an empty list to avoid blocking the user from saving their query.
         # In the future, we may want to log these exceptions to help improve our SQL parsing capabilities.
@@ -18,30 +15,28 @@ def extract_sql_table_refs(raw_sql: str, dialect: sg.Dialect | None = None) -> l
 
     cte_aliases = {
         str(alias)
-        for statement in statements
-        for cte_exp in statement.find_all(sg.exp.CTE)
+        for cte_exp in parsed.find_all(sg.exp.CTE)
         if (alias := getattr(cte_exp, "alias_or_name", None) or cte_exp.alias)
     }
 
     table_refs = []
     seen_refs = set()
-    for statement in statements:
-        for table_exp in statement.find_all(sg.exp.Table):
-            table_name = table_exp.name
-            if not table_name or table_name in cte_aliases:
-                continue
+    for table_exp in parsed.find_all(sg.exp.Table):
+        table_name = table_exp.name
+        if not table_name or table_name in cte_aliases:
+            continue
 
-            table_ref = frappe._dict(
-                name=table_name,
-                db=str(table_exp.db) if table_exp.db else None,
-                catalog=str(table_exp.catalog) if table_exp.catalog else None,
-            )
-            ref_key = (table_ref.name, table_ref.db, table_ref.catalog)
-            if ref_key in seen_refs:
-                continue
+        table_ref = frappe._dict(
+            name=table_name,
+            db=str(table_exp.db) if table_exp.db else None,
+            catalog=str(table_exp.catalog) if table_exp.catalog else None,
+        )
+        ref_key = (table_ref.name, table_ref.db, table_ref.catalog)
+        if ref_key in seen_refs:
+            continue
 
-            seen_refs.add(ref_key)
-            table_refs.append(table_ref)
+        seen_refs.add(ref_key)
+        table_refs.append(table_ref)
 
     return table_refs
 

--- a/insights/insights/query_utils.py
+++ b/insights/insights/query_utils.py
@@ -7,7 +7,10 @@ import sqlglot as sg
 
 def extract_sql_table_refs(raw_sql: str, dialect: sg.Dialect | None = None) -> list[frappe._dict]:
     try:
-        parsed = sg.parse_one(raw_sql, dialect=dialect)
+        # `sg.parse` over `sg.parse_one`: only `parse` reports every statement on
+        # every sqlglot version, and a statement missed here is a table nobody
+        # checks. An empty statement — a stray `;` — parses to None.
+        statements = [statement for statement in sg.parse(raw_sql, dialect=dialect) if statement]
     except Exception:
         # If parsing fails, we return an empty list to avoid blocking the user from saving their query.
         # In the future, we may want to log these exceptions to help improve our SQL parsing capabilities.
@@ -15,28 +18,30 @@ def extract_sql_table_refs(raw_sql: str, dialect: sg.Dialect | None = None) -> l
 
     cte_aliases = {
         str(alias)
-        for cte_exp in parsed.find_all(sg.exp.CTE)
+        for statement in statements
+        for cte_exp in statement.find_all(sg.exp.CTE)
         if (alias := getattr(cte_exp, "alias_or_name", None) or cte_exp.alias)
     }
 
     table_refs = []
     seen_refs = set()
-    for table_exp in parsed.find_all(sg.exp.Table):
-        table_name = table_exp.name
-        if not table_name or table_name in cte_aliases:
-            continue
+    for statement in statements:
+        for table_exp in statement.find_all(sg.exp.Table):
+            table_name = table_exp.name
+            if not table_name or table_name in cte_aliases:
+                continue
 
-        table_ref = frappe._dict(
-            name=table_name,
-            db=str(table_exp.db) if table_exp.db else None,
-            catalog=str(table_exp.catalog) if table_exp.catalog else None,
-        )
-        ref_key = (table_ref.name, table_ref.db, table_ref.catalog)
-        if ref_key in seen_refs:
-            continue
+            table_ref = frappe._dict(
+                name=table_name,
+                db=str(table_exp.db) if table_exp.db else None,
+                catalog=str(table_exp.catalog) if table_exp.catalog else None,
+            )
+            ref_key = (table_ref.name, table_ref.db, table_ref.catalog)
+            if ref_key in seen_refs:
+                continue
 
-        seen_refs.add(ref_key)
-        table_refs.append(table_ref)
+            seen_refs.add(ref_key)
+            table_refs.append(table_ref)
 
     return table_refs
 

--- a/insights/tests/test_native_sql_rewrite.py
+++ b/insights/tests/test_native_sql_rewrite.py
@@ -1,0 +1,95 @@
+import frappe
+import sqlglot as sg
+
+from insights.insights.doctype.insights_data_source_v3.ibis_utils import IbisQueryBuilder
+from insights.tests.base import InsightsIntegrationTestCase
+
+SITE_DB = "Site DB"
+
+
+class TestNativeSQLTableRewrite(InsightsIntegrationTestCase):
+    """A native SQL query reads its tables through a permission-filtered select.
+
+    The rewrite replaces each table reference in place. It used to prepend one CTE
+    per table, which made the CTE name a collision surface.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.data_source = frappe.get_doc("Insights Data Source v3", SITE_DB)
+        self.dialect = self.data_source.get_sqlglot_dialect()
+        self.builder = IbisQueryBuilder(
+            frappe._dict(
+                name="Native SQL Rewrite Test",
+                title="Native SQL Rewrite Test",
+                use_live_connection=1,
+                operations=frappe.as_json([]),
+            )
+        )
+
+    def rewrite(self, raw_sql, replace_map=None):
+        if replace_map is None:
+            tables = self.builder._get_sql_table_names(
+                raw_sql, dialect=self.dialect, use_live_connection=True
+            )
+            replace_map = self.builder._get_sql_table_bindings(
+                SITE_DB,
+                tables,
+                dialect=self.dialect,
+                use_live_connection=True,
+                check_permissions=False,
+            )
+        return self.builder._replace_sql_tables(raw_sql, replace_map, dialect=self.dialect)
+
+    def cte_names(self, sql):
+        parsed = sg.parse_one(sql, dialect=self.dialect)
+        return [cte.alias_or_name for cte in parsed.find_all(sg.exp.CTE)]
+
+    def execute(self, sql):
+        return self.data_source._get_ibis_backend().sql(sql).execute()
+
+    def test_two_spellings_of_one_table_produce_no_cte(self):
+        # MariaDB matches CTE names case-insensitively, so a CTE per spelling was
+        # rejected with "Duplicate query name". A reference carries no name.
+        raw_sql = "select a.name from `tabUser` a join tabuser b on a.name = b.name"
+        replace_map = {
+            "tabUser": "SELECT * FROM `tabUser`",
+            "tabuser": "SELECT * FROM `tabuser`",
+        }
+
+        rewritten = self.rewrite(raw_sql, replace_map)
+
+        self.assertEqual(self.cte_names(rewritten), [])
+        self.assertEqual(rewritten.count("SELECT * FROM `tabUser`"), 1)
+        self.assertEqual(rewritten.count("SELECT * FROM `tabuser`"), 1)
+
+    def test_table_name_needing_quotes_runs_on_the_source(self):
+        # the alias used to be rendered with sqlglot's default dialect, which gave
+        # MariaDB a string literal instead of an identifier
+        rewritten = self.rewrite("select name from `tabInsights Table v3` limit 1")
+
+        self.assertIn("`tabInsights Table v3`", rewritten)
+        self.execute(rewritten)
+
+    def test_unaliased_reference_keeps_the_table_name(self):
+        rewritten = self.rewrite("select `tabUser`.name from `tabUser` limit 1")
+
+        self.execute(rewritten)
+
+    def test_aliased_reference_keeps_its_alias(self):
+        rewritten = self.rewrite("select u.name from `tabUser` u limit 1")
+
+        self.execute(rewritten)
+
+    def test_the_query_keeps_its_own_cte(self):
+        raw_sql = "with recent as (select name from `tabUser`) select * from recent limit 1"
+
+        rewritten = self.rewrite(raw_sql)
+
+        self.assertEqual(self.cte_names(rewritten), ["recent"])
+        self.execute(rewritten)
+
+    def test_sql_is_untouched_when_no_table_is_bound(self):
+        raw_sql = "select 1 as one"
+
+        self.assertEqual(self.rewrite(raw_sql, {}), raw_sql)

--- a/insights/tests/test_native_sql_rewrite.py
+++ b/insights/tests/test_native_sql_rewrite.py
@@ -80,6 +80,32 @@ class TestNativeSQL(InsightsIntegrationTestCase):
 
         self.assertEqual(len(rows), 1)
 
+    def test_a_trailing_semicolon_survives_the_nesting(self):
+        # the nesting brackets the query, and a semicolon inside them is a syntax error
+        rows = self.run_native_sql(
+            "with recent as (select name from `tabUser` limit 1) select * from recent;"
+        )
+
+        self.assertEqual(len(rows), 1)
+
+    def test_a_rewritten_query_that_opens_with_a_cte_runs(self):
+        # the two rewrites meet here: the tables are replaced, then the result is nested
+        raw_sql = "with recent as (select name from `tabUser` limit 1) select * from recent"
+        rewritten = self.rewrite(raw_sql, {"tabUser": "SELECT * FROM `tabUser`"})
+
+        rows = (
+            self.data_source._get_ibis_backend()
+            .sql(self.builder._hide_ctes_from_ibis(rewritten, dialect=self.dialect))
+            .execute()
+        )
+
+        self.assertEqual(len(rows), 1)
+
+    def test_more_than_one_statement_is_refused(self):
+        # ibis runs one statement, and both rewrites read the first one only
+        with self.assertRaises(frappe.ValidationError):
+            self.run_native_sql("select 1 as one; select 2 as two")
+
     # --- the permission rewrite ---
 
     def test_two_spellings_of_one_table_produce_no_cte(self):

--- a/insights/tests/test_native_sql_rewrite.py
+++ b/insights/tests/test_native_sql_rewrite.py
@@ -7,25 +7,33 @@ from insights.tests.base import InsightsIntegrationTestCase
 SITE_DB = "Site DB"
 
 
-class TestNativeSQLTableRewrite(InsightsIntegrationTestCase):
+class TestNativeSQL(InsightsIntegrationTestCase):
     """A native SQL query reads its tables through a permission-filtered select.
 
-    The rewrite replaces each table reference in place. It used to prepend one CTE
-    per table, which made the CTE name a collision surface.
+    Two things used to put a `WITH` clause in front of the query the database runs:
+    the permission rewrite named a CTE after each table, and ibis re-attached the
+    query's own CTEs without clearing them first. Both ended in MariaDB's
+    "Duplicate query name".
     """
 
     def setUp(self):
         super().setUp()
         self.data_source = frappe.get_doc("Insights Data Source v3", SITE_DB)
         self.dialect = self.data_source.get_sqlglot_dialect()
-        self.builder = IbisQueryBuilder(
-            frappe._dict(
-                name="Native SQL Rewrite Test",
-                title="Native SQL Rewrite Test",
-                use_live_connection=1,
-                operations=frappe.as_json([]),
-            )
+        self.builder = IbisQueryBuilder(self.make_query_doc([]))
+
+    def make_query_doc(self, operations):
+        return frappe._dict(
+            name="Native SQL Test",
+            title="Native SQL Test",
+            use_live_connection=1,
+            operations=frappe.as_json(operations),
         )
+
+    def run_native_sql(self, raw_sql):
+        """Execute `raw_sql` the way a native query operation does."""
+        operations = [{"type": "sql", "data_source": SITE_DB, "raw_sql": raw_sql}]
+        return IbisQueryBuilder(self.make_query_doc(operations)).build().execute()
 
     def rewrite(self, raw_sql, replace_map=None):
         if replace_map is None:
@@ -47,8 +55,32 @@ class TestNativeSQLTableRewrite(InsightsIntegrationTestCase):
         parsed = sg.parse_one(sql, dialect=self.dialect)
         return sorted(table.name for table in parsed.find_all(sg.exp.Table))
 
-    def execute(self, sql):
-        return self.data_source._get_ibis_backend().sql(sql).execute()
+    # --- the query the database runs ---
+
+    def test_a_query_that_opens_with_a_cte_runs(self):
+        # ibis 11 re-attaches a query's CTEs without clearing them first, because
+        # sqlglot 28 renamed the key it clears. MariaDB rejects the doubled pair.
+        rows = self.run_native_sql("with recent as (select name from `tabUser` limit 1) select * from recent")
+
+        self.assertEqual(len(rows), 1)
+
+    def test_a_query_with_several_ctes_runs(self):
+        rows = self.run_native_sql(
+            """
+            with one as (select name from `tabUser` limit 1),
+                 two as (select name from one)
+            select * from two
+            """
+        )
+
+        self.assertEqual(len(rows), 1)
+
+    def test_a_query_without_a_cte_runs(self):
+        rows = self.run_native_sql("select name from `tabUser` limit 1")
+
+        self.assertEqual(len(rows), 1)
+
+    # --- the permission rewrite ---
 
     def test_two_spellings_of_one_table_produce_no_cte(self):
         # MariaDB matches CTE names case-insensitively, so a CTE per spelling was
@@ -71,17 +103,16 @@ class TestNativeSQLTableRewrite(InsightsIntegrationTestCase):
         rewritten = self.rewrite("select name from `tabInsights Table v3` limit 1")
 
         self.assertIn("`tabInsights Table v3`", rewritten)
-        self.execute(rewritten)
 
     def test_unaliased_reference_keeps_the_table_name(self):
         rewritten = self.rewrite("select `tabUser`.name from `tabUser` limit 1")
 
-        self.execute(rewritten)
+        self.assertIn("AS `tabUser`", rewritten)
 
     def test_aliased_reference_keeps_its_alias(self):
         rewritten = self.rewrite("select u.name from `tabUser` u limit 1")
 
-        self.execute(rewritten)
+        self.assertIn("AS u", rewritten)
 
     def test_the_query_keeps_its_own_cte(self):
         raw_sql = "with recent as (select name from `tabUser`) select * from recent limit 1"
@@ -89,17 +120,11 @@ class TestNativeSQLTableRewrite(InsightsIntegrationTestCase):
         rewritten = self.rewrite(raw_sql)
 
         self.assertEqual(self.cte_names(rewritten), ["recent"])
-        self.execute(rewritten)
 
     def test_sql_is_untouched_when_no_table_is_bound(self):
         raw_sql = "select 1 as one"
 
         self.assertEqual(self.rewrite(raw_sql, {}), raw_sql)
-
-    def test_an_empty_statement_does_not_break_the_rewrite(self):
-        rewritten = self.rewrite("select `tabUser`.name from `tabUser` limit 1;;")
-
-        self.execute(rewritten)
 
     def test_a_schema_qualified_table_is_refused(self):
         # the binding is looked up by the bare name, so reading `sales.orders`

--- a/insights/tests/test_native_sql_rewrite.py
+++ b/insights/tests/test_native_sql_rewrite.py
@@ -29,9 +29,7 @@ class TestNativeSQLTableRewrite(InsightsIntegrationTestCase):
 
     def rewrite(self, raw_sql, replace_map=None):
         if replace_map is None:
-            tables = self.builder._get_sql_table_names(
-                raw_sql, dialect=self.dialect, use_live_connection=True
-            )
+            tables = self.builder._get_sql_table_names(raw_sql, dialect=self.dialect)
             replace_map = self.builder._get_sql_table_bindings(
                 SITE_DB,
                 tables,
@@ -44,6 +42,10 @@ class TestNativeSQLTableRewrite(InsightsIntegrationTestCase):
     def cte_names(self, sql):
         parsed = sg.parse_one(sql, dialect=self.dialect)
         return [cte.alias_or_name for cte in parsed.find_all(sg.exp.CTE)]
+
+    def table_names(self, sql):
+        parsed = sg.parse_one(sql, dialect=self.dialect)
+        return sorted(table.name for table in parsed.find_all(sg.exp.Table))
 
     def execute(self, sql):
         return self.data_source._get_ibis_backend().sql(sql).execute()
@@ -59,9 +61,9 @@ class TestNativeSQLTableRewrite(InsightsIntegrationTestCase):
 
         rewritten = self.rewrite(raw_sql, replace_map)
 
+        # each reference reads its own binding, and neither carries a name
         self.assertEqual(self.cte_names(rewritten), [])
-        self.assertEqual(rewritten.count("SELECT * FROM `tabUser`"), 1)
-        self.assertEqual(rewritten.count("SELECT * FROM `tabuser`"), 1)
+        self.assertEqual(self.table_names(rewritten), ["tabUser", "tabuser"])
 
     def test_table_name_needing_quotes_runs_on_the_source(self):
         # the alias used to be rendered with sqlglot's default dialect, which gave
@@ -93,3 +95,14 @@ class TestNativeSQLTableRewrite(InsightsIntegrationTestCase):
         raw_sql = "select 1 as one"
 
         self.assertEqual(self.rewrite(raw_sql, {}), raw_sql)
+
+    def test_an_empty_statement_does_not_break_the_rewrite(self):
+        rewritten = self.rewrite("select `tabUser`.name from `tabUser` limit 1;;")
+
+        self.execute(rewritten)
+
+    def test_a_schema_qualified_table_is_refused(self):
+        # the binding is looked up by the bare name, so reading `sales.orders`
+        # would bind whichever `orders` the default schema holds
+        with self.assertRaises(frappe.ValidationError):
+            self.builder._get_sql_table_names("select * from sales.orders", dialect=self.dialect)


### PR DESCRIPTION
Every native SQL query holding a `WITH` clause fails on v3.12.6:

```
(4004, 'Duplicate query name `ticket_data` in WITH clause')
```

Two causes put a duplicate name in the `WITH` list.

## 1. ibis writes the query's own CTEs twice

ibis 11 clears a parsed statement's `WITH` clause before re-attaching it:

```python
compiled_query.args.pop("with", None)          # ibis/backends/sql/compilers/base.py
parsed = reduce(lambda parsed, cte: parsed.with_(...), ctes, compiled_query)
```

sqlglot 28 renamed that key to `with_`, so the clear became a no-op:

```sql
-- what you write
WITH recent AS (SELECT name FROM `tabUser`) SELECT * FROM recent

-- what ibis compiles
WITH recent AS (SELECT name FROM `tabUser`), recent AS (SELECT name FROM `tabUser`)
SELECT * FROM recent
```

#1299 moved the pin from `sqlglot<28.0.0` to `>=30.12.0,<31`, for frappe/frappe#41956. v3.12.6 shipped six days later.

Going back below 28 is not open to us, so hand ibis a statement with no top-level CTE — `SELECT * FROM (<the query>) AS _insights_native_sql`. ibis 12 drops the offending `pop` entirely, so this goes when the ibis pin moves.

## 2. The permission rewrite names a CTE after the table

A native query reads each table through a permission-filtered select, spliced in as a CTE named after the table. The name is the collision surface, and it collides two ways.

**MariaDB matches CTE names case-insensitively:**

```sql
select a.name from `tabTask` a join tabtask b on a.name = b.parent_task
--> WITH tabTask AS (...), tabtask AS (...) select ...
-- (4004, 'Duplicate query name `tabtask` in WITH clause')
```

**The name has to be quoted for the source dialect.** `f"{sg.to_identifier(name)}"` renders sqlglot's default dialect, so a table name with a space came out double-quoted — a string to MariaDB, not an identifier:

```sql
WITH "tabHD Ticket" AS (...) select ...
-- (1064, 'You have an error in your SQL syntax ...')
```

Replace the table reference instead of shadowing its name. A reference carries no name, so no spelling can collide, and sqlglot writes the alias in the right dialect. An unaliased reference keeps the table name as its alias, so a qualified column still resolves:

```sql
select `tabTask`.name from `tabTask`
--> SELECT `tabTask`.name FROM (SELECT * FROM `tabTask`) AS `tabTask`
```

Folding the case instead does not work: sqlglot marks MySQL identifiers case-sensitive, whether two spellings are one table depends on the server's `lower_case_table_names`, and on Postgres `"tabTask"` and `tabtask` really are two tables.

## Also here

- A schema-qualified reference is refused on live connections, not only on the data store. A binding is looked up by the bare name, so `sales.orders` bound whichever `orders` the default schema holds.
- More than one statement is refused on every path. ibis cannot run two, and the rewrites read the first only.

## Tests

`insights/tests/test_native_sql_rewrite.py`. No test built a `sql` operation before this, which is why a dependency bump took the whole path out unnoticed.