### PR TITLE
fix: accept a numeric workbook name on insert

### DIFF
--- a/insights/insights/doctype/insights_workbook/insights_workbook.py
+++ b/insights/insights/doctype/insights_workbook/insights_workbook.py
@@ -35,6 +35,12 @@ class InsightsWorkbook(Document):
         title: DF.Data
     # end: auto-generated types
 
+    def before_naming(self):
+        # a fixture or export written while this doctype was still `autoincrement` carries a
+        # numeric name, and the column is varchar now — `validate_name` throws on an int
+        if isinstance(self.name, int):
+            self.name = str(self.name)
+
     def autoname(self):
         # plain numbers, carrying on from where `autoincrement` left off — see
         # insights/patches/name_workbooks_as_strings.py for why this needs to be a string.

--- a/insights/tests/test_workbook_naming.py
+++ b/insights/tests/test_workbook_naming.py
@@ -1,0 +1,25 @@
+"""A workbook exported before the naming change carries a numeric name.
+
+`Insights Workbook` used to be named by `autoincrement`, so a fixture written on an
+older site holds `"name": 12`. The column is varchar now, and `validate_name` throws
+on an int. Such a fixture is already shipped in other apps, so the import has to keep
+working (frappe/insights#1193).
+"""
+
+import frappe
+
+from insights.tests.base import InsightsIntegrationTestCase
+
+
+class TestWorkbookNaming(InsightsIntegrationTestCase):
+    def test_numeric_name_is_stored_as_string(self):
+        frappe.flags.in_import = True
+        try:
+            workbook = frappe.get_doc(
+                {"doctype": "Insights Workbook", "name": 999999, "title": "Imported"}
+            ).insert()
+        finally:
+            frappe.flags.in_import = False
+
+        self.addCleanup(frappe.delete_doc, "Insights Workbook", workbook.name, force=True)
+        self.assertEqual(workbook.name, "999999")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "SQLAlchemy==2.0.41",
     "python-telegram-bot==21.4",
     "duckdb~=1.4.3",
-    "sqlglot>=30.12.0,<31",
+    "sqlglot>=30.12.0,<30.18",
     "ibis-framework~=11.0.0",
     "ibis-framework[duckdb]",
     "ibis-framework[mysql]",


### PR DESCRIPTION
`Insights Workbook` used to be named by `autoincrement`. A fixture or export written on a site running that version carries `"name": 12`. The column is varchar since #1193, and `validate_name` throws `Invalid name type (integer) for varchar name column` on an int.

`sync_fixtures` only catches `ImportError` and `DoesNotExistError`, so the throw kills `bench migrate` outright on any site whose apps ship such a fixture. Re-exporting the fixture fixes it, but the fixtures are already out there.

`before_naming` runs before `validate_name`, so the cast lands there and covers every insert path.

Measured on MariaDB: a `workbook` link value that is an int is coerced to a string on write and compares fine, so the doctypes that link a workbook need nothing. On postgres such a fixture never reaches this code — `import_file` calls `frappe.db.exists(doctype, 12)` first, and that comparison throws.