### PR TITLE
ci: fix the compatibility matrix environment

### DIFF
--- a/.github/workflows/compat-matrix.yml
+++ b/.github/workflows/compat-matrix.yml
@@ -6,6 +6,10 @@ on:
     - cron: '0 2 * * *'
   workflow_dispatch:
 
+concurrency:
+  group: compat-matrix-${{ github.event_name }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -17,21 +21,49 @@ jobs:
       matrix:
         insights_branch: [main, version-3, develop]
         frappe_branch: [version-15, version-16]
+        exclude:
+          # main is Insights v2, which never targeted Frappe v16
+          - insights_branch: main
+            frappe_branch: version-16
 
     name: Install (Insights=${{ matrix.insights_branch }}, Frappe=${{ matrix.frappe_branch }})
 
     services:
       mariadb:
-        image: mariadb:10.6
+        # Each Frappe branch runs the MariaDB its own CI runs
+        image: mariadb:${{ matrix.frappe_branch == 'version-16' && '11.8' || '10.6' }}
         env:
           MYSQL_ROOT_PASSWORD: root
         ports:
           - 3306:3306
         options: >-
-          --health-cmd="mysqladmin ping"
+          --health-cmd="healthcheck.sh --connect --innodb_initialized"
           --health-interval=5s
           --health-timeout=2s
-          --health-retries=3
+          --health-retries=10
+
+      # bench keeps the default redis hosts even when it skips config
+      # generation, so these ports must answer. Frappe v16 raises a redis
+      # connection error where v15 only warns.
+      redis-cache:
+        image: redis:8-alpine
+        ports:
+          - 13000:6379
+        options: >-
+          --health-cmd="redis-cli ping"
+          --health-interval=5s
+          --health-timeout=2s
+          --health-retries=5
+
+      redis-queue:
+        image: redis:8-alpine
+        ports:
+          - 11000:6379
+        options: >-
+          --health-cmd="redis-cli ping"
+          --health-interval=5s
+          --health-timeout=2s
+          --health-retries=5
 
     env:
       BENCH_PATH: /home/runner/frappe-bench
@@ -41,17 +73,17 @@ jobs:
 
     steps:
       - name: Checkout Insights
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ matrix.insights_branch }}
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.frappe_branch == 'version-16' && '3.14' || '3.10' }}
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.frappe_branch == 'version-16' && '24' || '20' }}
 
@@ -87,3 +119,45 @@ jobs:
             --admin-password "$ADMIN_PASSWORD"
           bench --site "$SITE_NAME" install-app insights
           bench --site "$SITE_NAME" run-tests --app insights --module insights.tests.test_basic_workflow
+
+  report-failure:
+    name: Report failure
+    needs: install-matrix
+    if: ${{ failure() && github.event_name == 'schedule' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      # A scheduled run has no reviewer. Without this the matrix stays red
+      # unnoticed, which it did for a week.
+      - name: Open or update the tracking issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh label create compat-matrix \
+            --repo "$GITHUB_REPOSITORY" \
+            --description "Nightly Frappe compatibility matrix" \
+            --color d73a4a \
+            --force
+
+          existing=$(gh issue list \
+            --repo "$GITHUB_REPOSITORY" \
+            --state open \
+            --label compat-matrix \
+            --limit 1 \
+            --json number \
+            --jq '.[0].number')
+
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" \
+              --repo "$GITHUB_REPOSITORY" \
+              --body "Still failing: $RUN_URL"
+          else
+            gh issue create \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "Nightly compatibility matrix is failing" \
+              --label compat-matrix \
+              --body "The nightly compatibility matrix failed. Run: $RUN_URL"
+          fi

--- a/README.md
+++ b/README.md
@@ -175,13 +175,15 @@ To setup the repository locally follow the steps mentioned below:
 
 ## Compatibility Matrix
 
-| Insights Branch | Frappe Framework Version            | Node Version |
-|-----------------|-------------------------------------|--------------|
-| main            | version-14, version-15              | v18+         |
-| version-3       | version-14, version-15              | v18+         |
-| develop         | develop                             | v20+         |
+A [nightly workflow](.github/workflows/compat-matrix.yml) installs each branch and runs the test suite. It verifies these combinations:
 
-> Note: Frappe v14 supports Node v14 and above, but Insights requires Node v18 and above. So, while using Insights with Frappe v14, please ensure that Node v18+ is installed.
+| Insights Branch | Frappe Framework       | Node   | Python     |
+|-----------------|------------------------|--------|------------|
+| main            | version-15             | 20     | 3.10       |
+| version-3       | version-15, version-16 | 20, 24 | 3.10, 3.14 |
+| develop         | version-15, version-16 | 20, 24 | 3.10, 3.14 |
+
+> Note: the Node column lists the versions CI runs, not the minimum. Each branch declares its own minimum in `frontend/package.json`: `>=16.0.0` on main, `>=18` on version-3, `>=20.19.0` on develop.
 
 ## Learn and connect
 


### PR DESCRIPTION
The nightly matrix has been red since it started testing Frappe v16. `main` + `version-16` was the only failing cell, and the cause was not a v2/v16 incompatibility:

```
redis.exceptions.ConnectionError: Error 111 connecting to 127.0.0.1:13000. Connection refused.
AssertionError: Should not fail silently in tests
```

No job in the matrix ran redis. The five green cells printed `WARN Cannot connect to redis_cache` and passed anyway, because Frappe v15 swallows that error. So the red cell was the only honest one.

Review notes:

- The MariaDB image is now keyed on the Frappe branch. Frappe v15 CI runs 10.6, Frappe develop CI runs 11.8. A single image would test a branch on a database its own CI never sees.
- `--skip-redis-config-generation` stays. It only skips the `config/redis_*.conf` files `bench start` reads, and this workflow never runs `bench start`. The host keys in `common_site_config.json` are unaffected, which is why the ports must answer.
- `main` + `version-16` is excluded on its own merit: `main` is Insights v2, which never targeted v16.
- The README table had drifted since d781c0d dropped version-14 from the matrix in January.

Unverified until this merges: `workflow_dispatch` reads the workflow from the default branch, so the run cannot be tested from the branch. If the fix works, `main` + `version-15` stops printing the redis warning.