### PR TITLE
fix: keep one record per remote table when its name changes

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -58,6 +58,14 @@ _Avoid_: connection
 **Table**:
 A table exposed by a data source, selectable as a query's source.
 
+**Table Name**:
+The string that names a Table — `Insights Table v3.table`. Every referrer quotes it,
+and the record's key derives from it. A postgres name carries a `<schema>.` prefix
+while the Data Source reads several schemas, so the name can change while the table
+does not. A rename therefore has to move every referrer. See
+`docs/adr/the-schema-is-a-coordinate-not-a-name.md`.
+_Avoid_: table id, table key
+
 **Table Link**:
 A stored join relationship between two tables, used to suggest joins.
 

--- a/docs/adr/the-schema-is-a-coordinate-not-a-name.md
+++ b/docs/adr/the-schema-is-a-coordinate-not-a-name.md
@@ -1,0 +1,133 @@
+# The schema is a coordinate, not part of a table's name
+
+Date: 2026-09-07
+
+## Status
+
+Accepted. Interim — see "Where this is going".
+
+## Context
+
+`Insights Table v3` derives its primary key from the table it names:
+
+```python
+def autoname(self):
+    self.name = get_table_name(self.data_source, self.table)   # md5(data_source + table)
+```
+
+That same string is what every referrer quotes. A query names its source as
+`{data_source, table_name}` in the operations JSON. A Table Link, an
+`Insights Query Reference` and an import log all name it the same way. A grant
+names the derived key.
+
+Postgres puts the schema in that string, but only when the Data Source reads
+from more than one schema. `frappe/insights#1254` made it conditional to fix
+`frappe/insights#1195`, where an unconditional `public.` prefix broke the table
+to doctype mapping and leaked into the UI.
+
+The condition reads the `schema` field of the Data Source. So a field a person
+can edit decides how every Table under it is named. Remove one schema from that
+field and every stored name is the wrong one.
+
+The table list sync compared the remote names to the stored names as strings:
+
+```python
+new_tables = set(remote_tables) - set(existing_tables)
+```
+
+A re-named table therefore read as a table never seen. The sync created a second
+record and kept the first. Both stayed `stored = 1`, so the daily Table Import
+ran twice against one remote table and took the Data Store write lock twice. A
+production site reported 22 such pairs out of ~84 tables
+(`frappe/insights#1371`).
+
+The duplicate is the visible cost. The design cost is larger. Seven pieces of
+code exist only because the schema sits inside the name: `qualify_table_names`
+decides whether to encode it, `format_table_name` encodes it,
+`split_table_name` decodes it, `strip_schema_prefix` decodes it again for the
+doctype mapping, `table_identity` undoes the encoding to compare,
+`reconcile_table_names` finds the records the encoding stranded, and
+`table_rename` rewrites six referrers when the encoding changes.
+
+## Decision
+
+**A Table's stored name must not encode anything that can change.**
+
+Until the schema leaves the name, the sync holds the line. It resolves every
+remote name and every stored name to the table it points at, and compares those.
+On a match it renames the record. Where both names already exist it merges them,
+so a site the old sync duplicated repairs itself on the next sync.
+
+Two supporting choices:
+
+- **A merge moves the whole record, not only its Data Store copy.** On an
+  affected site the survivor is the duplicate the sync made, so the grants, the
+  row restrictions and the import settings all sit on the record being folded
+  in. Only `stored`, `last_synced_on` and `last_sync_bookmark` wait on the copy
+  moving. A cleared `stored` re-imports on the next read. A cursor column a
+  person typed does not come back.
+- **A Data Store failure never aborts a rename.** The write lock is held for the
+  length of a Table Import, so a drop or a rename can time out at any moment. An
+  undropped table is an Unexplained Orphan, which the weekly cleanup already
+  finds and reports. A half-renamed set of records is not recoverable.
+
+Rejected: **qualify every postgres name, always.** This is the shortest route to
+one name per table, and it is blocked. `insights/workbook_templates/` names 13
+tables as bare `tab...` strings. So does every exported workbook, and every
+template another app ships through the `insights_workbook_templates` hook. The
+bare name is the portable name. Qualifying the stored name breaks all of them on
+a postgres site. It also keeps the rename, because existing records still have
+to move on to the qualified name.
+
+Rejected: **let the sync delete a record it cannot match.** A re-named table then
+reads as a delete and a create. The record's grants, import settings and Data
+Store copy go with it. That is worse than the duplicate it fixes.
+
+## Consequences
+
+**A request path carries a rename engine.** Saving a Data Source can now rewrite
+every query on the site. It runs only when a name actually changed, which is
+rare, but the cost is there.
+
+**`split_table_name` still guesses.** It reads the part before the first dot as
+a schema when that schema is configured. A table named `v1.2 metrics` is safe. A
+table literally named `sales.orders` inside `public` is not, once `sales` is
+configured. This is inherited from `frappe/insights#1254` and is not widened
+here. It goes away with the name.
+
+**Stale records still survive.** A table dropped at the source leaves its record
+behind forever. That gap is independent of naming and belongs to the sync.
+
+## Where this is going
+
+Give the schema its own field.
+
+```
+Insights Table v3
+  data_source   prod_pg
+  schema        public                              a coordinate, in its own column
+  table         orders                              always bare
+  name          md5(data_source + schema + table)
+```
+
+Two tables named `orders`, in `public` and in `sales`, are then two records with
+two keys. The prefix existed only to keep those apart, and the key does that
+instead. The `schema` field of the Data Source can change to anything, and no
+record's name changes with it.
+
+Six of the seven pieces go: `qualify_table_names`, `format_table_name`,
+`split_table_name`'s guess, `strip_schema_prefix`, `table_identity` and
+`reconcile_table_names`. `table_rename` survives as the one-shot migration, and
+goes with it.
+
+The cost is one thing, and it is the whole decision. A query names its source by
+a bare `table_name`. Two records for `orders` make that ambiguous, so the
+reference needs an optional `schema` key and a default for every document
+written before it. The operations JSON is saved, exported and shipped in
+templates, so this is a format change to a portable document.
+
+Templates keep working through that default: a bare name resolves against the
+Data Source's first schema, which is where a frappe database keeps its tables.
+
+Pay for one format change, or keep a translation layer between two names for one
+table. This ADR is interim because the first has not been paid yet.

--- a/insights/insights/doctype/insights_data_source_v3/insights_data_source_v3.py
+++ b/insights/insights/doctype/insights_data_source_v3/insights_data_source_v3.py
@@ -18,6 +18,7 @@ from insights.insights.doctype.insights_table_link_v3.insights_table_link_v3 imp
 from insights.insights.doctype.insights_table_v3.insights_table_v3 import (
     InsightsTablev3,
 )
+from insights.insights.doctype.insights_table_v3.table_rename import rename_tables
 
 from .connectors.bigquery import get_bigquery_connection
 from .connectors.clickhouse import get_clickhouse_connection
@@ -386,6 +387,18 @@ class InsightsDataSourcev3(InsightsDataSourceDocument, Document):
             return schema, table
         return schemas[0], table_name
 
+    def table_identity(self, table_name: str) -> str:
+        """Name the remote table `table_name` points at, free of the spelling of the day.
+
+        `format_table_name` answers differently once the number of configured schemas
+        changes, so the stored name is a spelling, not an identity. Matching the remote
+        list against stored spellings makes one table look like two (frappe/insights#1371).
+        """
+        if self.database_type != "PostgreSQL":
+            return table_name
+        schema, table = self.split_table_name(table_name)
+        return f"{schema}.{table}"
+
     def get_table_list(self):
         db = self._get_ibis_backend()
 
@@ -455,21 +468,47 @@ class InsightsDataSourcev3(InsightsDataSourceDocument, Document):
                 "Insights Table v3",
                 {"data_source": self.name},
             )
-
-        new_tables = set(remote_tables)
-        if not force:
-            existing_tables = frappe.get_all(
-                "Insights Table v3",
-                {"data_source": self.name},
-                pluck="table",
-            )
-            new_tables = set(remote_tables) - set(existing_tables)
-
-        if not new_tables:
+            InsightsTablev3.bulk_create(self.name, list(set(remote_tables)))
+            self.update_table_links(force)
             return
 
+        new_tables, renames = self.reconcile_table_names(remote_tables)
+        if not new_tables and not renames:
+            return
+
+        rename_tables(self.name, renames)
         InsightsTablev3.bulk_create(self.name, list(new_tables))
         self.update_table_links(force)
+
+    def reconcile_table_names(self, remote_tables: list[str]) -> tuple[set[str], dict[str, str]]:
+        """Split the remote list into tables to create and stored names to re-spell.
+
+        A record already exists for a remote table whenever some stored name has the same
+        `table_identity`. That name may not be the one `get_table_list` reports today, so
+        the record is renamed. A second record would import the same table a second time.
+        """
+        stored_names = frappe.get_all(
+            "Insights Table v3",
+            {"data_source": self.name},
+            pluck="table",
+        )
+
+        stored_by_identity = {}
+        for name in stored_names:
+            stored_by_identity.setdefault(self.table_identity(name), []).append(name)
+
+        new_tables = set()
+        renames = {}
+        for remote in set(remote_tables):
+            matches = stored_by_identity.get(self.table_identity(remote))
+            if not matches:
+                new_tables.add(remote)
+                continue
+            for stored in matches:
+                if stored != remote:
+                    renames[stored] = remote
+
+        return new_tables, renames
 
     def update_table_links(self, force=False):
         links = []

--- a/insights/insights/doctype/insights_table_v3/table_rename.py
+++ b/insights/insights/doctype/insights_table_v3/table_rename.py
@@ -1,0 +1,315 @@
+"""Move a `Insights Table v3` record on to another spelling of the table it names.
+
+Every referrer names a table by the string the record stores, so a rename has to carry
+the queries, the references, the links, the grants and the imported copy with it. See
+`InsightsDataSourcev3.table_identity` for why the spelling changes at all.
+
+`rename_tables` is the one entry point. It renames a record in place, or merges it into
+the record that already holds the new name, and rewrites the referrers either way.
+"""
+
+import frappe
+
+import insights
+from insights.insights.doctype.insights_table_v3.insights_table_v3 import get_table_name
+
+# How a person asked for the table to be imported. A merge keeps these whatever happens to
+# the Data Store copy. Nothing else holds them, and only a person can type them again.
+IMPORT_SETTINGS_FIELDS = (
+    "sync_mode",
+    "sync_from",
+    "sync_cursor_column",
+    "sync_primary_key_column",
+    "sync_strategy",
+    "row_limit",
+    "before_import_script",
+)
+# The subset of the settings a person types. Only these say whether anyone configured the
+# record — see `import_settings_are_untouched`.
+TYPED_SETTINGS_FIELDS = (
+    "sync_cursor_column",
+    "sync_primary_key_column",
+    "sync_from",
+    "row_limit",
+    "before_import_script",
+)
+# What the record says about its Data Store copy. These only hold once that copy moves.
+WAREHOUSE_STATE_FIELDS = (
+    "stored",
+    "last_synced_on",
+    "last_sync_bookmark",
+)
+
+
+def rename_tables(data_source: str, renames: dict[str, str]) -> None:
+    """Apply `{old_table: new_table}` to `data_source`.
+
+    The referrers are rewritten once for the whole batch: `update_queries` reads every
+    query of the site, which is far too expensive to repeat per table.
+    """
+    applied = {}
+    for old_table, new_table in renames.items():
+        if old_table == new_table:
+            continue
+        if rename_table_record(data_source, old_table, new_table):
+            applied[old_table] = new_table
+
+    if not applied:
+        return
+
+    update_queries(data_source, applied)
+    update_query_references(data_source, applied)
+    update_table_links(data_source, applied)
+    update_import_logs(data_source, applied)
+
+    clear_permission_caches()
+
+
+def clear_permission_caches() -> None:
+    """Make the next permission check read the grants this rename moved.
+
+    A rename gives the record a new key, and a team's allowed list holds keys. Two caches
+    answer with the old one. `_get_allowed_resources_for_user` is cached for a day. It is
+    built from `get_cached_doc("Insights Team", ...)`, which holds the grant rows
+    themselves. `Insights Team.on_change` clears both, and nothing here saves a team.
+    """
+    from insights.insights.doctype.insights_team.insights_team import clear_cache
+
+    # no name clears every team in one pass, so no team has to be read to be cleared
+    frappe.clear_document_cache("Insights Team")
+    clear_cache()
+
+
+def rename_table_record(data_source: str, old_table: str, new_table: str) -> bool:
+    """Move the record for `old_table` on to `new_table`. Returns False if there is none."""
+    row = frappe.db.get_value(
+        "Insights Table v3",
+        {"data_source": data_source, "table": old_table},
+        ["name", "table", "label", "stored"],
+        as_dict=True,
+    )
+    if not row:
+        return False
+
+    new_name = get_table_name(data_source, new_table)
+    if frappe.db.exists("Insights Table v3", new_name):
+        merge_table(data_source, row, new_name, new_table)
+        return True
+
+    # renaming by hand rather than through `frappe.rename_doc`: every referrer is rewritten
+    # below anyway, and this keeps the rename from touching the remote database, which is
+    # routinely unreachable while `bench migrate` runs.
+    frappe.db.set_value(
+        "Insights Table v3",
+        row.name,
+        {
+            "name": new_name,
+            "table": new_table,
+            # an untouched label is the table name; a label a person wrote is theirs
+            "label": new_table if row.label == old_table else row.label,
+        },
+        update_modified=False,
+    )
+    frappe.db.set_value(
+        "Insights Resource Permission",
+        {"resource_type": "Insights Table v3", "resource_name": row.name},
+        "resource_name",
+        new_name,
+        update_modified=False,
+    )
+
+    if row.stored and not rename_warehouse_table(data_source, old_table, new_table):
+        # the imported data can no longer be found under the new name — let it re-import
+        frappe.db.set_value("Insights Table v3", new_name, "stored", 0, update_modified=False)
+
+    return True
+
+
+def merge_table(data_source: str, row, survivor_name: str, new_table: str) -> None:
+    """Fold `row` into the record that already holds `new_table`, then delete it.
+
+    Both records name one remote table, so only one may stay `stored`. Two would import
+    the same table twice per cycle and take the Data Store write lock twice.
+
+    On a site the sync duplicated, `row` is the record that has been there all along and
+    the survivor is the copy the sync made. So the survivor inherits the import — but only
+    while nobody has configured it, because a person may have set up the duplicate instead.
+    """
+    survivor = frappe.db.get_value("Insights Table v3", survivor_name, ["stored", "label"], as_dict=True)
+    inherit = not survivor.stored and import_settings_are_untouched(survivor_name)
+
+    moved = False
+    if inherit:
+        settings = frappe.db.get_value("Insights Table v3", row.name, IMPORT_SETTINGS_FIELDS, as_dict=True)
+        moved = bool(row.stored) and rename_warehouse_table(data_source, row.table, new_table)
+        if moved:
+            settings.update(
+                frappe.db.get_value("Insights Table v3", row.name, WAREHOUSE_STATE_FIELDS, as_dict=True)
+            )
+        frappe.db.set_value("Insights Table v3", survivor_name, settings, update_modified=False)
+
+    if row.stored and not moved:
+        drop_warehouse_table(data_source, row.table)
+
+    if row.label != row.table and survivor.label == new_table:
+        # the same label rule as a rename: a label a person wrote is theirs
+        frappe.db.set_value("Insights Table v3", survivor_name, "label", row.label, update_modified=False)
+
+    move_grants(row.name, survivor_name)
+    frappe.delete_doc("Insights Table v3", row.name, force=True, ignore_permissions=True)
+
+
+def import_settings_are_untouched(name: str) -> bool:
+    """True while nobody has said how this record imports.
+
+    Only the typed fields answer this. `sync_mode` and `sync_strategy` mean nothing on
+    their own. Incremental needs a cursor column, and its upsert strategy needs a primary
+    key. A default read back from a blank document would not help either. The sync writes
+    its records through `bulk_insert`, over a column list that names no sync field.
+    """
+    typed = frappe.db.get_value("Insights Table v3", name, TYPED_SETTINGS_FIELDS, as_dict=True)
+    return not any(typed.values())
+
+
+def move_grants(old_name: str, new_name: str) -> None:
+    """Point the grants of `old_name` at `new_name`, dropping the ones already there.
+
+    A grant is an `Insights Resource Permission` row a team holds against the record, and
+    it carries that team's row restrictions. Deleting the rows instead would revoke the
+    table from every team that reads it.
+    """
+    granted_to = frappe.get_all(
+        "Insights Resource Permission",
+        filters={"resource_type": "Insights Table v3", "resource_name": new_name},
+        pluck="parent",
+    )
+    if granted_to:
+        # a team that already reads the survivor would hold two rows saying one thing
+        frappe.db.delete(
+            "Insights Resource Permission",
+            {
+                "resource_type": "Insights Table v3",
+                "resource_name": old_name,
+                "parent": ["in", granted_to],
+            },
+        )
+
+    frappe.db.set_value(
+        "Insights Resource Permission",
+        {"resource_type": "Insights Table v3", "resource_name": old_name},
+        "resource_name",
+        new_name,
+        update_modified=False,
+    )
+
+
+def rename_warehouse_table(data_source: str, old_table: str, new_table: str) -> bool:
+    from insights.insights.doctype.insights_data_source_v3.data_warehouse import (
+        get_warehouse_schema_name,
+        quote_identifier,
+    )
+
+    old_name = quote_identifier(frappe.scrub(old_table))
+    new_name = quote_identifier(frappe.scrub(new_table))
+    schema = get_warehouse_schema_name(data_source)
+    try:
+        with insights.warehouse.get_write_connection(schema) as db:
+            db.raw_sql(f"ALTER TABLE {old_name} RENAME TO {new_name}")
+        return True
+    except Exception:
+        return False
+
+
+def drop_warehouse_table(data_source: str, table: str) -> None:
+    """Drop the Data Store copy, but never let the Data Store block the rename.
+
+    `WarehouseTable.drop` waits on the write lock. A Table Import holds that lock for its
+    whole run. A rename that raised here would roll back the records it already moved. An
+    undropped table is harmless, because `drop_orphan_warehouse_tables` collects it.
+    """
+    try:
+        insights.warehouse.get_table(data_source, table).drop()
+    except Exception:
+        frappe.log_error(title=f"Failed to drop {table} of {data_source} from the data store")
+
+
+def update_queries(data_source: str, renames: dict[str, str]) -> None:
+    """Rewrite the table names referenced by the source/join/union operations of every query."""
+    queries = frappe.get_all(
+        "Insights Query v3",
+        filters={"operations": ["like", "%table_name%"]},
+        fields=["name", "operations"],
+    )
+
+    updates = {}
+    for query in queries:
+        operations = frappe.parse_json(query.operations)
+        if not operations:
+            continue
+
+        if not rewrite_table_names(operations, data_source, renames):
+            continue
+
+        updates[query.name] = {"operations": frappe.as_json(operations)}
+
+    frappe.db.bulk_update("Insights Query v3", updates, update_modified=False)
+
+
+def rewrite_table_names(node, data_source: str, renames: dict[str, str]) -> bool:
+    """Recursively rename every `{data_source, table_name}` reference. Returns True if changed."""
+    changed = False
+
+    if isinstance(node, list):
+        for item in node:
+            changed = rewrite_table_names(item, data_source, renames) or changed
+        return changed
+
+    if not isinstance(node, dict):
+        return False
+
+    if node.get("data_source") == data_source and node.get("table_name") in renames:
+        node["table_name"] = renames[node["table_name"]]
+        changed = True
+
+    for value in node.values():
+        changed = rewrite_table_names(value, data_source, renames) or changed
+
+    return changed
+
+
+def update_query_references(data_source: str, renames: dict[str, str]) -> None:
+    rename_column_values("Insights Query Reference", data_source, "table_name", renames)
+
+
+def update_import_logs(data_source: str, renames: dict[str, str]) -> None:
+    """Keep the sync history, which `get_table_stats` reads by table name."""
+    rename_column_values("Insights Table Import Log", data_source, "table_name", renames)
+
+
+def update_table_links(data_source: str, renames: dict[str, str]) -> None:
+    # a link can name a renamed table on either side, so each side is its own rewrite
+    for field in ("left_table", "right_table"):
+        rename_column_values("Insights Table Link v3", data_source, field, renames)
+
+
+def rename_column_values(doctype: str, data_source: str, field: str, renames: dict[str, str]) -> None:
+    """Rewrite `field` from every old name to its new one, in a single statement.
+
+    Every row holding a given old name takes the same new one, so the rows themselves carry
+    nothing a rename needs. `frappe.db.bulk_update` matches by document name, so it would
+    have to read them all first — and an import log keeps a row per import forever.
+    """
+    table = frappe.qb.DocType(doctype)
+    column = table[field]
+
+    case = frappe.qb.terms.Case()
+    for old_value, new_value in renames.items():
+        case = case.when(column == old_value, new_value)
+
+    (
+        frappe.qb.update(table)
+        .set(column, case)
+        .where(table.data_source == data_source)
+        .where(column.isin(list(renames)))
+        .run()
+    )

--- a/insights/patches/strip_default_schema_from_table_names.py
+++ b/insights/patches/strip_default_schema_from_table_names.py
@@ -1,10 +1,6 @@
 import frappe
 
-import insights
-from insights.insights.doctype.insights_data_source_v3.data_warehouse import (
-    get_warehouse_schema_name,
-)
-from insights.insights.doctype.insights_table_v3.insights_table_v3 import get_table_name
+from insights.insights.doctype.insights_table_v3.table_rename import rename_tables
 
 
 def execute():
@@ -31,171 +27,17 @@ def execute():
             continue
 
         try:
-            unqualify_source(source, f"{schemas[0]}.")
+            unqualify_source(source.name, f"{schemas[0]}.")
             frappe.db.commit()
         except Exception:
             frappe.db.rollback()
             frappe.log_error(title=f"Failed to strip schema prefix for {source.name}")
 
 
-def unqualify_source(source, prefix):
-    renames = rename_tables(source.name, prefix)
-    if not renames:
-        return
-
-    update_queries(source.name, renames)
-    update_query_references(source.name, renames)
-    update_table_links(source.name, renames)
-
-
-def rename_tables(data_source, prefix) -> dict[str, str]:
-    """Strip `prefix` from the stored `Insights Table v3` records. Returns {old: new}."""
-    rows = frappe.get_all(
+def unqualify_source(data_source: str, prefix: str) -> None:
+    tables = frappe.get_all(
         "Insights Table v3",
         filters={"data_source": data_source, "table": ["like", f"{prefix}%"]},
-        fields=["name", "table", "label", "stored"],
+        pluck="table",
     )
-
-    renames = {}
-    for row in rows:
-        new_table = row.table[len(prefix) :]
-        new_name = get_table_name(data_source, new_table)
-
-        if frappe.db.exists("Insights Table v3", new_name):
-            # an unqualified record already exists — drop the duplicate
-            discard_table(data_source, row)
-            renames[row.table] = new_table
-            continue
-
-        # renaming by hand rather than through `frappe.rename_doc`: every referrer is
-        # rewritten below anyway, and this keeps the migration from touching the remote
-        # database, which is routinely unreachable while `bench migrate` runs.
-        frappe.db.set_value(
-            "Insights Table v3",
-            row.name,
-            {
-                "name": new_name,
-                "table": new_table,
-                "label": row.label[len(prefix) :] if row.label.startswith(prefix) else row.label,
-            },
-            update_modified=False,
-        )
-        frappe.db.set_value(
-            "Insights Resource Permission",
-            {"resource_type": "Insights Table v3", "resource_name": row.name},
-            "resource_name",
-            new_name,
-            update_modified=False,
-        )
-
-        if row.stored and not rename_warehouse_table(data_source, row.table, new_table):
-            # the imported data can no longer be found under the new name — let it re-import
-            frappe.db.set_value("Insights Table v3", new_name, "stored", 0, update_modified=False)
-
-        renames[row.table] = new_table
-
-    return renames
-
-
-def discard_table(data_source, row):
-    """Delete a qualified record whose unqualified counterpart already exists.
-
-    Deleting an `Insights Table v3` doesn't clean up after itself, so drop the imported
-    data and the permissions pointing at it here — the surviving record has its own.
-    """
-    if row.stored:
-        insights.warehouse.get_table(data_source, row.table).drop()
-
-    frappe.db.delete(
-        "Insights Resource Permission",
-        {"resource_type": "Insights Table v3", "resource_name": row.name},
-    )
-    frappe.delete_doc("Insights Table v3", row.name, force=True, ignore_permissions=True)
-
-
-def rename_warehouse_table(data_source, old_table, new_table) -> bool:
-    old_name = frappe.scrub(old_table)
-    new_name = frappe.scrub(new_table)
-    schema = get_warehouse_schema_name(data_source)
-    try:
-        with insights.warehouse.get_write_connection(schema) as db:
-            db.raw_sql(f'ALTER TABLE "{old_name}" RENAME TO "{new_name}"')
-        return True
-    except Exception:
-        return False
-
-
-def update_queries(data_source, renames):
-    """Rewrite the table names referenced by the source/join/union operations of every query."""
-    queries = frappe.get_all(
-        "Insights Query v3",
-        filters={"operations": ["like", "%table_name%"]},
-        fields=["name", "operations"],
-    )
-
-    for query in queries:
-        operations = frappe.parse_json(query.operations)
-        if not operations:
-            continue
-
-        if not rewrite_table_names(operations, data_source, renames):
-            continue
-
-        frappe.db.set_value(
-            "Insights Query v3",
-            query.name,
-            "operations",
-            frappe.as_json(operations),
-            update_modified=False,
-        )
-
-
-def rewrite_table_names(node, data_source, renames) -> bool:
-    """Recursively rename every `{data_source, table_name}` reference. Returns True if changed."""
-    changed = False
-
-    if isinstance(node, list):
-        for item in node:
-            changed = rewrite_table_names(item, data_source, renames) or changed
-        return changed
-
-    if not isinstance(node, dict):
-        return False
-
-    if node.get("data_source") == data_source and node.get("table_name") in renames:
-        node["table_name"] = renames[node["table_name"]]
-        changed = True
-
-    for value in node.values():
-        changed = rewrite_table_names(value, data_source, renames) or changed
-
-    return changed
-
-
-def update_query_references(data_source, renames):
-    for old_table, new_table in renames.items():
-        frappe.db.set_value(
-            "Insights Query Reference",
-            {"data_source": data_source, "table_name": old_table},
-            "table_name",
-            new_table,
-            update_modified=False,
-        )
-
-
-def update_table_links(data_source, renames):
-    """Rename the tables a link points at.
-
-    Links were always generated from the bare doctype name ("tabUser"), which is why they
-    never matched a qualified table to begin with — so this only has anything to do for
-    links written after the source stopped spanning several schemas.
-    """
-    for old_table, new_table in renames.items():
-        for field in ("left_table", "right_table"):
-            frappe.db.set_value(
-                "Insights Table Link v3",
-                {"data_source": data_source, field: old_table},
-                field,
-                new_table,
-                update_modified=False,
-            )
+    rename_tables(data_source, {table: table[len(prefix) :] for table in tables})

--- a/insights/tests/test_table_name_reconcile.py
+++ b/insights/tests/test_table_name_reconcile.py
@@ -1,0 +1,427 @@
+"""Guards against regressing frappe/insights#1371.
+
+A table list sync used to match the remote tables against the stored spellings, so a
+re-spelled table read as one never seen. See `InsightsDataSourcev3.table_identity`.
+"""
+
+from unittest.mock import patch
+
+import frappe
+
+from insights.insights.doctype.insights_data_source_v3.insights_data_source_v3 import (
+    InsightsDataSourcev3,
+)
+from insights.insights.doctype.insights_table_v3 import table_rename
+from insights.insights.doctype.insights_table_v3.insights_table_v3 import InsightsTablev3, get_table_name
+from insights.insights.doctype.insights_team.insights_team import (
+    get_allowed_resources_for_user,
+)
+from insights.tests.base import InsightsIntegrationTestCase
+from insights.tests.factories import DT, create_test_query, create_test_workbook, create_user
+
+TITLE = "Table Reconcile Test PG"
+
+
+class TestTableNameReconcile(InsightsIntegrationTestCase):
+    def before_test(self):
+        # import logs outlive the data source they name — `on_trash` does not reach them
+        frappe.db.delete("Insights Table Import Log", {"data_source": frappe.scrub(TITLE)})
+        self.data_source = self.create_data_source()
+        # the Data Store is not what these tests are about; a rename always lands
+        self.renamed = []
+        self.dropped = []
+        self.warehouse_moves = True
+        self.patch(table_rename, "rename_warehouse_table", self.fake_rename)
+        self.patch(table_rename, "drop_warehouse_table", self.fake_drop)
+
+    # helpers
+
+    def patch(self, target, attribute, replacement):
+        patcher = patch.object(target, attribute, replacement)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def fake_rename(self, data_source, old_table, new_table):
+        self.renamed.append((old_table, new_table))
+        return self.warehouse_moves
+
+    def fake_drop(self, data_source, table):
+        self.dropped.append(table)
+
+    def create_data_source(self, schema=None):
+        name = frappe.scrub(TITLE)
+        if frappe.db.exists("Insights Data Source v3", name):
+            frappe.delete_doc("Insights Data Source v3", name, force=True)
+
+        doc = frappe.get_doc(
+            {
+                "doctype": "Insights Data Source v3",
+                "title": TITLE,
+                "database_type": "PostgreSQL",
+                "database_name": "reconcile_test",
+                "schema": schema,
+                "host": "localhost",
+                "port": 5432,
+                "username": "test",
+                "password": "test",
+            }
+        )
+        # `on_update` reaches the remote database, which these tests do not have
+        with patch.object(InsightsDataSourcev3, "on_update", lambda self: None):
+            doc.insert()
+        return doc
+
+    def create_table(self, table, stored=0, **kwargs):
+        doc = frappe.get_doc(
+            {
+                "doctype": "Insights Table v3",
+                "data_source": self.data_source.name,
+                "table": table,
+                "label": table,
+                "stored": stored,
+                **kwargs,
+            }
+        )
+        doc.flags.ignore_links = True
+        doc.insert(ignore_permissions=True)
+        return doc
+
+    def create_team_with_grant(self, resource_name, restrictions=None, members=None):
+        team = frappe.get_doc(
+            {
+                "doctype": "Insights Team",
+                "team_name": "Reconcile Test Team",
+                "team_members": [{"user": member} for member in members or []],
+            }
+        )
+        team.flags.ignore_links = True
+        team.insert(ignore_permissions=True)
+        self.addCleanup(frappe.delete_doc, "Insights Team", team.name, force=True)
+        self.grant(team.name, resource_name, restrictions)
+        return team.name
+
+    def grant(self, team, resource_name, restrictions=None):
+        parent = frappe.get_doc("Insights Team", team)
+        parent.append(
+            "team_permissions",
+            {
+                "resource_type": "Insights Table v3",
+                "resource_name": resource_name,
+                "table_restrictions": restrictions,
+            },
+        )
+        parent.flags.ignore_links = True
+        parent.save(ignore_permissions=True)
+
+    def sync(self, remote_tables):
+        with patch.object(InsightsDataSourcev3, "get_table_list", return_value=remote_tables):
+            self.data_source.update_table_list()
+
+    def stored_tables(self):
+        return sorted(
+            frappe.get_all("Insights Table v3", {"data_source": self.data_source.name}, pluck="table")
+        )
+
+    # tests
+
+    def test_a_re_spelled_table_is_renamed_not_duplicated(self):
+        self.create_table("public.orders", stored=1)
+
+        self.sync(["orders"])
+
+        self.assertEqual(self.stored_tables(), ["orders"])
+        self.assertEqual(self.renamed, [("public.orders", "orders")])
+        # the record keeps its identity as the name derived from the new table
+        self.assertTrue(
+            frappe.db.exists("Insights Table v3", get_table_name(self.data_source.name, "orders"))
+        )
+
+    def test_a_re_spelled_table_keeps_its_import(self):
+        self.create_table("public.orders", stored=1, sync_mode="Full", row_limit=500)
+
+        self.sync(["orders"])
+
+        record = frappe.db.get_value(
+            "Insights Table v3",
+            get_table_name(self.data_source.name, "orders"),
+            ["stored", "row_limit"],
+            as_dict=True,
+        )
+        self.assertEqual(record.stored, 1)
+        self.assertEqual(record.row_limit, 500)
+
+    def test_a_re_spelled_table_that_cannot_move_its_data_re_imports(self):
+        self.create_table("public.orders", stored=1)
+        self.warehouse_moves = False
+
+        self.sync(["orders"])
+
+        stored = frappe.db.get_value(
+            "Insights Table v3", get_table_name(self.data_source.name, "orders"), "stored"
+        )
+        self.assertEqual(stored, 0)
+
+    def test_an_existing_duplicate_pair_is_merged(self):
+        self.create_table("public.orders", stored=1, row_limit=900)
+        self.create_table("orders", stored=0)
+
+        self.sync(["orders"])
+
+        self.assertEqual(self.stored_tables(), ["orders"])
+        survivor = frappe.db.get_value(
+            "Insights Table v3",
+            get_table_name(self.data_source.name, "orders"),
+            ["stored", "row_limit"],
+            as_dict=True,
+        )
+        # the survivor had no copy of its own, so it inherits the one that was importing
+        self.assertEqual(survivor.stored, 1)
+        self.assertEqual(survivor.row_limit, 900)
+
+    def test_a_merge_keeps_the_survivors_own_import(self):
+        self.create_table("public.orders", stored=1, row_limit=900)
+        self.create_table("orders", stored=1, row_limit=100)
+
+        self.sync(["orders"])
+
+        self.assertEqual(self.stored_tables(), ["orders"])
+        survivor = frappe.db.get_value(
+            "Insights Table v3",
+            get_table_name(self.data_source.name, "orders"),
+            ["stored", "row_limit"],
+            as_dict=True,
+        )
+        self.assertEqual(survivor.row_limit, 100)
+        # one remote table, one Data Store copy; the loser's is dropped
+        self.assertEqual(self.dropped, ["public.orders"])
+
+    def test_a_rename_follows_the_queries_that_name_the_table(self):
+        self.create_table("public.orders")
+        workbook = create_test_workbook("Administrator", "Reconcile Test Workbook")
+        query = create_test_query(
+            "Administrator",
+            workbook.name,
+            title="Reconcile Test Query",
+            operations=[
+                {
+                    "type": "source",
+                    "table": {
+                        "type": "table",
+                        "data_source": self.data_source.name,
+                        "table_name": "public.orders",
+                    },
+                }
+            ],
+        )
+
+        self.sync(["orders"])
+
+        operations = frappe.parse_json(frappe.db.get_value("Insights Query v3", query.name, "operations"))
+        self.assertEqual(operations[0]["table"]["table_name"], "orders")
+
+    def test_a_new_table_is_still_created(self):
+        self.create_table("orders")
+
+        self.sync(["orders", "invoices"])
+
+        self.assertEqual(self.stored_tables(), ["invoices", "orders"])
+        self.assertEqual(self.renamed, [])
+
+    def test_a_table_gaining_a_prefix_is_renamed_too(self):
+        self.data_source.db_set("schema", "public, sales")
+        self.data_source.reload()
+        self.create_table("orders", stored=1)
+
+        self.sync(["public.orders", "sales.leads"])
+
+        self.assertEqual(self.stored_tables(), ["public.orders", "sales.leads"])
+        self.assertEqual(self.renamed, [("orders", "public.orders")])
+
+    def test_a_table_name_holding_a_dot_is_not_read_as_a_schema(self):
+        self.create_table("v1.2 metrics")
+
+        self.sync(["v1.2 metrics"])
+
+        self.assertEqual(self.stored_tables(), ["v1.2 metrics"])
+        self.assertEqual(self.renamed, [])
+
+    def test_a_merge_keeps_the_import_settings_when_the_data_cannot_move(self):
+        self.create_table("public.orders", stored=1, sync_mode="Incremental", sync_cursor_column="modified")
+        self.create_table("orders", stored=0)
+        self.warehouse_moves = False
+
+        self.sync(["orders"])
+
+        survivor = frappe.db.get_value(
+            "Insights Table v3",
+            get_table_name(self.data_source.name, "orders"),
+            ["stored", "sync_mode", "sync_cursor_column"],
+            as_dict=True,
+        )
+        # only the copy was at risk — the cursor column is the user's, and unrecoverable
+        self.assertEqual(survivor.stored, 0)
+        self.assertEqual(survivor.sync_mode, "Incremental")
+        self.assertEqual(survivor.sync_cursor_column, "modified")
+
+    def test_a_merge_keeps_the_teams_that_read_the_table(self):
+        loser = self.create_table("public.orders", stored=1)
+        self.create_table("orders")
+        team = self.create_team_with_grant(loser.name, restrictions='[{"column": "region"}]')
+
+        self.sync(["orders"])
+
+        survivor_name = get_table_name(self.data_source.name, "orders")
+        grants = frappe.get_all(
+            "Insights Resource Permission",
+            filters={"parent": team, "resource_type": "Insights Table v3"},
+            fields=["resource_name", "table_restrictions"],
+        )
+        self.assertEqual([g.resource_name for g in grants], [survivor_name])
+        self.assertEqual(grants[0].table_restrictions, '[{"column": "region"}]')
+
+    def test_a_merge_does_not_grant_a_team_the_same_table_twice(self):
+        loser = self.create_table("public.orders", stored=1)
+        survivor = self.create_table("orders")
+        team = self.create_team_with_grant(loser.name)
+        self.grant(team, survivor.name)
+
+        self.sync(["orders"])
+
+        grants = frappe.get_all(
+            "Insights Resource Permission",
+            filters={"parent": team, "resource_type": "Insights Table v3"},
+            pluck="resource_name",
+        )
+        self.assertEqual(grants, [get_table_name(self.data_source.name, "orders")])
+
+    def test_a_rename_follows_the_sync_history(self):
+        self.create_table("public.orders", stored=1)
+        frappe.get_doc(
+            {
+                "doctype": "Insights Table Import Log",
+                "data_source": self.data_source.name,
+                "table_name": "public.orders",
+                "status": "Completed",
+                "rows_imported": 10,
+                "time_taken": 2,
+            }
+        ).insert(ignore_permissions=True)
+
+        self.sync(["orders"])
+
+        logs = frappe.get_all(
+            "Insights Table Import Log",
+            filters={"data_source": self.data_source.name},
+            pluck="table_name",
+        )
+        self.assertEqual(logs, ["orders"])
+
+    def test_a_merge_keeps_settings_the_user_typed_on_the_survivor(self):
+        self.create_table("public.orders", stored=1, sync_mode="Full")
+        # the user found the duplicate the sync made and set it up — no import has run yet
+        self.create_table("orders", stored=0, sync_mode="Incremental", sync_cursor_column="modified")
+
+        self.sync(["orders"])
+
+        survivor = frappe.db.get_value(
+            "Insights Table v3",
+            get_table_name(self.data_source.name, "orders"),
+            ["sync_mode", "sync_cursor_column"],
+            as_dict=True,
+        )
+        self.assertEqual(survivor.sync_mode, "Incremental")
+        self.assertEqual(survivor.sync_cursor_column, "modified")
+        # the copy belongs to settings the survivor does not share
+        self.assertEqual(self.dropped, ["public.orders"])
+
+    def test_a_merge_keeps_a_label_the_user_wrote(self):
+        loser = self.create_table("public.orders")
+        frappe.db.set_value("Insights Table v3", loser.name, "label", "Orders 2026")
+        self.create_table("orders")
+
+        self.sync(["orders"])
+
+        label = frappe.db.get_value(
+            "Insights Table v3", get_table_name(self.data_source.name, "orders"), "label"
+        )
+        self.assertEqual(label, "Orders 2026")
+
+    def test_a_rename_clears_the_cached_team_grants(self):
+        loser = self.create_table("public.orders", stored=1)
+        self.create_table("orders")
+        user = create_user("reconcile_test_user@test.com", roles="Insights User")
+        self.addCleanup(frappe.delete_doc, DT.USER, user.name, force=True)
+        self.create_team_with_grant(loser.name, members=[user.name])
+        self.set_team_permissions(True)
+
+        # read once, so the allowed list is cached under the old record name
+        self.assertEqual(get_allowed_resources_for_user("Insights Table v3", user.name), [loser.name])
+
+        self.sync(["orders"])
+
+        survivor_name = get_table_name(self.data_source.name, "orders")
+        self.assertEqual(get_allowed_resources_for_user("Insights Table v3", user.name), [survivor_name])
+
+    def test_a_rename_follows_a_link_on_either_side(self):
+        self.create_table("public.orders")
+        self.create_table("public.customers")
+        frappe.get_doc(
+            {
+                "doctype": "Insights Table Link v3",
+                "data_source": self.data_source.name,
+                "left_table": "public.customers",
+                "left_column": "name",
+                "right_table": "public.orders",
+                "right_column": "customer",
+            }
+        ).insert(ignore_permissions=True)
+
+        self.sync(["orders", "customers"])
+
+        link = frappe.get_all(
+            "Insights Table Link v3",
+            filters={"data_source": self.data_source.name},
+            fields=["left_table", "right_table"],
+        )[0]
+        self.assertEqual(link.left_table, "customers")
+        self.assertEqual(link.right_table, "orders")
+
+    def test_a_rename_leaves_the_other_side_of_a_link_alone(self):
+        self.create_table("public.orders")
+        self.create_table("regions")
+        frappe.get_doc(
+            {
+                "doctype": "Insights Table Link v3",
+                "data_source": self.data_source.name,
+                "left_table": "regions",
+                "left_column": "name",
+                "right_table": "public.orders",
+                "right_column": "region",
+            }
+        ).insert(ignore_permissions=True)
+
+        self.sync(["orders", "regions"])
+
+        link = frappe.get_all(
+            "Insights Table Link v3",
+            filters={"data_source": self.data_source.name},
+            fields=["left_table", "right_table"],
+        )[0]
+        self.assertEqual(link.left_table, "regions")
+        self.assertEqual(link.right_table, "orders")
+
+    def test_a_merge_inherits_when_the_survivor_came_from_a_bulk_insert(self):
+        self.create_table("public.orders", stored=1, sync_cursor_column="modified")
+        # the sync writes records through `bulk_insert`, which names no sync field
+        InsightsTablev3.bulk_create(self.data_source.name, ["orders"])
+
+        self.sync(["orders"])
+
+        survivor = frappe.db.get_value(
+            "Insights Table v3",
+            get_table_name(self.data_source.name, "orders"),
+            ["stored", "sync_cursor_column"],
+            as_dict=True,
+        )
+        self.assertEqual(survivor.stored, 1)
+        self.assertEqual(survivor.sync_cursor_column, "modified")


### PR DESCRIPTION
Fixes #1371.

A postgres Table Name carries a `<schema>.` prefix only while the Data Source reads several schemas. That field is editable, so the name changes while the table does not. `update_table_list` compared the remote names to the stored names as strings, so a table whose name had changed read as one never seen. It created a second record next to the first, and both kept importing the same table.

The sync now resolves each name to the table it points at. Where both names exist it merges the records, so an affected site repairs itself on the next sync.

Review notes:

- The rename machinery moves out of the 3.13 patch into `table_rename`. The patch behaves as before.
- A merge moves the whole record — grants, row restrictions and import settings. Only `stored` and the sync bookmark wait on the Data Store copy.
- A rename clears the two caches that answer with the grants it moved. Neither is reached by writing a permission row.
- Stale records still survive. A table dropped at the source keeps its record. That gap belongs to the sync, not to naming.
- `split_table_name` reads a dotted name as a schema when that schema is configured. This PR inherits that and does not widen it.

`docs/adr/the-schema-is-a-coordinate-not-a-name.md` carries the decision, the two rejected alternatives and the destination.