### PR TITLE
fix: read a money measure's currency from its data, not from the site

### DIFF
--- a/frontend/src2/charts/components/MeasurePicker.vue
+++ b/frontend/src2/charts/components/MeasurePicker.vue
@@ -169,6 +169,14 @@ const filteredColumnOptions = computed(() => {
 	return columnOptions.value.filter((option) => option.label.toLowerCase().includes(query))
 })
 
+// a currency code is text, so only text columns are offered
+const currencyColumnOptions = computed(() => [
+	{ label: __('Site currency'), value: '' },
+	...props.columnOptions
+		.filter((column) => FIELDTYPES.TEXT.includes(column.data_type))
+		.map((column) => ({ label: column.label, value: column.value })),
+])
+
 function getAggregationLabel(aggregation: AggregationType) {
 	return aggregationOptions.find((option) => option.value === aggregation)?.label
 }
@@ -359,6 +367,18 @@ function handleRemove() {
 							:options="formatOptions"
 							:modelValue="measure.format || ''"
 							@update:modelValue="measure.format = $event || undefined"
+						/>
+					</InlineFormControlLabel>
+
+					<InlineFormControlLabel
+						v-if="props.enableFormat && measure.format === 'currency'"
+						:label="__('Currency from')"
+					>
+						<FormControl
+							type="select"
+							:options="currencyColumnOptions"
+							:modelValue="measure.currency_column || ''"
+							@update:modelValue="measure.currency_column = $event || undefined"
 						/>
 					</InlineFormControlLabel>
 

--- a/frontend/src2/charts/components/NumberChart.vue
+++ b/frontend/src2/charts/components/NumberChart.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { formatNumber, getFormatUnits, getShortNumber } from '../../helpers'
+import { getRowCurrency } from '../../query/helpers'
 import { NumberChartConfig, NumberColumnOptions } from '../../types/chart.types'
 import { DataFormat, QueryResult, QueryResultColumn, QueryResultRow } from '../../types/query.types'
 import Sparkline from './Sparkline.vue'
@@ -53,11 +54,12 @@ const cards = computed(() => {
 		const shorten_numbers = getNumberOption(idx, 'shorten_numbers')
 		const format = config.value.number_columns.find((c) => c.measure_name === measure_name)
 			?.format
+		const currency = getRowCurrency(props.result.rows.at(-1), measure_name)
 
 		// The measure's format states the unit. A prefix set on the card replaces
 		// it — a card that spelled out its own symbol meant that one. A suffix
 		// sits after the unit instead, the way "12.5% of target" reads.
-		const units = getFormatUnits(format)
+		const units = getFormatUnits(format, currency)
 		const prefix = getNumberOption(idx, 'prefix') || units.prefix
 		const suffix = `${units.suffix}${getNumberOption(idx, 'suffix') || ''}`
 

--- a/frontend/src2/charts/components/TableChartConfigForm.vue
+++ b/frontend/src2/charts/components/TableChartConfigForm.vue
@@ -47,6 +47,9 @@ watchEffect(() => {
 	}
 })
 
+// a pivot aggregates on its own path and ignores a measure's format
+const isPivoted = computed(() => config.value.columns?.some((c) => c?.column_name))
+
 const measuresAsDimensions = computed<DimensionOption[]>(() =>
 	props.columnOptions
 		.filter((o) => FIELDTYPES.NUMBER.includes(o.data_type))
@@ -258,7 +261,7 @@ function updateTextWrap(column_name: string, wrap: boolean | undefined) {
 						<MeasurePicker
 							:model-value="item"
 							:column-options="props.columnOptions"
-							:enable-format="true"
+							:enable-format="!isPivoted"
 							@update:model-value="Object.assign(item, $event || {})"
 							@remove="config.values.splice(index, 1)"
 						/>

--- a/frontend/src2/components/DataTable.vue
+++ b/frontend/src2/components/DataTable.vue
@@ -6,6 +6,7 @@ import { computed, nextTick, ref } from 'vue'
 import { usePagination } from '../composables/usePagination'
 import { createHeaders, formatNumber, getFormatUnits, getShortNumber } from '../helpers'
 import { FIELDTYPES } from '../helpers/constants'
+import { getRowCurrency } from '../query/helpers'
 import {
 	applyDateRule,
 	applyRankRule,
@@ -524,13 +525,30 @@ function getCellStyleClass(colName: string, val: any): string {
 	return ''
 }
 
-function _formatNumber(value: any, columnName?: string) {
+// a total over rows in different currencies is an amount in none, so it prints bare
+const currencyPerColumn = computed(() => {
+	const codes: Record<string, string | null | undefined> = {}
+	const rows = visibleRows.value || []
+	for (const [name, format] of Object.entries(props.columnFormats || {})) {
+		if (format !== 'currency') continue
+		const seen = new Set(rows.map((row) => getRowCurrency(row, name)))
+		codes[name] = seen.size === 1 ? [...seen][0] : null
+	}
+	return codes
+})
+
+function _formatNumber(value: any, columnName?: string, row?: any) {
 	const isNull = value === null || value === undefined
 	if (isNull) {
 		return props.replaceNullsWithZeros ? 0 : 'null'
 	}
 	const { scale, prefix, suffix } = getFormatUnits(
 		columnName ? props.columnFormats?.[columnName] : undefined,
+		columnName
+			? row
+				? getRowCurrency(row, columnName)
+				: currencyPerColumn.value[columnName]
+			: undefined,
 	)
 	const scaled = value * scale
 	const printed = props.compactNumbers ? getShortNumber(scaled) : formatNumber(scaled)
@@ -727,7 +745,7 @@ function toggleNewColumn() {
 							@dblclick="isNumberColumn(col.name) && props.onDrilldown?.(col, row)"
 						>
 							<template v-if="isNumberColumn(col.name)">
-								{{ _formatNumber(row[col.name], col.name) }}
+								{{ _formatNumber(row[col.name], col.name, row) }}
 							</template>
 							<template v-else-if="isUrl(row[col.name])">
 								<a :href="row[col.name]" target="_blank" class="underline">

--- a/frontend/src2/helpers/index.ts
+++ b/frontend/src2/helpers/index.ts
@@ -191,21 +191,19 @@ export type FormatUnits = {
 const NO_UNITS: FormatUnits = { scale: 1, prefix: '', suffix: '' }
 
 // A measure states its unit once, and every reading of it prints that unit the
-// same way. A currency reads the site's symbol rather than carrying one, so the
-// same shipped chart is right on a site in dollars and a site in rupees. The
-// symbol sits where fmt_money puts it, so Insights and desk agree.
-export function getFormatUnits(format?: DataFormat): FormatUnits {
+// same way. The symbol sits where fmt_money puts it, so Insights and desk agree.
+export function getFormatUnits(format?: DataFormat, code?: string | null): FormatUnits {
 	if (format === 'percent') {
 		return { scale: 100, prefix: '', suffix: '%' }
 	}
-	if (format === 'currency') {
-		const symbol = session.site?.currency_symbol
-		if (!symbol) return NO_UNITS
-		return session.site.currency_symbol_on_right
-			? { scale: 1, prefix: '', suffix: ` ${symbol}` }
-			: { scale: 1, prefix: `${symbol} `, suffix: '' }
-	}
-	return NO_UNITS
+	if (format !== 'currency') return NO_UNITS
+
+	const resolved = code === undefined ? session.site?.currency : code
+	const currency = resolved ? session.site?.currency_symbols?.[resolved] : undefined
+	if (!currency?.symbol) return NO_UNITS
+	return currency.symbol_on_right
+		? { scale: 1, prefix: '', suffix: ` ${currency.symbol}` }
+		: { scale: 1, prefix: `${currency.symbol} `, suffix: '' }
 }
 
 export function guessPrecision(number: number) {

--- a/frontend/src2/query/helpers.ts
+++ b/frontend/src2/query/helpers.ts
@@ -103,6 +103,16 @@ export const expression = (expression: string): Expression => ({
 	expression,
 })
 
+// the server's summarize carries a money measure's currency code under this name;
+// `CARRIED_CURRENCY_SUFFIX` in ibis_utils.py must match
+export const currencyColumnName = (measure_name: string) => `${measure_name}__currency`
+
+// `undefined`: the measure names no column. `null`: the row mixes currencies.
+export function getRowCurrency(row: any, measure_name: string): string | null | undefined {
+	const key = currencyColumnName(measure_name)
+	return key in (row || {}) ? (row[key] ?? null) : undefined
+}
+
 // export const window_operation = (options: WindowOperationArgs): WindowOperation => ({
 // 	type: 'window_operation',
 // 	operation: options.operation,

--- a/frontend/src2/query/query.ts
+++ b/frontend/src2/query/query.ts
@@ -243,8 +243,10 @@ export function makeQuery(name: string) {
 			if (!response) return
 
 			result.value.executedSQL = response.sql
-			result.value.columns = response.columns
+			// the row keeps a hidden column; only the listing drops it
+			result.value.columns = response.columns.filter((c: QueryResultColumn) => !c.hidden)
 			result.value.rows = response.rows
+			Object.assign(session.site.currency_symbols, response.currency_symbols || {})
 			result.value.totalRowCount = 0
 			result.value.formattedRows = getFormattedRows(result.value, query.doc.operations)
 

--- a/frontend/src2/session.ts
+++ b/frontend/src2/session.ts
@@ -19,18 +19,19 @@ type SessionUser = {
 // Settings of the site, not of whoever is reading it. A guest opening a public
 // dashboard gets these and nothing else, so a shared chart prints its amounts
 // the same way the workbook does.
+type CurrencySymbol = { symbol: string; symbol_on_right: boolean }
 type SiteInfo = {
 	country: string
+	// stands in for a measure that names no currency column
 	currency: string | null
-	currency_symbol: string
-	currency_symbol_on_right: boolean
+	// starts with the site currency; each result adds its codes
+	currency_symbols: Record<string, CurrencySymbol>
 }
 
 const emptySite: SiteInfo = {
 	country: '',
 	currency: null,
-	currency_symbol: '',
-	currency_symbol_on_right: false,
+	currency_symbols: {},
 }
 
 const emptyUser: SessionUser = {
@@ -90,10 +91,7 @@ async function fetchSessionInfo() {
 
 async function fetchSiteInfo() {
 	const siteInfo: SiteInfo = await call('insights.api.get_site_info')
-	Object.assign(session.site, {
-		...siteInfo,
-		currency_symbol_on_right: Boolean(siteInfo.currency_symbol_on_right),
-	})
+	Object.assign(session.site, siteInfo)
 }
 
 async function login(email: string, password: string) {

--- a/frontend/src2/types/query.types.ts
+++ b/frontend/src2/types/query.types.ts
@@ -19,12 +19,14 @@ export type ColumnMeasure = {
 	data_type: MeasureDataType
 	aggregation: AggregationType
 	format?: DataFormat
+	currency_column?: string
 }
 export type ExpressionMeasure = {
 	measure_name: string
 	expression: Expression
 	data_type: MeasureDataType
 	format?: DataFormat
+	currency_column?: string
 }
 export type MeasureOption = Measure & { label: string; value: string }
 export type Dimension = {
@@ -202,6 +204,7 @@ export type QueryResultRow = Record<string, any>
 export type QueryResultColumn = {
 	name: string
 	type: ColumnDataType
+	hidden?: boolean
 }
 
 export type DropdownOption = {

--- a/insights/api/__init__.py
+++ b/insights/api/__init__.py
@@ -6,7 +6,6 @@ import os
 import frappe
 from frappe.handler import is_valid_http_method, is_whitelisted
 from frappe.monitor import add_data_to_monitor
-from frappe.utils import cint
 
 from insights.api.shared import get_public_permission_user, is_public
 from insights.decorators import insights_whitelist
@@ -20,7 +19,7 @@ from insights.insights.doctype.insights_team.insights_team import (
     check_data_source_permission,
 )
 from insights.permission_user import permission_user
-from insights.utils import get_owned_file
+from insights.utils import get_currency_symbols, get_owned_file
 
 
 @insights_whitelist()
@@ -28,8 +27,8 @@ def get_app_version():
     return frappe.get_attr("insights" + ".__version__")
 
 
-@frappe.whitelist(allow_guest=True)  # nosemgrep - the payload is the site's currency and
-# country, which a public dashboard already prints
+@frappe.whitelist(allow_guest=True)  # nosemgrep - the payload is the site's country and
+# currency, which a public dashboard already prints
 def get_site_info():
     """Settings of the site, not of whoever reads it. A guest opening a public
     dashboard needs them to print an amount the way the workbook does."""
@@ -40,30 +39,18 @@ def get_site_info():
 
 
 def get_currency_info():
-    """The site's display currency, as the client needs it to print an amount.
+    """The site's currency: the code a measure that names no column prints in.
+
+    Its symbol is the one entry the client starts with.
 
     The `currency` global default covers a site with ERPNext and one without:
     ERPNext's Global Defaults writes `default_currency` into it, and plain Frappe
-    writes `System Settings.currency` into it. `hide_currency_symbol` empties the
-    symbol, which is how a site says amounts print bare.
+    writes `System Settings.currency` into it.
     """
     # System Settings writes the default only when the field changes, so read the
     # field too — a site installed with a currency has never "changed" it
     currency = frappe.db.get_default("currency") or frappe.db.get_single_value("System Settings", "currency")
-    if not currency:
-        return {"currency": None, "currency_symbol": "", "currency_symbol_on_right": False}
-
-    hidden = cint(frappe.defaults.get_global_default("hide_currency_symbol"))
-    symbol, on_right = frappe.db.get_value("Currency", currency, ["symbol", "symbol_on_right"]) or (
-        None,
-        None,
-    )
-    return {
-        "currency": currency,
-        # a currency with no symbol of its own prints as its code, the way fmt_money does
-        "currency_symbol": "" if hidden else (symbol or currency),
-        "currency_symbol_on_right": bool(on_right),
-    }
+    return {"currency": currency or None, "currency_symbols": get_currency_symbols([currency])}
 
 
 @insights_whitelist()

--- a/insights/insights/doctype/insights_data_source_v3/ibis_utils.py
+++ b/insights/insights/doctype/insights_data_source_v3/ibis_utils.py
@@ -53,6 +53,31 @@ SQL_COLUMN_RELATION = "_insights_sql_column"
 NATIVE_SQL_RELATION = "_insights_native_sql"
 
 
+# the summarize carries a money measure's currency code as `<measure>__currency`,
+# because the code must survive aggregation. The client reads it by that name
+# (`currencyColumnName` in query/helpers.ts), so the suffix is a contract. A column
+# so named is hidden in every schema read.
+CARRIED_CURRENCY_SUFFIX = "__currency"
+
+
+def is_carried_currency_column(name: str) -> bool:
+    return name.endswith(CARRIED_CURRENCY_SUFFIX)
+
+
+# a carried currency is the only kind of hidden column today
+def is_hidden_column(name: str) -> bool:
+    return is_carried_currency_column(name)
+
+
+def get_carried_currency_columns(measures) -> dict[str, str]:
+    """Carried column name to the source column it is read from."""
+    return {
+        f"{measure['measure_name']}{CARRIED_CURRENCY_SUFFIX}": measure["currency_column"]
+        for measure in measures or []
+        if measure.get("format") == "currency" and measure.get("currency_column")
+    }
+
+
 class CircularQueryReferenceError(frappe.ValidationError):
     """Raised when a circular query reference is detected during query building."""
 
@@ -610,8 +635,22 @@ class IbisQueryBuilder:
     def apply_summary(self, summarize_args):
         aggregates = [self.translate_measure(measure) for measure in summarize_args.measures]
         aggregates = {agg.get_name(): agg for agg in aggregates}
+        aggregates.update(self.translate_carried_currencies(summarize_args.measures))
         group_bys = [self.translate_dimension(dimension) for dimension in summarize_args.dimensions]
         return self.query.aggregate(**aggregates, by=group_bys)
+
+    def translate_carried_currencies(self, measures):
+        carried = {}
+        for name, column_name in get_carried_currency_columns(measures).items():
+            # a missing column must not fail the query; it carries null and the amount prints bare
+            col = self.get_column(column_name, throw=False)
+            if col is None:
+                carried[name] = ibis.null().cast("string")
+                continue
+            # min and max skip nulls, so a row with no code is checked apart
+            one_currency = (col.min() == col.max()) & ~col.isnull().any()
+            carried[name] = ibis.ifelse(one_currency, col.min(), ibis.null()).cast("string")
+        return carried
 
     def apply_order_by(self, order_by_args):
         order_by_column = self.get_column(order_by_args.column.column_name, throw=False)
@@ -1141,6 +1180,7 @@ def get_columns_from_schema(schema: ibis.Schema):
         {
             "name": col,
             "type": to_insights_type(dtype),
+            **({"hidden": True} if is_hidden_column(col) else {}),
         }
         for col, dtype in schema.items()
     ]

--- a/insights/insights/doctype/insights_query_v3/insights_query_v3.py
+++ b/insights/insights/doctype/insights_query_v3/insights_query_v3.py
@@ -19,6 +19,8 @@ from insights.insights.doctype.insights_data_source_v3.ibis_utils import (
     IbisQueryBuilder,
     execute_ibis_query,
     get_columns_from_schema,
+    is_carried_currency_column,
+    is_hidden_column,
 )
 from insights.insights.query_utils import (
     extract_query_deps_from_operations,
@@ -29,7 +31,7 @@ from insights.insights.query_utils import (
     table_references,
     transitive_closure,
 )
-from insights.utils import as_text, deep_convert_dict_to_dict
+from insights.utils import as_text, deep_convert_dict_to_dict, get_currency_symbols
 
 
 class InsightsQueryv3(Document):
@@ -198,6 +200,9 @@ class InsightsQueryv3(Document):
 
         columns = get_columns_from_schema(ibis_query.schema())
 
+        carried = [c["name"] for c in columns if is_carried_currency_column(c["name"])]
+        codes = {row[name] for name in carried for row in results}
+
         sql = None
         with suppress(Exception):
             for op in frappe.parse_json(self.operations) or []:
@@ -209,6 +214,7 @@ class InsightsQueryv3(Document):
             "sql": ibis.to_sql(ibis_query),
             "columns": columns,
             "rows": results,
+            "currency_symbols": get_currency_symbols(codes),
             "time_taken": time_taken,
             "is_aggregated_sql": _sql_has_group_by(sql) if sql else False,
         }
@@ -262,6 +268,10 @@ class InsightsQueryv3(Document):
 
         with set_adhoc_filters(adhoc_filters):
             ibis_query = self.build(active_operation_idx)
+
+        hidden = [col for col in ibis_query.columns if is_hidden_column(col)]
+        if hidden:
+            ibis_query = ibis_query.drop(*hidden)
 
         import ibis.expr.datatypes as dt
 
@@ -326,8 +336,7 @@ class InsightsQueryv3(Document):
     @insights_whitelist()
     def get_columns_for_selection(self, active_operation_idx: int | None = None):
         ibis_query = self.build(active_operation_idx)
-        columns = get_columns_from_schema(ibis_query.schema())
-        return columns
+        return [c for c in get_columns_from_schema(ibis_query.schema()) if not c.get("hidden")]
 
     def evaluate_alert_expression(self, expression):
         builder = IbisQueryBuilder(self)

--- a/insights/tests/test_currency_info.py
+++ b/insights/tests/test_currency_info.py
@@ -5,11 +5,12 @@ import frappe
 from insights.api import get_currency_info, get_site_info
 from insights.tests.base import InsightsIntegrationTestCase
 from insights.tests.factories import as_user
+from insights.utils import get_currency_symbols
 
 
 def _defaults(currency=None, hide_symbol=None):
-    """Stand in for the two default reads get_currency_info makes, so a test
-    states a site's currency without writing the shared site's defaults."""
+    """Stand in for the two default reads `get_currency_info` and `get_currency_symbols`
+    make, so a test states a site's currency without writing the shared site's defaults."""
     return (
         patch.object(frappe.db, "get_default", return_value=currency),
         patch.object(frappe.defaults, "get_global_default", return_value=hide_symbol),
@@ -17,45 +18,55 @@ def _defaults(currency=None, hide_symbol=None):
 
 
 class TestCurrencyInfo(InsightsIntegrationTestCase):
-    # two tests edit a Currency record to state a shape the site does not have
+    # tests edit Currency records to state a shape the site does not have
     SAVEPOINT = "test_currency_info"
 
-    def test_symbol_comes_from_the_site_currency(self):
+    def test_the_session_starts_with_the_site_currency_and_its_symbol(self):
         currency, hidden = _defaults("USD")
         with currency, hidden:
             self.assertEqual(
                 get_currency_info(),
-                {"currency": "USD", "currency_symbol": "$", "currency_symbol_on_right": False},
+                {"currency": "USD", "currency_symbols": {"USD": {"symbol": "$", "symbol_on_right": False}}},
             )
 
-    def test_symbol_sits_on_the_right_when_the_currency_says_so(self):
-        frappe.db.set_value("Currency", "SEK", "symbol_on_right", 1)
-        currency, hidden = _defaults("SEK")
-        with currency, hidden:
-            info = get_currency_info()
-        self.assertEqual(info["currency"], "SEK")
-        self.assertTrue(info["currency_symbol_on_right"])
+    def test_a_symbol_is_looked_up_by_the_code_a_result_carries(self):
+        # a disabled currency resolves like an enabled one
+        frappe.db.set_value("Currency", "SEK", {"enabled": 0, "symbol_on_right": 1})
+        _, hidden = _defaults()
+        with hidden:
+            symbols = get_currency_symbols(["INR", "SEK"])
+        self.assertEqual(symbols["INR"]["symbol"], "₹")
+        self.assertEqual(symbols["SEK"], {"symbol": "kr", "symbol_on_right": True})
 
     def test_a_currency_without_a_symbol_prints_as_its_code(self):
         frappe.db.set_value("Currency", "XAF", "symbol", "")
-        currency, hidden = _defaults("XAF")
-        with currency, hidden:
-            self.assertEqual(get_currency_info()["currency_symbol"], "XAF")
+        _, hidden = _defaults()
+        with hidden:
+            self.assertEqual(get_currency_symbols(["XAF"])["XAF"]["symbol"], "XAF")
 
-    def test_hide_currency_symbol_empties_the_symbol(self):
+    def test_a_code_with_no_currency_row_prints_as_itself(self):
+        # a CSV value has no Currency row, and the amount still prints
+        _, hidden = _defaults()
+        with hidden:
+            self.assertEqual(
+                get_currency_symbols(["High"])["High"], {"symbol": "High", "symbol_on_right": False}
+            )
+
+    def test_a_null_code_is_skipped(self):
+        _, hidden = _defaults()
+        with hidden:
+            self.assertEqual(get_currency_symbols([None, ""]), {})
+
+    def test_hide_currency_symbol_empties_every_lookup(self):
         currency, hidden = _defaults("INR", hide_symbol="1")
         with currency, hidden:
-            info = get_currency_info()
-        self.assertEqual(info["currency"], "INR")
-        self.assertEqual(info["currency_symbol"], "")
+            self.assertEqual(get_currency_info(), {"currency": "INR", "currency_symbols": {}})
+            self.assertEqual(get_currency_symbols(["USD"]), {})
 
-    def test_a_site_without_a_currency_prints_amounts_bare(self):
+    def test_a_site_without_a_currency_has_none_to_assume(self):
         currency, hidden = _defaults(None)
         with currency, hidden, patch.object(frappe.db, "get_single_value", return_value=""):
-            self.assertEqual(
-                get_currency_info(),
-                {"currency": None, "currency_symbol": "", "currency_symbol_on_right": False},
-            )
+            self.assertEqual(get_currency_info(), {"currency": None, "currency_symbols": {}})
 
     def test_a_guest_reading_a_public_dashboard_gets_the_symbol(self):
         # the guest whitelist is the point of the endpoint: a shared chart is
@@ -63,7 +74,7 @@ class TestCurrencyInfo(InsightsIntegrationTestCase):
         self.assertIn(get_site_info, frappe.guest_methods)
         currency, hidden = _defaults("USD")
         with as_user("Guest"), currency, hidden:
-            self.assertEqual(get_site_info()["currency_symbol"], "$")
+            self.assertEqual(get_site_info()["currency_symbols"]["USD"]["symbol"], "$")
 
     def test_the_client_can_reach_it_the_way_it_calls_it(self):
         # frappe-ui's `call` posts. An endpoint declared GET-only answers it

--- a/insights/tests/test_hidden_columns.py
+++ b/insights/tests/test_hidden_columns.py
@@ -1,0 +1,149 @@
+"""A summarize carries a money measure's currency code beside the measure. The value
+is in every row, read by name. The column is listed nowhere and exported nowhere.
+"""
+
+import copy
+
+import frappe
+
+from insights.insights.doctype.insights_data_source_v3.ibis_utils import is_hidden_column
+from insights.tests.base import InsightsIntegrationTestCase
+from insights.tests.factories import DT, as_user, create_test_query, create_test_workbook, delete_users
+from insights.tests.permissions_utils import ADMIN, create_test_users
+
+SITE_DB = {"type": "table", "data_source": "Site DB", "table_name": "tabToDo"}
+
+# filters out the site's other ToDos
+TOKEN = "insights-hidden-columns"
+
+# a ToDo's priority is a short code, so it stands in for a currency column
+OPERATIONS = [
+    {"type": "source", "table": SITE_DB},
+    {
+        "type": "filter_group",
+        "logical_operator": "And",
+        "filters": [
+            {
+                "column": {"type": "column", "column_name": "description"},
+                "operator": "=",
+                "value": TOKEN,
+            }
+        ],
+    },
+    {
+        "type": "summarize",
+        "measures": [
+            {
+                "measure_name": "todos",
+                "column_name": "name",
+                "data_type": "Integer",
+                "aggregation": "count",
+                "format": "currency",
+                "currency_column": "priority",
+            }
+        ],
+        "dimensions": [{"dimension_name": "status", "column_name": "status", "data_type": "String"}],
+    },
+]
+
+
+def make_todo(status, priority):
+    todo = frappe.get_doc(
+        {
+            "doctype": "ToDo",
+            "description": TOKEN,
+            "status": status,
+            "priority": priority,
+        }
+    ).insert()
+    if priority is None:
+        # priority has a default, so empty it after insert
+        frappe.db.set_value("ToDo", todo.name, "priority", None)
+    return todo.name
+
+
+class TestHiddenColumns(InsightsIntegrationTestCase):
+    @classmethod
+    def before_class(cls):
+        create_test_users()
+        cls.workbook = create_test_workbook(ADMIN, title="Hidden Columns Workbook").name
+        cls.query = create_test_query(ADMIN, cls.workbook, title="Hidden Columns", operations=OPERATIONS).name
+        with as_user(ADMIN):
+            cls.todos = [
+                make_todo("Open", "High"),
+                make_todo("Closed", "Medium"),
+                make_todo("Closed", None),
+            ]
+        # the query reads over its own connection, so commit
+        frappe.db.commit()
+
+    @classmethod
+    def after_class(cls):
+        frappe.delete_doc(DT.WORKBOOK, cls.workbook, force=True, ignore_permissions=True)
+        for todo in cls.todos:
+            frappe.delete_doc("ToDo", todo, force=True, ignore_permissions=True)
+        frappe.db.commit()
+        delete_users(ADMIN)
+
+    def carried(self):
+        with as_user(ADMIN):
+            result = frappe.get_doc(DT.QUERY, self.query).execute(force=True)
+        return result, {row["status"]: row["todos__currency"] for row in result["rows"]}
+
+    def test_the_name_says_what_is_carried(self):
+        # the client reads the code off the row by this name
+        self.assertTrue(is_hidden_column("todos__currency"))
+        self.assertFalse(is_hidden_column("todos"))
+
+    def test_a_query_built_on_this_one_hides_the_carried_column_too(self):
+        operations = [
+            {
+                "type": "source",
+                "table": {"type": "query", "workbook": self.workbook, "query_name": self.query},
+            }
+        ]
+        reader = create_test_query(ADMIN, self.workbook, title="Reads Hidden Columns", operations=operations)
+        with as_user(ADMIN):
+            result = reader.execute(force=True)
+            offered = reader.get_columns_for_selection()
+        by_name = {c["name"]: c for c in result["columns"]}
+        self.assertTrue(by_name["todos__currency"].get("hidden"))
+        self.assertNotIn("todos__currency", [c["name"] for c in offered])
+
+    def test_a_carried_column_is_marked_and_its_value_still_rides_in_the_row(self):
+        result, by_status = self.carried()
+        by_name = {c["name"]: c for c in result["columns"]}
+        self.assertTrue(by_name["todos__currency"].get("hidden"))
+        self.assertNotIn("hidden", by_name["todos"])
+        self.assertEqual(by_status["Open"], "High")
+        self.assertEqual(result["currency_symbols"]["High"]["symbol"], "High")
+        self.assertNotIn(None, result["currency_symbols"])
+
+    def test_a_group_holding_a_row_without_a_code_carries_none(self):
+        # min and max skip nulls, so a null row must void the group on its own
+        _, by_status = self.carried()
+        self.assertIsNone(by_status["Closed"])
+
+    def test_a_carried_column_is_not_offered_to_the_author(self):
+        with as_user(ADMIN):
+            offered = frappe.get_doc(DT.QUERY, self.query).get_columns_for_selection()
+        names = [c["name"] for c in offered]
+        self.assertIn("todos", names)
+        self.assertNotIn("todos__currency", names)
+
+    def test_a_currency_column_that_is_gone_carries_none_rather_than_failing(self):
+        # a missing column must not fail the query, and it carries null, not the site currency
+        operations = copy.deepcopy(OPERATIONS)
+        operations[-1]["measures"][0]["currency_column"] = "no_such_column"
+        query = create_test_query(ADMIN, self.workbook, title="Missing Currency", operations=operations)
+        with as_user(ADMIN):
+            result = query.execute(force=True)
+        self.assertTrue(all(row["todos__currency"] is None for row in result["rows"]))
+
+    def test_a_carried_column_does_not_leave_in_an_export(self):
+        frappe.db.set_single_value("Insights Settings", "allow_download", 1)
+        with as_user(ADMIN):
+            csv = frappe.get_doc(DT.QUERY, self.query).download_results(format="csv")
+        header = csv.splitlines()[0].split(",")
+        self.assertIn("todos", header)
+        self.assertNotIn("todos__currency", header)

--- a/insights/tests/test_workbook_templates.py
+++ b/insights/tests/test_workbook_templates.py
@@ -62,6 +62,35 @@ def bumped_version(template_name, version):
     return patch("insights.api.templates._discover_templates", return_value=registry)
 
 
+def money_measures(node):
+    """Every measure in a chart that prints an amount, wherever it sits in the config."""
+    if isinstance(node, dict):
+        if node.get("format") == "currency":
+            yield node
+        for value in node.values():
+            yield from money_measures(value)
+    elif isinstance(node, list):
+        for value in node:
+            yield from money_measures(value)
+
+
+def query_columns(query):
+    """The columns a template query makes, and whether that is all of them.
+
+    A source table's own columns are not written in the operations, so the set
+    is open until a `select` names every column that survives it.
+    """
+    columns, closed = set(), False
+    for op in query["operations"]:
+        if op["type"] == "join":
+            columns.update(column["column_name"] for column in op.get("select_columns") or [])
+        elif op["type"] == "select":
+            columns, closed = set(op["column_names"]), True
+        elif op["type"] == "mutate":
+            columns.add(op["new_name"])
+    return columns, closed
+
+
 def cleanup_template_workbooks():
     # template workbooks are owned by Administrator now, so owner-scoped cleanup
     # can't reach them — delete by their derived origin tag instead
@@ -359,6 +388,19 @@ class TestWorkbookTemplates(InsightsIntegrationTestCase):
         self.assertEqual(
             frappe.db.get_value("Insights Workbook", workbook_name, "imported_version"), TEMPLATE_VERSION
         )
+
+    def test_every_money_measure_names_a_currency_column_its_query_makes(self):
+        for name in get_template_names():
+            workbook = get_template_workbook(name)["dependencies"]
+            for chart_name, chart in workbook["charts"].items():
+                for measure in money_measures(chart):
+                    column = measure.get("currency_column")
+                    self.assertTrue(column, f"{chart_name} formats money without a currency column")
+                    columns, closed = query_columns(workbook["queries"][chart["query"]])
+                    if closed or column in columns:
+                        self.assertIn(
+                            column, columns, f"{chart_name} names a currency column its query drops"
+                        )
 
     def test_every_committed_template_is_valid_and_importable(self):
         """CI guard: every committed manifest parses with the required keys and

--- a/insights/utils.py
+++ b/insights/utils.py
@@ -221,3 +221,28 @@ class InsightsPageRenderer(TemplatePage):
         allowed_origins = [origin.strip() for origin in allowed_origins]
         allowed_origins = " ".join(allowed_origins)
         self.headers["Content-Security-Policy"] = f"frame-ancestors 'self' {allowed_origins}"
+
+
+def get_currency_symbols(codes) -> dict:
+    """The symbol for each currency code.
+
+    Codes arrive with each result, so nothing is sent ahead. A code with no Currency
+    row, or with no symbol, prints as the code, the way fmt_money does.
+    `hide_currency_symbol` empties every symbol.
+    """
+    codes = {code for code in codes if code}
+    if not codes or frappe.utils.cint(frappe.defaults.get_global_default("hide_currency_symbol")):
+        return {}
+
+    # one read: a measure pointed at the wrong column names as many codes as rows
+    rows = frappe.db.get_all(
+        "Currency", filters={"name": ("in", list(codes))}, fields=["name", "symbol", "symbol_on_right"]
+    )
+    known = {row.name: row for row in rows}
+    return {
+        code: {
+            "symbol": (known[code].symbol if code in known else None) or code,
+            "symbol_on_right": bool(known[code].symbol_on_right) if code in known else False,
+        }
+        for code in codes
+    }

--- a/insights/workbook_templates/accounting/manifest.json
+++ b/insights/workbook_templates/accounting/manifest.json
@@ -1,8 +1,8 @@
 {
-	"version": 3,
+	"version": 4,
 	"title": "Receivables, Payables & Cash",
 	"description": "AR/AP ageing, a collections worklist and a cash-flow view for receivables, payables and cash.",
-	"notes": "Built from submitted Sales/Purchase Invoices, Payment Entries and the Payment Ledger (delinked=0), so payment-rounding residuals don't inflate receivables/payables. AR/AP outstanding is read from the Payment Ledger Entry rather than reconstructed from GL, which is far cheaper on large sites. Snapshot figures are as-of-today in the company's base currency; the date filter drives the cash-flow trends.",
+	"notes": "Built from submitted Sales/Purchase Invoices, Payment Entries and the Payment Ledger (delinked=0), so payment-rounding residuals don't inflate receivables/payables. AR/AP outstanding is read from the Payment Ledger Entry rather than reconstructed from GL, which is far cheaper on large sites. Snapshot figures are as-of-today in each company's base currency, so a reading that spans companies with different currencies prints bare. Reads Company for each company's currency, so a reader needs that table too; the date filter drives the cash-flow trends.",
 	"module": "Accounts",
 	"required_apps": [
 		"erpnext"
@@ -11,6 +11,7 @@
 		"Sales Invoice",
 		"Purchase Invoice",
 		"Payment Entry",
-		"Payment Ledger Entry"
+		"Payment Ledger Entry",
+		"Company"
 	]
 }

--- a/insights/workbook_templates/accounting/workbook.json
+++ b/insights/workbook_templates/accounting/workbook.json
@@ -126,6 +126,31 @@
 						}
 					},
 					{
+						"type": "join",
+						"join_type": "left",
+						"table": {
+							"type": "table",
+							"data_source": "Site DB",
+							"table_name": "tabCompany"
+						},
+						"select_columns": [
+							{
+								"type": "column",
+								"column_name": "default_currency"
+							}
+						],
+						"join_condition": {
+							"left_column": {
+								"type": "column",
+								"column_name": "company"
+							},
+							"right_column": {
+								"type": "column",
+								"column_name": "name"
+							}
+						}
+					},
+					{
 						"type": "mutate",
 						"new_name": "days_overdue",
 						"data_type": "Integer",
@@ -288,6 +313,31 @@
 						}
 					},
 					{
+						"type": "join",
+						"join_type": "left",
+						"table": {
+							"type": "table",
+							"data_source": "Site DB",
+							"table_name": "tabCompany"
+						},
+						"select_columns": [
+							{
+								"type": "column",
+								"column_name": "default_currency"
+							}
+						],
+						"join_condition": {
+							"left_column": {
+								"type": "column",
+								"column_name": "company"
+							},
+							"right_column": {
+								"type": "column",
+								"column_name": "name"
+							}
+						}
+					},
+					{
 						"type": "mutate",
 						"new_name": "days_overdue",
 						"data_type": "Integer",
@@ -359,6 +409,31 @@
 								]
 							}
 						]
+					},
+					{
+						"type": "join",
+						"join_type": "left",
+						"table": {
+							"type": "table",
+							"data_source": "Site DB",
+							"table_name": "tabCompany"
+						},
+						"select_columns": [
+							{
+								"type": "column",
+								"column_name": "default_currency"
+							}
+						],
+						"join_condition": {
+							"left_column": {
+								"type": "column",
+								"column_name": "company"
+							},
+							"right_column": {
+								"type": "column",
+								"column_name": "name"
+							}
+						}
 					},
 					{
 						"type": "mutate",
@@ -547,7 +622,8 @@
 							"column_name": "outstanding",
 							"data_type": "Decimal",
 							"aggregation": "sum",
-							"format": "currency"
+							"format": "currency",
+							"currency_column": "default_currency"
 						}
 					],
 					"comparison": false,
@@ -570,7 +646,8 @@
 							"column_name": "outstanding",
 							"data_type": "Decimal",
 							"aggregation": "sum",
-							"format": "currency"
+							"format": "currency",
+							"currency_column": "default_currency"
 						}
 					],
 					"comparison": false,
@@ -645,7 +722,8 @@
 							"column_name": "net_amount",
 							"data_type": "Decimal",
 							"aggregation": "sum",
-							"format": "currency"
+							"format": "currency",
+							"currency_column": "default_currency"
 						}
 					],
 					"comparison": false,
@@ -756,14 +834,16 @@
 							"column_name": "outstanding",
 							"data_type": "Decimal",
 							"aggregation": "sum",
-							"format": "currency"
+							"format": "currency",
+							"currency_column": "default_currency"
 						},
 						{
 							"measure_name": "Overdue",
 							"column_name": "overdue_outstanding",
 							"data_type": "Decimal",
 							"aggregation": "sum",
-							"format": "currency"
+							"format": "currency",
+							"currency_column": "default_currency"
 						},
 						{
 							"measure_name": "Oldest Days",
@@ -817,7 +897,8 @@
 							"column_name": "outstanding",
 							"data_type": "Decimal",
 							"aggregation": "sum",
-							"format": "currency"
+							"format": "currency",
+							"currency_column": "default_currency"
 						}
 					],
 					"filters": {

--- a/insights/workbook_templates/purchasing/manifest.json
+++ b/insights/workbook_templates/purchasing/manifest.json
@@ -1,9 +1,9 @@
 {
-	"version": 2,
+	"version": 3,
 	"title": "Purchasing Overview",
 	"description": "Supplier spend, order workload and receiving risk at a glance — spend trend with month-on-month KPIs, spend by item group, top suppliers, purchase-order status mix and an overdue-POs list.",
-	"notes": "Built from submitted Purchase Invoices and Purchase Orders. Amounts are in the company's base currency and net of returns (debit notes ride along as negative rows). Order count and average order value are measured on Purchase Orders by transaction date.",
+	"notes": "Built from submitted Purchase Invoices and Purchase Orders. Amounts are in each company's base currency and net of returns (debit notes ride along as negative rows), so a reading that spans companies with different currencies prints bare. Reads Company for each company's currency, so a reader needs that table too. Order count and average order value are measured on Purchase Orders by transaction date.",
 	"module": "Buying",
 	"required_apps": ["erpnext"],
-	"source_doctypes": ["Purchase Invoice", "Purchase Invoice Item", "Purchase Order"]
+	"source_doctypes": ["Purchase Invoice", "Purchase Invoice Item", "Purchase Order", "Company"]
 }

--- a/insights/workbook_templates/purchasing/workbook.json
+++ b/insights/workbook_templates/purchasing/workbook.json
@@ -41,6 +41,31 @@
 								"value": 1
 							}
 						]
+					},
+					{
+						"type": "join",
+						"join_type": "left",
+						"table": {
+							"type": "table",
+							"data_source": "Site DB",
+							"table_name": "tabCompany"
+						},
+						"select_columns": [
+							{
+								"type": "column",
+								"column_name": "default_currency"
+							}
+						],
+						"join_condition": {
+							"left_column": {
+								"type": "column",
+								"column_name": "company"
+							},
+							"right_column": {
+								"type": "column",
+								"column_name": "name"
+							}
+						}
 					}
 				]
 			},
@@ -140,6 +165,31 @@
 								"value": 1
 							}
 						]
+					},
+					{
+						"type": "join",
+						"join_type": "left",
+						"table": {
+							"type": "table",
+							"data_source": "Site DB",
+							"table_name": "tabCompany"
+						},
+						"select_columns": [
+							{
+								"type": "column",
+								"column_name": "default_currency"
+							}
+						],
+						"join_condition": {
+							"left_column": {
+								"type": "column",
+								"column_name": "company"
+							},
+							"right_column": {
+								"type": "column",
+								"column_name": "name"
+							}
+						}
 					}
 				]
 			},
@@ -203,6 +253,31 @@
 						]
 					},
 					{
+						"type": "join",
+						"join_type": "left",
+						"table": {
+							"type": "table",
+							"data_source": "Site DB",
+							"table_name": "tabCompany"
+						},
+						"select_columns": [
+							{
+								"type": "column",
+								"column_name": "default_currency"
+							}
+						],
+						"join_condition": {
+							"left_column": {
+								"type": "column",
+								"column_name": "company"
+							},
+							"right_column": {
+								"type": "column",
+								"column_name": "name"
+							}
+						}
+					},
+					{
 						"type": "mutate",
 						"new_name": "days_late",
 						"data_type": "Integer",
@@ -230,7 +305,8 @@
 							"column_name": "base_net_total",
 							"data_type": "Decimal",
 							"aggregation": "sum",
-							"format": "currency"
+							"format": "currency",
+							"currency_column": "default_currency"
 						},
 						{
 							"measure_name": "Active Suppliers",
@@ -293,7 +369,8 @@
 							"column_name": "base_grand_total",
 							"data_type": "Decimal",
 							"aggregation": "avg",
-							"format": "currency"
+							"format": "currency",
+							"currency_column": "default_currency"
 						}
 					],
 					"number_column_options": [
@@ -516,7 +593,8 @@
 							"column_name": "base_grand_total",
 							"data_type": "Decimal",
 							"aggregation": "sum",
-							"format": "currency"
+							"format": "currency",
+							"currency_column": "default_currency"
 						}
 					],
 					"order_by": [

--- a/insights/workbook_templates/sales/manifest.json
+++ b/insights/workbook_templates/sales/manifest.json
@@ -1,9 +1,9 @@
 {
-	"version": 3,
+	"version": 4,
 	"title": "Sales Performance",
 	"description": "Revenue, customers and fulfilment at a glance — revenue trend with month-on-month KPIs, top customers and items, a quotation-to-order funnel and an overdue-deliveries list.",
-	"notes": "Built from submitted Sales Invoices, Quotations and Sales Orders. Amounts are in the company's base currency and net of returns. POS invoices are reflected only after POS closing.",
+	"notes": "Built from submitted Sales Invoices, Quotations and Sales Orders. Amounts are in each company's base currency and net of returns, so a reading that spans companies with different currencies prints bare. Reads Company for each company's currency, so a reader needs that table too. POS invoices are reflected only after POS closing.",
 	"module": "Selling",
 	"required_apps": ["erpnext"],
-	"source_doctypes": ["Sales Invoice", "Sales Invoice Item", "Sales Order", "Quotation"]
+	"source_doctypes": ["Sales Invoice", "Sales Invoice Item", "Sales Order", "Quotation", "Company"]
 }

--- a/insights/workbook_templates/sales/workbook.json
+++ b/insights/workbook_templates/sales/workbook.json
@@ -41,6 +41,31 @@
 								"value": 1
 							}
 						]
+					},
+					{
+						"type": "join",
+						"join_type": "left",
+						"table": {
+							"type": "table",
+							"data_source": "Site DB",
+							"table_name": "tabCompany"
+						},
+						"select_columns": [
+							{
+								"type": "column",
+								"column_name": "default_currency"
+							}
+						],
+						"join_condition": {
+							"left_column": {
+								"type": "column",
+								"column_name": "company"
+							},
+							"right_column": {
+								"type": "column",
+								"column_name": "name"
+							}
+						}
 					}
 				]
 			},
@@ -332,6 +357,31 @@
 						]
 					},
 					{
+						"type": "join",
+						"join_type": "left",
+						"table": {
+							"type": "table",
+							"data_source": "Site DB",
+							"table_name": "tabCompany"
+						},
+						"select_columns": [
+							{
+								"type": "column",
+								"column_name": "default_currency"
+							}
+						],
+						"join_condition": {
+							"left_column": {
+								"type": "column",
+								"column_name": "company"
+							},
+							"right_column": {
+								"type": "column",
+								"column_name": "name"
+							}
+						}
+					},
+					{
 						"type": "mutate",
 						"new_name": "days_late",
 						"data_type": "Integer",
@@ -359,7 +409,8 @@
 							"column_name": "base_net_total",
 							"data_type": "Decimal",
 							"aggregation": "sum",
-							"format": "currency"
+							"format": "currency",
+							"currency_column": "default_currency"
 						},
 						{
 							"measure_name": "Invoices",
@@ -372,7 +423,8 @@
 							"column_name": "base_net_total",
 							"data_type": "Decimal",
 							"aggregation": "avg",
-							"format": "currency"
+							"format": "currency",
+							"currency_column": "default_currency"
 						},
 						{
 							"measure_name": "Active Customers",
@@ -694,7 +746,8 @@
 							"column_name": "base_grand_total",
 							"data_type": "Decimal",
 							"aggregation": "sum",
-							"format": "currency"
+							"format": "currency",
+							"currency_column": "default_currency"
 						}
 					],
 					"order_by": [

--- a/insights/workbook_templates/stock/manifest.json
+++ b/insights/workbook_templates/stock/manifest.json
@@ -1,9 +1,9 @@
 {
-	"version": 2,
+	"version": 3,
 	"title": "Inventory Health",
 	"description": "Stock value, ageing and reorder health — value by warehouse and item group, incoming vs outgoing movement, a reorder alert list and top items by value.",
-	"notes": "Built from live Bin balances and Stock Ledger Entries. Values are in the company's base currency and reflect the site's current valuation state (backdated or un-reposted entries can skew Bin values). Stock ageing and dead-stock use an item-level last-movement proxy, not FIFO lot ageing.",
+	"notes": "Built from live Bin balances and Stock Ledger Entries. Values are in each company's base currency, so a reading that spans companies with different currencies prints bare, and they reflect the site's current valuation state (backdated or un-reposted entries can skew Bin values). Reads Company for each company's currency, so a reader needs that table too. Stock ageing and dead-stock use an item-level last-movement proxy, not FIFO lot ageing.",
 	"module": "Stock",
 	"required_apps": ["erpnext"],
-	"source_doctypes": ["Bin", "Stock Ledger Entry", "Item", "Item Reorder"]
+	"source_doctypes": ["Bin", "Stock Ledger Entry", "Item", "Item Reorder", "Company"]
 }

--- a/insights/workbook_templates/stock/workbook.json
+++ b/insights/workbook_templates/stock/workbook.json
@@ -30,6 +30,31 @@
 					},
 					{
 						"type": "join",
+						"join_type": "left",
+						"table": {
+							"type": "table",
+							"data_source": "Site DB",
+							"table_name": "tabCompany"
+						},
+						"select_columns": [
+							{
+								"type": "column",
+								"column_name": "default_currency"
+							}
+						],
+						"join_condition": {
+							"left_column": {
+								"type": "column",
+								"column_name": "company"
+							},
+							"right_column": {
+								"type": "column",
+								"column_name": "name"
+							}
+						}
+					},
+					{
+						"type": "join",
 						"join_type": "inner",
 						"table": {
 							"type": "table",
@@ -67,7 +92,8 @@
 							"company",
 							"actual_qty",
 							"valuation_rate",
-							"stock_value"
+							"stock_value",
+							"default_currency"
 						]
 					}
 				]
@@ -106,6 +132,31 @@
 						]
 					},
 					{
+						"type": "join",
+						"join_type": "left",
+						"table": {
+							"type": "table",
+							"data_source": "Site DB",
+							"table_name": "tabCompany"
+						},
+						"select_columns": [
+							{
+								"type": "column",
+								"column_name": "default_currency"
+							}
+						],
+						"join_condition": {
+							"left_column": {
+								"type": "column",
+								"column_name": "company"
+							},
+							"right_column": {
+								"type": "column",
+								"column_name": "name"
+							}
+						}
+					},
+					{
 						"type": "mutate",
 						"new_name": "incoming_value",
 						"data_type": "Decimal",
@@ -134,7 +185,8 @@
 							"actual_qty",
 							"stock_value_difference",
 							"incoming_value",
-							"outgoing_value"
+							"outgoing_value",
+							"default_currency"
 						]
 					}
 				]
@@ -213,6 +265,31 @@
 					},
 					{
 						"type": "join",
+						"join_type": "left",
+						"table": {
+							"type": "table",
+							"data_source": "Site DB",
+							"table_name": "tabCompany"
+						},
+						"select_columns": [
+							{
+								"type": "column",
+								"column_name": "default_currency"
+							}
+						],
+						"join_condition": {
+							"left_column": {
+								"type": "column",
+								"column_name": "company"
+							},
+							"right_column": {
+								"type": "column",
+								"column_name": "name"
+							}
+						}
+					},
+					{
+						"type": "join",
 						"join_type": "inner",
 						"table": {
 							"type": "query",
@@ -264,7 +341,8 @@
 							"stock_value",
 							"last_movement_date",
 							"days_since_movement",
-							"ageing_bucket"
+							"ageing_bucket",
+							"default_currency"
 						]
 					}
 				]
@@ -361,7 +439,8 @@
 							"column_name": "stock_value",
 							"data_type": "Decimal",
 							"aggregation": "sum",
-							"format": "currency"
+							"format": "currency",
+							"currency_column": "default_currency"
 						}
 					],
 					"number_column_options": [
@@ -389,7 +468,8 @@
 							"column_name": "stock_value_difference",
 							"data_type": "Decimal",
 							"aggregation": "sum",
-							"format": "currency"
+							"format": "currency",
+							"currency_column": "default_currency"
 						}
 					],
 					"number_column_options": [
@@ -444,7 +524,8 @@
 							"column_name": "stock_value",
 							"data_type": "Decimal",
 							"aggregation": "sum",
-							"format": "currency"
+							"format": "currency",
+							"currency_column": "default_currency"
 						}
 					],
 					"number_column_options": [
@@ -718,7 +799,8 @@
 							"column_name": "stock_value",
 							"data_type": "Decimal",
 							"aggregation": "sum",
-							"format": "currency"
+							"format": "currency",
+							"currency_column": "default_currency"
 						},
 						{
 							"measure_name": "days_since_movement",


### PR DESCRIPTION
Support ticket 78140: the Sales Performance dashboard prints `₹` on its KPI cards for every Company filter. The amounts are correct, because the template sums ERPNext's `base_*` fields. Only the symbol is wrong, because it comes from the site currency.

### A measure names where its currency comes from

```ts
{ measure_name: 'Revenue', column_name: 'base_net_total', aggregation: 'sum',
  format: 'currency', currency_column: 'default_currency' }
```

`currency_column` is any column of the query. Nothing reads doctype meta, so a CSV or a Postgres table declares it the same way the Site DB does. A measure that names no column prints in the site currency.

### The server carries the code through aggregation

Once rows are summed, the currency column is gone. So `apply_summary` adds a carried column beside each money measure:

```python
one_currency = (col.min() == col.max()) & ~col.isnull().any()
carried[f"{measure_name}__currency"] = ibis.ifelse(one_currency, col.min(), ibis.null())
```

Per group, `min` and `max` agree only when every row has the same code. A row with no code makes the group carry null. A null code prints bare. A Company filter narrows each group to one currency, so the symbol follows the filter. A missing currency column carries null instead of failing the query. Pivots aggregate on their own path and are untouched.

### A carried column is hidden by its name

The client reads the code off the row by `<measure>__currency`, so that suffix is the contract. `get_columns_from_schema` marks such a column `hidden`. Pickers and exports drop it. A query built on this one hides it the same way. The client keeps the value in the row.

```python
def is_hidden_column(name: str) -> bool:
    return is_carried_currency_column(name)   # the one kind of hidden column today
```

```ts
result.value.columns = response.columns.filter((c) => !c.hidden)
```

### The symbol travels with the code

A result sends the symbols of the codes it carries, so any code resolves: enabled, disabled, or a CSV value.

```python
codes = {row[name] for name in carried for row in results}
return {"columns": columns, "rows": results, "currency_symbols": get_currency_symbols(codes), ...}
```

```ts
Object.assign(session.site.currency_symbols, response.currency_symbols || {})
```

### Reading it back

```ts
getRowCurrency(row, 'Revenue')   // 'AED' | null (mixed or unknown) | undefined (no column named)
getFormatUnits('currency', code) // undefined falls back to session.site.currency
```

Only the number card and the table print a symbol. The card reads its last row. The table reads each row. Its totals row prints a symbol only when every row agrees.

### Templates

The four ERPNext templates join Company and name `default_currency`. Each manifest version goes up, so an existing import is offered the update. The notes say the workbook reads Company, because a reader under team permissions needs that grant.

### Behaviour changes to look at

- An unfiltered multi-company total now prints with no symbol. It summed unlike currencies and labelled the sum in rupees.
- `get_site_info` returns the site currency and a one-entry symbol map. `currency_symbol` and `currency_symbol_on_right` are gone from `session.site`; results add to `currency_symbols`.
- A source column that happens to end in `__currency` is hidden. The suffix is reserved.

### Not here

No pre-fill from doctype meta. For `base_*` fields Frappe's `options` is `Company:company:default_currency`, a link, not a code, so the ticket's case could not be pre-filled.

Verified against `erpnext.localhost`, which has companies in INR, USD, EUR, ZAR and AED: a per-company group returns each company's code, and a group spanning all of them returns null.