### PR TITLE
fix: wait for readers before opening the warehouse for a write

### DIFF
--- a/insights/insights/doctype/insights_data_source_v3/connectors/duckdb.py
+++ b/insights/insights/doctype/insights_data_source_v3/connectors/duckdb.py
@@ -22,7 +22,7 @@ from ibis.backends.duckdb import Backend as DuckDBBackend
 # a click must not hold a web worker while readers come and go, so the default
 # stays short. A writer in a background job can afford to sit it out, and asks.
 WRITE_LOCK_TIMEOUT = 30
-BACKGROUND_WRITE_LOCK_TIMEOUT = 5 * 60
+IMPORT_WRITE_LOCK_TIMEOUT = 5 * 60
 WRITE_LOCK_RETRY_INTERVAL = 1
 
 
@@ -95,23 +95,29 @@ def local_duckdb_write_lock(
     path: str,
     cache_key: str,
     timeout: int = WRITE_LOCK_TIMEOUT,
-) -> Generator[None, None, None]:
+) -> Generator[float, None, None]:
     """Serialize write access to a local DuckDB file.
 
     Holds a file-level lock and evicts the cached read-only connection for
     cache_key, so the caller is free to open the file for writing — or to
     replace the file altogether, as the warehouse compaction does.
 
+    Yields whatever is left of timeout once the lock is in hand. Waiting off
+    other writers and waiting off readers come out of the one budget, and the
+    caller does not have to work that out for itself.
+
     Args:
         path: Absolute path to the .duckdb file.
         cache_key: The key under which the read connection is cached in
             insights.db_connections (typically the data source name).
-        timeout: Seconds to wait for the file lock before giving up.
+        timeout: Seconds to spend reaching a writable file, lock and readers
+            together.
     """
     from frappe.utils.synchronization import filelock
 
     import insights
 
+    deadline = time.monotonic() + timeout
     lock_name = f"insights_duckdb_write_{frappe.scrub(os.path.basename(path))}"
     with filelock(lock_name, timeout=timeout):
         with suppress(Exception):
@@ -119,7 +125,7 @@ def local_duckdb_write_lock(
             if cached:
                 cached.disconnect()
 
-        yield
+        yield max(deadline - time.monotonic(), 0)
 
 
 @contextmanager
@@ -144,17 +150,15 @@ def local_duckdb_write_connection(
         cache_key: The key under which the read connection is cached in
             insights.db_connections (typically the data source name).
         allowed_dir: Directory to allow external file access from.
-        timeout: Total seconds to spend obtaining the write connection. The file
-            lock holds off other writers, the open waits out the readers, and
-            both come out of this one budget.
+        timeout: Total seconds to spend obtaining the write connection, lock
+            and readers together.
     """
-    deadline = time.monotonic() + timeout
-    with local_duckdb_write_lock(path, cache_key, timeout=timeout):
+    with local_duckdb_write_lock(path, cache_key, timeout=timeout) as lock_timeout:
         db = open_local_duckdb(
             path,
             read_only=False,
             allowed_dir=allowed_dir,
-            lock_timeout=max(deadline - time.monotonic(), 0),
+            lock_timeout=lock_timeout,
         )
         try:
             yield db

--- a/insights/insights/doctype/insights_data_source_v3/connectors/duckdb.py
+++ b/insights/insights/doctype/insights_data_source_v3/connectors/duckdb.py
@@ -16,8 +16,13 @@ from ibis.backends.duckdb import Backend as DuckDBBackend
 # DuckDB hands a file to one writer or to many readers, never both, and a read
 # connection holds its shared lock until its request ends. A writer that arrives
 # mid-request must therefore wait the readers out instead of failing on the
-# first attempt. Every writer here runs in a background job, so it can afford to.
-WRITE_LOCK_TIMEOUT = 5 * 60
+# first attempt.
+#
+# How long it may wait is the caller's business, not the file's. A writer serving
+# a click must not hold a web worker while readers come and go, so the default
+# stays short. A writer in a background job can afford to sit it out, and asks.
+WRITE_LOCK_TIMEOUT = 30
+BACKGROUND_WRITE_LOCK_TIMEOUT = 5 * 60
 WRITE_LOCK_RETRY_INTERVAL = 1
 
 

--- a/insights/insights/doctype/insights_data_source_v3/connectors/duckdb.py
+++ b/insights/insights/doctype/insights_data_source_v3/connectors/duckdb.py
@@ -2,14 +2,23 @@
 # For license information, please see license.txt
 
 import os
+import time
 from collections.abc import Generator
 from contextlib import contextmanager, suppress
 from urllib.parse import urlparse
 
 import frappe
 import ibis
+from duckdb import IOException
 from frappe.utils import get_files_path
 from ibis.backends.duckdb import Backend as DuckDBBackend
+
+# DuckDB hands a file to one writer or to many readers, never both, and a read
+# connection holds its shared lock until its request ends. A writer that arrives
+# mid-request must therefore wait the readers out instead of failing on the
+# first attempt. Every writer here runs in a background job, so it can afford to.
+WRITE_LOCK_TIMEOUT = 5 * 60
+WRITE_LOCK_RETRY_INTERVAL = 1
 
 
 def get_duckdb_path(data_source) -> str:
@@ -22,6 +31,7 @@ def open_local_duckdb(
     path,
     read_only=True,
     allowed_dir=None,
+    lock_timeout=WRITE_LOCK_TIMEOUT,
 ) -> DuckDBBackend:
     """Open a DuckDB connection at the given filesystem path.
 
@@ -32,12 +42,13 @@ def open_local_duckdb(
         path: Absolute path to the .duckdb file.
         read_only: Whether to open in read-only mode.
         allowed_dir: Directory to allow external file access from (write mode only).
+        lock_timeout: Seconds a write open waits for readers to release the file.
     """
     if not os.path.exists(path):
         db = ibis.duckdb.connect(path)
         db.disconnect()
 
-    db = ibis.duckdb.connect(path, read_only=read_only)
+    db = ibis.duckdb.connect(path, read_only=True) if read_only else _connect_for_write(path, lock_timeout)
 
     private_folder = os.path.realpath(get_files_path(is_private=1))
     private_folder = _escape_sql_path(private_folder)
@@ -57,11 +68,28 @@ def open_local_duckdb(
     return db
 
 
+def _connect_for_write(path: str, lock_timeout: float) -> DuckDBBackend:
+    """Open path for writing, waiting out the readers that still hold it."""
+    deadline = time.monotonic() + lock_timeout
+    waited = False
+
+    while True:
+        try:
+            return ibis.duckdb.connect(path, read_only=False)
+        except IOException as e:
+            if "Could not set lock" not in str(e) or time.monotonic() >= deadline:
+                raise
+            if not waited:
+                waited = True
+                frappe.logger().warning(f"Waiting for readers to release {os.path.basename(path)}")
+            time.sleep(WRITE_LOCK_RETRY_INTERVAL)
+
+
 @contextmanager
 def local_duckdb_write_lock(
     path: str,
     cache_key: str,
-    timeout: int = 30,
+    timeout: int = WRITE_LOCK_TIMEOUT,
 ) -> Generator[None, None, None]:
     """Serialize write access to a local DuckDB file.
 
@@ -94,7 +122,7 @@ def local_duckdb_write_connection(
     path: str,
     cache_key: str,
     allowed_dir: str,
-    timeout: int = 30,
+    timeout: int = WRITE_LOCK_TIMEOUT,
 ) -> Generator[DuckDBBackend, None, None]:
     """Context manager that safely yields a write connection to a local DuckDB file.
 
@@ -111,13 +139,17 @@ def local_duckdb_write_connection(
         cache_key: The key under which the read connection is cached in
             insights.db_connections (typically the data source name).
         allowed_dir: Directory to allow external file access from.
-        timeout: Seconds to wait for the file lock before giving up.
+        timeout: Total seconds to spend obtaining the write connection. The file
+            lock holds off other writers, the open waits out the readers, and
+            both come out of this one budget.
     """
+    deadline = time.monotonic() + timeout
     with local_duckdb_write_lock(path, cache_key, timeout=timeout):
         db = open_local_duckdb(
             path,
             read_only=False,
             allowed_dir=allowed_dir,
+            lock_timeout=max(deadline - time.monotonic(), 0),
         )
         try:
             yield db

--- a/insights/insights/doctype/insights_data_source_v3/data_warehouse.py
+++ b/insights/insights/doctype/insights_data_source_v3/data_warehouse.py
@@ -22,7 +22,7 @@ from ibis.expr.types import Expr, Table
 
 import insights
 from insights.insights.doctype.insights_data_source_v3.connectors.duckdb import (
-    BACKGROUND_WRITE_LOCK_TIMEOUT,
+    IMPORT_WRITE_LOCK_TIMEOUT,
     WRITE_LOCK_TIMEOUT,
     local_duckdb_write_connection,
     local_duckdb_write_lock,
@@ -208,7 +208,7 @@ class WarehouseTableWriter:
 
         total_rows = 0
         try:
-            with insights.warehouse.get_write_connection(timeout=BACKGROUND_WRITE_LOCK_TIMEOUT) as db:
+            with insights.warehouse.get_write_connection(timeout=IMPORT_WRITE_LOCK_TIMEOUT) as db:
                 self._log(f"Committing {len(self._parquet_files)} parquet files to '{self.table_name}'")
 
                 with suppress(CatalogException):
@@ -376,7 +376,7 @@ class WarehouseTable:
 
         insights.create_toast(
             f"The last import of {self.table_name} failed, so it has no rows yet. "
-            "Check the import logs of the table in the data store.",
+            "A fresh import is queued. Check the table's import logs in the data store.",
             title="Import Failed",
             type="error",
             duration=7,
@@ -1144,15 +1144,11 @@ def compact_warehouse() -> tuple[int, int] | None:
     folder = os.path.dirname(path)
     new_path = f"{path}.compact"
 
-    deadline = time.monotonic() + CLEANUP_LOCK_TIMEOUT
-    with local_duckdb_write_lock(path, cache_key=WAREHOUSE_DB_NAME, timeout=CLEANUP_LOCK_TIMEOUT):
+    with local_duckdb_write_lock(
+        path, cache_key=WAREHOUSE_DB_NAME, timeout=CLEANUP_LOCK_TIMEOUT
+    ) as lock_timeout:
         # ATTACH-ing the new file needs the warehouse folder allowed, not tmp.
-        db = open_local_duckdb(
-            path,
-            read_only=False,
-            allowed_dir=folder,
-            lock_timeout=max(deadline - time.monotonic(), 0),
-        )
+        db = open_local_duckdb(path, read_only=False, allowed_dir=folder, lock_timeout=lock_timeout)
         try:
             if get_free_block_ratio(db) < COMPACT_MIN_FREE_RATIO:
                 return None

--- a/insights/insights/doctype/insights_data_source_v3/data_warehouse.py
+++ b/insights/insights/doctype/insights_data_source_v3/data_warehouse.py
@@ -22,6 +22,7 @@ from ibis.expr.types import Expr, Table
 
 import insights
 from insights.insights.doctype.insights_data_source_v3.connectors.duckdb import (
+    BACKGROUND_WRITE_LOCK_TIMEOUT,
     WRITE_LOCK_TIMEOUT,
     local_duckdb_write_connection,
     local_duckdb_write_lock,
@@ -207,7 +208,7 @@ class WarehouseTableWriter:
 
         total_rows = 0
         try:
-            with insights.warehouse.get_write_connection() as db:
+            with insights.warehouse.get_write_connection(timeout=BACKGROUND_WRITE_LOCK_TIMEOUT) as db:
                 self._log(f"Committing {len(self._parquet_files)} parquet files to '{self.table_name}'")
 
                 with suppress(CatalogException):
@@ -1143,9 +1144,15 @@ def compact_warehouse() -> tuple[int, int] | None:
     folder = os.path.dirname(path)
     new_path = f"{path}.compact"
 
+    deadline = time.monotonic() + CLEANUP_LOCK_TIMEOUT
     with local_duckdb_write_lock(path, cache_key=WAREHOUSE_DB_NAME, timeout=CLEANUP_LOCK_TIMEOUT):
         # ATTACH-ing the new file needs the warehouse folder allowed, not tmp.
-        db = open_local_duckdb(path, read_only=False, allowed_dir=folder)
+        db = open_local_duckdb(
+            path,
+            read_only=False,
+            allowed_dir=folder,
+            lock_timeout=max(deadline - time.monotonic(), 0),
+        )
         try:
             if get_free_block_ratio(db) < COMPACT_MIN_FREE_RATIO:
                 return None

--- a/insights/insights/doctype/insights_data_source_v3/data_warehouse.py
+++ b/insights/insights/doctype/insights_data_source_v3/data_warehouse.py
@@ -22,6 +22,7 @@ from ibis.expr.types import Expr, Table
 
 import insights
 from insights.insights.doctype.insights_data_source_v3.connectors.duckdb import (
+    WRITE_LOCK_TIMEOUT,
     local_duckdb_write_connection,
     local_duckdb_write_lock,
     open_local_duckdb,
@@ -84,7 +85,7 @@ class Warehouse:
 
     @contextmanager
     def get_write_connection(
-        self, database: str | None = None, timeout: int = 30
+        self, database: str | None = None, timeout: int = WRITE_LOCK_TIMEOUT
     ) -> Generator[DuckDBBackend, None, None]:
         path = self.get_db_path()
         allowed_dir = str(Path(tempfile.gettempdir()))
@@ -336,6 +337,7 @@ class WarehouseTable:
         except TableNotFound:
             if import_if_not_exists:
                 self.enqueue_import()
+                self.announce_missing_table()
                 remote_table = self.get_remote_table()
                 return insights.warehouse.db.create_table(
                     self.warehouse_table_name,
@@ -351,6 +353,43 @@ class WarehouseTable:
         except Exception as e:
             frappe.log_error(e)
             frappe.throw("Error accessing the data warehouse. Please try again.")
+
+    def announce_missing_table(self):
+        """Say that the empty table the reader is about to get is not the real one.
+
+        A miss substitutes an empty table of the right shape so the chart still
+        renders while the import runs. That is indistinguishable from a table
+        which genuinely holds no rows, so a table whose import keeps failing
+        reads as a legitimate zero. The in-progress case already toasts from
+        enqueue_import; the failed case had nothing at all.
+        """
+        frappe.logger().warning(
+            f"{self.table_name} of {self.data_source} is not in the data warehouse, "
+            "serving an empty table in its place"
+        )
+
+        if not self.last_import_failed():
+            return
+
+        insights.create_toast(
+            f"The last import of {self.table_name} failed, so it has no rows yet. "
+            "Check the import logs of the table in the data store.",
+            title="Import Failed",
+            type="error",
+            duration=7,
+        )
+
+    def last_import_failed(self) -> bool:
+        log = frappe.qb.DocType("Insights Table Import Log")
+        last_status = (
+            frappe.qb.from_(log)
+            .select(log.status)
+            .where((log.data_source == self.data_source) & (log.table_name == self.table_name))
+            .orderby(log.creation, order=frappe.qb.desc)
+            .limit(1)
+            .run()
+        )
+        return bool(last_status) and last_status[0][0] == "Failed"
 
     def get_remote_table(self) -> Expr:
         ds = InsightsDataSourcev3.get_doc(self.data_source)

--- a/insights/insights/doctype/insights_data_source_v3/data_warehouse.py
+++ b/insights/insights/doctype/insights_data_source_v3/data_warehouse.py
@@ -336,8 +336,7 @@ class WarehouseTable:
             return insights.warehouse.db.table(self.warehouse_table_name, database=self.schema)
         except TableNotFound:
             if import_if_not_exists:
-                self.enqueue_import()
-                self.announce_missing_table()
+                self.announce_missing_table(import_running=self.enqueue_import())
                 remote_table = self.get_remote_table()
                 return insights.warehouse.db.create_table(
                     self.warehouse_table_name,
@@ -354,21 +353,24 @@ class WarehouseTable:
             frappe.log_error(e)
             frappe.throw("Error accessing the data warehouse. Please try again.")
 
-    def announce_missing_table(self):
+    def announce_missing_table(self, import_running: bool = False):
         """Say that the empty table the reader is about to get is not the real one.
 
         A miss substitutes an empty table of the right shape so the chart still
         renders while the import runs. That is indistinguishable from a table
         which genuinely holds no rows, so a table whose import keeps failing
-        reads as a legitimate zero. The in-progress case already toasts from
-        enqueue_import; the failed case had nothing at all.
+        reads as a legitimate zero.
+
+        enqueue_import already speaks for a job that is queued or running, and
+        the newest log stays "Failed" until that job starts — so announcing the
+        old failure as well would contradict it. Only the gap it leaves is ours.
         """
         frappe.logger().warning(
             f"{self.table_name} of {self.data_source} is not in the data warehouse, "
             "serving an empty table in its place"
         )
 
-        if not self.last_import_failed():
+        if import_running or not self.last_import_failed():
             return
 
         insights.create_toast(
@@ -395,12 +397,13 @@ class WarehouseTable:
         ds = InsightsDataSourcev3.get_doc(self.data_source)
         return ds.get_ibis_table(self.table_name)
 
-    def enqueue_import(self):
+    def enqueue_import(self) -> bool:
+        """Queue an import for this table. True when one was already under way."""
         if frappe.db.get_value("Insights Data Source v3", self.data_source, "type") == "REST API":
             frappe.throw("Import not supported for API data sources")
 
         importer = WarehouseTableImporter(self)
-        importer.enqueue_import()
+        return importer.enqueue_import()
 
     def drop(self) -> None:
         """Drop this table from the warehouse. No-op if it does not exist."""
@@ -436,7 +439,8 @@ class WarehouseTableImporter:
             ),
         )
 
-    def enqueue_import(self):
+    def enqueue_import(self) -> bool:
+        """Queue an import for this table. True when one was already under way."""
         job_id = f"import_{frappe.scrub(self.table.data_source)}_{frappe.scrub(self.table.table_name)}"
 
         if is_job_enqueued(job_id) or self.import_in_progress():
@@ -447,12 +451,13 @@ class WarehouseTableImporter:
                 type="info",
                 duration=7,
             )
-            return
+            return True
 
         enqueue_warehouse_table_import(
             data_source=self.table.data_source,
             table_name=self.table.table_name,
         )
+        return False
 
     def start_import(self):
         from insights.insights.doctype.insights_data_source_v3.insights_data_source_v3 import (

--- a/insights/tests/test_warehouse.py
+++ b/insights/tests/test_warehouse.py
@@ -167,13 +167,7 @@ class TestWarehouse(InsightsIntegrationTestCase):
 
 
 class TestWarehouseWriteLock(InsightsIntegrationTestCase):
-    """A writer must wait out the readers holding the warehouse file.
-
-    DuckDB gives the file to one writer or to many readers, never both, and a
-    web worker holds its read connection until its request ends. Before this,
-    an import failed on the first conflict — the single largest cause of failed
-    imports in production.
-    """
+    """A writer must wait out the readers holding the warehouse file."""
 
     @contextmanager
     def warehouse_held_by_a_reader(self, hold_seconds):
@@ -205,7 +199,7 @@ class TestWarehouseWriteLock(InsightsIntegrationTestCase):
             self.assertGreaterEqual(waited, 2, "the write open returned before the reader let go")
 
     def test_write_open_gives_up_at_the_timeout(self):
-        with self.warehouse_held_by_a_reader(hold_seconds=5) as (path, tmpdir):
+        with self.warehouse_held_by_a_reader(hold_seconds=2) as (path, tmpdir):
             with self.assertRaises(IOException) as caught:
                 open_local_duckdb(path, read_only=False, allowed_dir=tmpdir, lock_timeout=1)
 

--- a/insights/tests/test_warehouse.py
+++ b/insights/tests/test_warehouse.py
@@ -1,15 +1,33 @@
+import subprocess
+import sys
 import tempfile
+import time
 from contextlib import contextmanager, suppress
 from pathlib import Path
 from unittest.mock import patch
 
+import frappe
 import ibis
 import pandas as pd
+from duckdb import IOException
 
 import insights
 from insights.insights.doctype.insights_data_source_v3.connectors.duckdb import open_local_duckdb
-from insights.insights.doctype.insights_data_source_v3.data_warehouse import WarehouseTableWriter
+from insights.insights.doctype.insights_data_source_v3.data_warehouse import (
+    WarehouseTable,
+    WarehouseTableWriter,
+)
 from insights.tests.base import InsightsIntegrationTestCase
+
+# A reader in this process shares the DuckDB instance, so it never conflicts.
+# Only a second process reproduces the lock the web workers take in production.
+HOLD_READ_LOCK = """
+import sys, time, duckdb
+con = duckdb.connect(sys.argv[1], read_only=True)
+print("held", flush=True)
+time.sleep(float(sys.argv[2]))
+con.close()
+"""
 
 
 class TestWarehouse(InsightsIntegrationTestCase):
@@ -146,3 +164,89 @@ class TestWarehouse(InsightsIntegrationTestCase):
                     {"id": 2, "value": "beta", "modified": "2024-01-02 00:00:00"},
                 ],
             )
+
+
+class TestWarehouseWriteLock(InsightsIntegrationTestCase):
+    """A writer must wait out the readers holding the warehouse file.
+
+    DuckDB gives the file to one writer or to many readers, never both, and a
+    web worker holds its read connection until its request ends. Before this,
+    an import failed on the first conflict — the single largest cause of failed
+    imports in production.
+    """
+
+    @contextmanager
+    def warehouse_held_by_a_reader(self, hold_seconds):
+        with tempfile.TemporaryDirectory(prefix="insights_lock_test_") as tmpdir:
+            path = str(Path(tmpdir) / "warehouse.duckdb")
+            open_local_duckdb(path, read_only=False).disconnect()
+
+            reader = subprocess.Popen(
+                [sys.executable, "-c", HOLD_READ_LOCK, path, str(hold_seconds)],
+                stdout=subprocess.PIPE,
+                text=True,
+            )
+            try:
+                reader.stdout.readline()  # the reader holds the file from here
+                yield path, tmpdir
+            finally:
+                reader.wait()
+
+    def test_write_open_waits_for_a_reader_to_finish(self):
+        with self.warehouse_held_by_a_reader(hold_seconds=3) as (path, tmpdir):
+            started = time.monotonic()
+            db = open_local_duckdb(path, read_only=False, allowed_dir=tmpdir, lock_timeout=60)
+            waited = time.monotonic() - started
+            try:
+                db.raw_sql("create table t as select 1 as a")
+            finally:
+                db.disconnect()
+
+            self.assertGreaterEqual(waited, 2, "the write open returned before the reader let go")
+
+    def test_write_open_gives_up_at_the_timeout(self):
+        with self.warehouse_held_by_a_reader(hold_seconds=5) as (path, tmpdir):
+            with self.assertRaises(IOException) as caught:
+                open_local_duckdb(path, read_only=False, allowed_dir=tmpdir, lock_timeout=1)
+
+            self.assertIn("Could not set lock", str(caught.exception))
+
+
+class TestMissingTableNotice(InsightsIntegrationTestCase):
+    """A miss serves an empty table, so a failed import must not read as zero rows."""
+
+    def make_table(self):
+        return WarehouseTable("some_source", "some_table")
+
+    def write_log(self, status):
+        log = frappe.new_doc("Insights Table Import Log")
+        log.data_source = "some_source"
+        log.table_name = "some_table"
+        log.status = status
+        log.insert(ignore_permissions=True)
+        return log
+
+    def test_failed_import_tells_the_reader(self):
+        self.write_log("Completed")
+        self.write_log("Failed")
+
+        with patch.object(insights, "create_toast") as toast:
+            self.make_table().announce_missing_table()
+
+        toast.assert_called_once()
+        self.assertIn("some_table", toast.call_args.args[0])
+
+    def test_running_import_stays_quiet(self):
+        # enqueue_import already toasts this case; a second notice is noise.
+        self.write_log("In Progress")
+
+        with patch.object(insights, "create_toast") as toast:
+            self.make_table().announce_missing_table()
+
+        toast.assert_not_called()
+
+    def test_a_table_that_never_imported_stays_quiet(self):
+        with patch.object(insights, "create_toast") as toast:
+            WarehouseTable("some_source", "never_imported").announce_missing_table()
+
+        toast.assert_not_called()

--- a/insights/tests/test_warehouse.py
+++ b/insights/tests/test_warehouse.py
@@ -250,3 +250,13 @@ class TestMissingTableNotice(InsightsIntegrationTestCase):
             WarehouseTable("some_source", "never_imported").announce_missing_table()
 
         toast.assert_not_called()
+
+    def test_a_queued_retry_suppresses_the_failure_notice(self):
+        # The retry is queued but has not started, so the newest log still reads
+        # "Failed" while enqueue_import already toasted "Import In Progress".
+        self.write_log("Failed")
+
+        with patch.object(insights, "create_toast") as toast:
+            self.make_table().announce_missing_table(import_running=True)
+
+        toast.assert_not_called()


### PR DESCRIPTION
Relates to #1370 — fixes the lock contention, not the single-file design underneath.

An import opened the warehouse for writing with no retry, so it failed the moment any request held a read connection. On insights.frappe.io that is **169 of 323 failed imports in 30 days**, and 161 of those name a reader as the lock holder — DuckDB's message says read-only would have worked.

The file lock only ever held off other writers. A write open now waits the readers out as well, and both waits share one budget. How long a writer may wait belongs to the caller: the default stays at 30s so a click cannot hold a web worker, and the import commit asks for five minutes. That is well clear of the measured worst case on that site — query executions run 1.09s on average, 84.3s at the maximum, none over 120s.

A miss still substitutes an empty table so a chart renders while the import runs. An import in progress already toasts. A failed one said nothing, so a table whose import keeps failing read as a legitimate zero. That case now says so.

### Tests

`test_write_open_waits_for_a_reader_to_finish` fails on `develop` with the production error. The reader has to run in a second process: a reader in the same process shares the DuckDB instance and never conflicts.